### PR TITLE
Switch `gitea:latest-rootless` image to `gitea:latest`

### DIFF
--- a/template/gitea.yaml
+++ b/template/gitea.yaml
@@ -24,7 +24,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: gitea/gitea:latest-rootless
+    originImageName: gitea/gitea:latest
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     deploy.cloud.sealos.io/resize: 6Gi
@@ -51,7 +51,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: ${{ defaults.app_name }}
-          image: gitea/gitea:latest-rootless
+          image: gitea/gitea:latest
           env:
             - name: GITEA__database__DB_TYPE
               value: mysql


### PR DESCRIPTION
Follow #137.

Use `latest` instead of `:latest-rootless`, it will fail to create some dirs.

![image](https://github.com/labring-actions/templates/assets/9418365/c17f80fe-8e96-4214-acf9-87369ea0a56a)

It doesn't cause any security threats to remove `rootless`. And I have tested it on cloud.sealos.io, it works well.

<img width="1733" alt="image" src="https://github.com/labring-actions/templates/assets/9418365/8c300049-0c2f-45c6-b841-8fa376d898a4">


