### PR TITLE
Update logo of Halo

### DIFF
--- a/template/halo.yaml
+++ b/template/halo.yaml
@@ -9,7 +9,7 @@ spec:
   author: 'Sealos'
   description: '强大易用的开源建站工具。'
   readme: 'https://raw.githubusercontent.com/halo-dev/halo/main/README.md'
-  icon: 'https://raw.githubusercontent.com/halo-dev/halo/main/console/src/assets/logo.png'
+  icon: 'https://www.halo.run/logo'
   templateType: inline
   defaults:
     app_host:


### PR DESCRIPTION
After merging https://github.com/halo-dev/halo/pull/5314, the console directory in Halo's source repo is gone, so we can't load Halo's Logo anymore. This PR updates the Logo link to [www.halo.run/logo](http://www.halo.run/logo).

<img width="1172" alt="image" src="https://github.com/labring-actions/templates/assets/21301288/991c83ea-95e1-41ce-a50f-46c4c63be369">
