### PR TITLE
fix: Update `tls.secretName` value in template file

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -135,4 +135,4 @@ spec:
   tls:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      secretName: ${{ SEALOS_Cert_Secret_Name }}
+      secretName: ${{ SEALOS_CERT_SECRET_NAME }}


### PR DESCRIPTION
This PR fixed the issue #223 .

> The TLS certificate does not work for the yaml config generated from the [current version of template](https://github.com/labring-actions/templates/blob/c777eda3382946c6059ff058221295a974e69fa5/template.yaml)
>
> The tls.secretName in it does not exist. According to the [Template Variables](https://github.com/labring-actions/templates/blob/c777eda3382946c6059ff058221295a974e69fa5/example.md#built-in-system-variables), it should use all upper case letters SEALOS_CERT_SECRET_NAME instead of SEALOS_Cert_Secret_Name.