### PR TITLE
fix: correct chatgpt-on-wechat readme

### DIFF
--- a/template/chatgpt-on-wechat.yaml
+++ b/template/chatgpt-on-wechat.yaml
@@ -8,7 +8,7 @@ spec:
   gitRepo: 'https://github.com/zhayujie/chatgpt-on-wechat'
   author: 'zhayujie'
   description: '本项目是基于大模型的智能对话机器人，支持企业微信、微信公众号、飞书、钉钉接入，可选择GPT3.5/GPT4.0/Claude/文心一言/讯飞星火/通义千问/Gemini/LinkAI/ZhipuAI，能处理文本、语音和图片，通过插件访问操作系统和互联网等外部资源，支持基于自有知识库定制企业AI应用。'
-  readme: 'https://github.com/zhayujie/chatgpt-on-wechat/blob/master/README.md'
+  readme: 'https://raw.githubusercontent.com/zhayujie/chatgpt-on-wechat/master/README.md'
   icon: 'https://avatars.githubusercontent.com/u/26161723?v=4'
   templateType: inline
   categories:


### PR DESCRIPTION
chatgpt-on-wechat is not showing the readme in application shop. Sorry for incorrect config of readme in chatgpt-on-wechat. Create a pull request to fix it