### PR TITLE
fix(openclaw): upgrade image and stabilize health checks

### DIFF
--- a/template/openclaw/index.yaml
+++ b/template/openclaw/index.yaml
@@ -58,7 +58,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/openclaw/openclaw:2026.3.1
+    originImageName: ghcr.io/openclaw/openclaw:2026.3.8
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -98,7 +98,7 @@ spec:
             - name: vn-homevn-nodevn-npm
               mountPath: /home/node/.npm
         - name: init-openclaw-config
-          image: ghcr.io/openclaw/openclaw:2026.3.1
+          image: ghcr.io/openclaw/openclaw:2026.3.8
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENCLAW_PROVIDER_KIND
@@ -156,7 +156,7 @@ spec:
               memory: 512Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/openclaw/openclaw:2026.3.1
+          image: ghcr.io/openclaw/openclaw:2026.3.8
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
@@ -183,20 +183,28 @@ spec:
             - name: gateway
               containerPort: 3000
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /healthz
               port: 3000
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /readyz
               port: 3000
-            initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: vn-homevn-nodevn-openclaw
               mountPath: /home/node/.openclaw


### PR DESCRIPTION
## Summary
- bump the OpenClaw image to 2026.3.8
- add a startup probe before liveness checks begin
- relax health check timeouts and failure thresholds to reduce false restarts