### PR TITLE
fix(plane): use https for object storage endpoint urls

### DIFF
--- a/template/plane/index.yaml
+++ b/template/plane/index.yaml
@@ -284,7 +284,7 @@ spec:
             - name: BACKEND_STORAGE_MINIO_ENDPOINT
               value: "$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)"
             - name: AWS_S3_ENDPOINT_URL
-              value: "http://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
+              value: "https://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
             - name: USE_MINIO
               value: "0"
           command:
@@ -629,7 +629,7 @@ spec:
             - name: BACKEND_STORAGE_MINIO_ENDPOINT
               value: "$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)"
             - name: AWS_S3_ENDPOINT_URL
-              value: "http://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
+              value: "https://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
             - name: USE_MINIO
               value: "0"
           resources:
@@ -796,7 +796,7 @@ spec:
             - name: BACKEND_STORAGE_MINIO_ENDPOINT
               value: "$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)"
             - name: AWS_S3_ENDPOINT_URL
-              value: "http://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
+              value: "https://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
             - name: USE_MINIO
               value: "0"
           resources:
@@ -938,7 +938,7 @@ spec:
             - name: BACKEND_STORAGE_MINIO_ENDPOINT
               value: "$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)"
             - name: AWS_S3_ENDPOINT_URL
-              value: "http://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
+              value: "https://$(BACKEND_STORAGE_MINIO_ENDPOINT)/$(BACKEND_STORAGE_PRIVATE_BUCKET)"
             - name: USE_MINIO
               value: "0"
           resources:


### PR DESCRIPTION
## Summary
- use https for object storage endpoint urls in the Plane template
- prevent mixed-content failures when Plane runs behind HTTPS

## Testing
- validated template checks and quality gate locally