### PR TITLE
fix(templates): stabilize Cap deployment

### DIFF
--- a/.agents/skills/docker-to-sealos/SKILL.md
+++ b/.agents/skills/docker-to-sealos/SKILL.md
@@ -167,7 +167,7 @@ If validation fails, fix template/rules/examples first.
 - MongoDB cluster must follow upgraded structure (`componentDef: mongodb`, `serviceVersion: 8.0.4`, labels `kb.io/database` and `app.kubernetes.io/instance`).
 - MySQL cluster must follow upgraded structure (`kb.io/database: ac-mysql-8.0.30-1`, `clusterDefinitionRef: apecloud-mysql`, `clusterVersionRef: ac-mysql-8.0.30-1`, `tolerations: []`).
 - Redis cluster must follow upgraded structure (`componentDef: redis-7`, `componentDef: redis-sentinel-7`, `serviceVersion: 7.2.7`, main data PVC `1Gi`, topology `replication`).
-- Database cluster component resources must use `limits(cpu=200m,memory=256Mi)` and `requests(cpu=20m,memory=25Mi)` unless source docs explicitly require otherwise.
+- Database cluster component resources must use `limits(cpu=500m,memory=512Mi)` and `requests(cpu=50m,memory=51Mi)` unless source docs explicitly require otherwise.
 - Secret naming:
   - MongoDB: `${{ defaults.app_name }}-mongo-mongodb-account-root` (or `${{ defaults.app_name }}-mongodb-mongodb-account-root` when the MongoDB cluster name uses `-mongodb`)
   - Redis: `${{ defaults.app_name }}-redis-redis-account-default` (legacy `${{ defaults.app_name }}-redis-account-default` may be accepted for backward compatibility)

--- a/.agents/skills/docker-to-sealos/references/conversion-mappings.md
+++ b/.agents/skills/docker-to-sealos/references/conversion-mappings.md
@@ -534,6 +534,8 @@ resources:
 
 源文档明确声明资源需求时，按实际需求转换为 Kubernetes resource quantity。
 
+此节适用于应用容器、辅助容器、initContainer 和 Job 容器；KubeBlocks 数据库组件资源基线以 `references/database-templates.md` 为准。
+
 ### Docker Compose
 ```yaml
 services:

--- a/.agents/skills/docker-to-sealos/references/database-templates.md
+++ b/.agents/skills/docker-to-sealos/references/database-templates.md
@@ -28,11 +28,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-pg
       switchPolicy:
         type: Noop
@@ -167,11 +167,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mysql
       switchPolicy:
         type: Noop
@@ -254,11 +254,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mongo
       serviceVersion: 8.0.4
       volumeClaimTemplates:
@@ -347,11 +347,11 @@ spec:
         - name: CUSTOM_SENTINEL_MASTER_NAME
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
       switchPolicy:
@@ -370,11 +370,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
       volumeClaimTemplates:
@@ -468,11 +468,11 @@ spec:
           effect: NoSchedule
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -496,11 +496,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: metadata
           spec:
@@ -515,11 +515,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
 
 ---
 apiVersion: v1

--- a/.agents/skills/docker-to-sealos/references/example-guide.md
+++ b/.agents/skills/docker-to-sealos/references/example-guide.md
@@ -660,11 +660,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mongo
       serviceVersion: 8.0.4
       volumeClaimTemplates:
@@ -759,11 +759,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-pg
       switchPolicy:
         type: Noop
@@ -856,11 +856,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mysql
       switchPolicy:
         type: Noop
@@ -958,11 +958,11 @@ spec:
         - name: CUSTOM_SENTINEL_MASTER_NAME
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
       switchPolicy:
@@ -981,11 +981,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 20m
-          memory: 100Mi
+          cpu: 50m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
       volumeClaimTemplates:
@@ -1083,11 +1083,11 @@ spec:
           effect: NoSchedule
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -1111,11 +1111,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: metadata
           spec:
@@ -1130,11 +1130,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
 ```
 
 </details>
@@ -1165,11 +1165,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -1185,11 +1185,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -1205,11 +1205,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -1254,11 +1254,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-clickhouse
       volumeClaimTemplates:
         - name: data
@@ -1274,11 +1274,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-clickhouse
       volumeClaimTemplates:
         - name: data
@@ -1294,11 +1294,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-clickhouse
       volumeClaimTemplates:
         - name: data
@@ -1341,11 +1341,11 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 200m
-          memory: 256Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 20m
-          memory: 25Mi
+          cpu: 50m
+          memory: 51Mi
       rsmTransformPolicy: ToSts
       serviceAccountName: ${{ defaults.app_name }}-weaviate
       volumeClaimTemplates:

--- a/.agents/skills/docker-to-sealos/references/must-rules-map.yaml
+++ b/.agents/skills/docker-to-sealos/references/must-rules-map.yaml
@@ -208,7 +208,7 @@ must_rules:
     enforcement:
       type: manual
       note: "Requires schema-level validation for Redis cluster fields."
-  - must: "Database cluster component resources must use `limits(cpu=200m,memory=256Mi)` and `requests(cpu=20m,memory=25Mi)` unless source docs explicitly require otherwise."
+  - must: "Database cluster component resources must use `limits(cpu=500m,memory=512Mi)` and `requests(cpu=50m,memory=51Mi)` unless source docs explicitly require otherwise."
     enforcement:
       type: rule
       target: R019

--- a/.agents/skills/docker-to-sealos/references/rules-registry.yaml
+++ b/.agents/skills/docker-to-sealos/references/rules-registry.yaml
@@ -68,7 +68,7 @@ rules:
     description: Database connection env fields (endpoint/host/port/username/password) in business workloads must use approved Kubeblocks database secretKeyRef entries, except Redis host/port may use Sealos Redis Service FQDN and port 6379; endpoint/URL fields may compose values from approved DB secretKeyRef env vars.
     severity: error
   - id: R019
-    description: Database cluster component resources must use limits cpu=200m/memory=256Mi and requests cpu=20m/memory=25Mi.
+    description: Database cluster component resources must use limits cpu=500m/memory=512Mi and requests cpu=50m/memory=51Mi.
     severity: error
   - id: R020
     description: Service spec.ports entries must define non-empty name fields in template artifacts.

--- a/.agents/skills/docker-to-sealos/references/sealos-specs.md
+++ b/.agents/skills/docker-to-sealos/references/sealos-specs.md
@@ -858,7 +858,7 @@ spec:
 
 **⚠️ 重要：所有容器的 resources 字段必须包含 requests 和 limits！**
 
-除非源文档明确要求更高资源，所有应用容器、辅助容器、initContainer、Job 容器和数据库组件默认使用统一资源配额：
+除非源文档明确要求更高资源，应用容器、辅助容器、initContainer 和 Job 容器默认使用统一资源配额：
 
 ```yaml
 resources:
@@ -870,12 +870,24 @@ resources:
     memory: 25Mi
 ```
 
+KubeBlocks 数据库组件统一使用更高的资源基线（0.5c 在 Kubernetes YAML 中写作 500m）：
+
+```yaml
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 51Mi
+```
+
 **配额设置原则**：
 
-1. **默认保持统一**：不要因为应用类型主观放大资源；只有源文档明确给出最低需求时才提高。
-2. **总是同时设置 requests 和 limits**：缺任一项都不符合模板规范。
-3. **资源字段顺序**：推荐先写 `limits`，再写 `requests`，便于人工审查。
-4. **数据库组件同样遵循默认值**：除源文档明确要求，否则 KubeBlocks 组件资源也使用上述默认配置。
+1. **应用基线保持统一**：不要因为应用类型主观放大应用容器资源；只有源文档明确给出最低需求时才提高。
+2. **数据库基线单独统一**：除源文档明确要求更高资源，否则所有 KubeBlocks 数据库组件都使用 `limits(cpu=500m,memory=512Mi)` 与 `requests(cpu=50m,memory=51Mi)`。
+3. **总是同时设置 requests 和 limits**：缺任一项都不符合模板规范。
+4. **资源字段顺序**：推荐先写 `limits`，再写 `requests`，便于人工审查。
 
 **示例对比**：
 

--- a/.agents/skills/docker-to-sealos/scripts/check_consistency_models.py
+++ b/.agents/skills/docker-to-sealos/scripts/check_consistency_models.py
@@ -32,8 +32,8 @@ DB_SECRET_SUFFIXES = (
     "-broker-account-admin",
 )
 MAX_PVC_STORAGE_BYTES = 1024 ** 3  # 1Gi
-DB_COMPONENT_RESOURCE_LIMITS = {"cpu": "200m", "memory": "256Mi"}
-DB_COMPONENT_RESOURCE_REQUESTS = {"cpu": "20m", "memory": "25Mi"}
+DB_COMPONENT_RESOURCE_LIMITS = {"cpu": "500m", "memory": "512Mi"}
+DB_COMPONENT_RESOURCE_REQUESTS = {"cpu": "50m", "memory": "51Mi"}
 STORAGE_UNIT_TO_BYTES = {
     "": 1,
     "k": 1000,

--- a/.agents/skills/docker-to-sealos/scripts/compose_to_template.py
+++ b/.agents/skills/docker-to-sealos/scripts/compose_to_template.py
@@ -91,8 +91,8 @@ COMPOSE_BRACED_VAR_RE = re.compile(r"\$\{([^}]+)\}")
 COMPOSE_SIMPLE_VAR_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
 DEFAULT_RESOURCE_LIMITS = {"cpu": "200m", "memory": "256Mi"}
 DEFAULT_RESOURCE_REQUESTS = {"cpu": "20m", "memory": "25Mi"}
-DB_COMPONENT_RESOURCE_LIMITS = DEFAULT_RESOURCE_LIMITS
-DB_COMPONENT_RESOURCE_REQUESTS = DEFAULT_RESOURCE_REQUESTS
+DB_COMPONENT_RESOURCE_LIMITS = {"cpu": "500m", "memory": "512Mi"}
+DB_COMPONENT_RESOURCE_REQUESTS = {"cpu": "50m", "memory": "51Mi"}
 ZH_CHAR_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF]")
 EN_DESCRIPTION_REWRITE_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
     (

--- a/.agents/skills/docker-to-sealos/scripts/test_compose_to_template.py
+++ b/.agents/skills/docker-to-sealos/scripts/test_compose_to_template.py
@@ -615,10 +615,10 @@ class ComposeToTemplateTests(unittest.TestCase):
             self.assertNotIn("nodeLabels", affinity)
             self.assertNotIn("topologyKeys", affinity)
             pg_comp = cluster["spec"]["componentSpecs"][0]
-            self.assertEqual("200m", pg_comp["resources"]["limits"]["cpu"])
-            self.assertEqual("256Mi", pg_comp["resources"]["limits"]["memory"])
-            self.assertEqual("20m", pg_comp["resources"]["requests"]["cpu"])
-            self.assertEqual("25Mi", pg_comp["resources"]["requests"]["memory"])
+            self.assertEqual("500m", pg_comp["resources"]["limits"]["cpu"])
+            self.assertEqual("512Mi", pg_comp["resources"]["limits"]["memory"])
+            self.assertEqual("50m", pg_comp["resources"]["requests"]["cpu"])
+            self.assertEqual("51Mi", pg_comp["resources"]["requests"]["memory"])
 
             deployment = next(doc for doc in docs if doc.get("kind") == "Deployment")
             env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
@@ -766,15 +766,15 @@ class ComposeToTemplateTests(unittest.TestCase):
             redis_comp = next(item for item in cluster["spec"]["componentSpecs"] if item["name"] == "redis")
             redis_data = redis_comp["volumeClaimTemplates"][0]["spec"]["resources"]["requests"]["storage"]
             self.assertEqual("1Gi", redis_data)
-            self.assertEqual("200m", redis_comp["resources"]["limits"]["cpu"])
-            self.assertEqual("256Mi", redis_comp["resources"]["limits"]["memory"])
-            self.assertEqual("20m", redis_comp["resources"]["requests"]["cpu"])
-            self.assertEqual("25Mi", redis_comp["resources"]["requests"]["memory"])
+            self.assertEqual("500m", redis_comp["resources"]["limits"]["cpu"])
+            self.assertEqual("512Mi", redis_comp["resources"]["limits"]["memory"])
+            self.assertEqual("50m", redis_comp["resources"]["requests"]["cpu"])
+            self.assertEqual("51Mi", redis_comp["resources"]["requests"]["memory"])
             sentinel_comp = next(item for item in cluster["spec"]["componentSpecs"] if item["name"] == "redis-sentinel")
-            self.assertEqual("200m", sentinel_comp["resources"]["limits"]["cpu"])
-            self.assertEqual("256Mi", sentinel_comp["resources"]["limits"]["memory"])
-            self.assertEqual("20m", sentinel_comp["resources"]["requests"]["cpu"])
-            self.assertEqual("25Mi", sentinel_comp["resources"]["requests"]["memory"])
+            self.assertEqual("500m", sentinel_comp["resources"]["limits"]["cpu"])
+            self.assertEqual("512Mi", sentinel_comp["resources"]["limits"]["memory"])
+            self.assertEqual("50m", sentinel_comp["resources"]["requests"]["cpu"])
+            self.assertEqual("51Mi", sentinel_comp["resources"]["requests"]["memory"])
 
             deployment = next(doc for doc in docs if doc.get("kind") == "Deployment")
             env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
@@ -813,10 +813,10 @@ class ComposeToTemplateTests(unittest.TestCase):
             self.assertNotIn("annotations", cluster["metadata"])
             self.assertEqual(["kubernetes.io/hostname"], cluster["spec"]["affinity"]["topologyKeys"])
             mysql_comp = cluster["spec"]["componentSpecs"][0]
-            self.assertEqual("200m", mysql_comp["resources"]["limits"]["cpu"])
-            self.assertEqual("256Mi", mysql_comp["resources"]["limits"]["memory"])
-            self.assertEqual("20m", mysql_comp["resources"]["requests"]["cpu"])
-            self.assertEqual("25Mi", mysql_comp["resources"]["requests"]["memory"])
+            self.assertEqual("500m", mysql_comp["resources"]["limits"]["cpu"])
+            self.assertEqual("512Mi", mysql_comp["resources"]["limits"]["memory"])
+            self.assertEqual("50m", mysql_comp["resources"]["requests"]["cpu"])
+            self.assertEqual("51Mi", mysql_comp["resources"]["requests"]["memory"])
 
             deployment = next(doc for doc in docs if doc.get("kind") == "Deployment")
             env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
@@ -859,10 +859,10 @@ class ComposeToTemplateTests(unittest.TestCase):
             mongo_comp = cluster["spec"]["componentSpecs"][0]
             self.assertEqual("mongodb", mongo_comp["componentDef"])
             self.assertEqual("8.0.4", mongo_comp["serviceVersion"])
-            self.assertEqual("200m", mongo_comp["resources"]["limits"]["cpu"])
-            self.assertEqual("256Mi", mongo_comp["resources"]["limits"]["memory"])
-            self.assertEqual("20m", mongo_comp["resources"]["requests"]["cpu"])
-            self.assertEqual("25Mi", mongo_comp["resources"]["requests"]["memory"])
+            self.assertEqual("500m", mongo_comp["resources"]["limits"]["cpu"])
+            self.assertEqual("512Mi", mongo_comp["resources"]["limits"]["memory"])
+            self.assertEqual("50m", mongo_comp["resources"]["requests"]["cpu"])
+            self.assertEqual("51Mi", mongo_comp["resources"]["requests"]["memory"])
 
             deployment = next(doc for doc in docs if doc.get("kind") == "Deployment")
             env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
@@ -899,10 +899,10 @@ class ComposeToTemplateTests(unittest.TestCase):
             controller_comp = next(item for item in cluster["spec"]["componentSpecs"] if item["name"] == "controller")
             metrics_comp = next(item for item in cluster["spec"]["componentSpecs"] if item["name"] == "metrics-exp")
             for comp in (broker_comp, controller_comp, metrics_comp):
-                self.assertEqual("200m", comp["resources"]["limits"]["cpu"])
-                self.assertEqual("256Mi", comp["resources"]["limits"]["memory"])
-                self.assertEqual("20m", comp["resources"]["requests"]["cpu"])
-                self.assertEqual("25Mi", comp["resources"]["requests"]["memory"])
+                self.assertEqual("500m", comp["resources"]["limits"]["cpu"])
+                self.assertEqual("512Mi", comp["resources"]["limits"]["memory"])
+                self.assertEqual("50m", comp["resources"]["requests"]["cpu"])
+                self.assertEqual("51Mi", comp["resources"]["requests"]["memory"])
 
             deployment = next(doc for doc in docs if doc.get("kind") == "Deployment")
             env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/template/cap/README.md
+++ b/template/cap/README.md
@@ -1,28 +1,134 @@
-# Cap
+# Deploy and Host Cap on Sealos
 
-## Overview
+Cap is an open-source screen recording and video sharing platform for teams that want to own their recording workflow and data. This template deploys Cap Web with a media server, MySQL database, and S3-compatible object storage on Sealos Cloud.
 
-Open source alternative to Loom. Record, edit and share videos in seconds.
+![Cap app preview](https://raw.githubusercontent.com/CapSoftware/Cap/refs/heads/main/apps/web/public/landing-cover.png)
 
-This Sealos template deploys **Cap** as the `cap` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Cap
 
-## Deploy on Sealos
+Cap provides a web dashboard for viewing, sharing, and managing screen recordings created with the Cap desktop app. It supports share links, team collaboration, comments, transcripts, analytics, custom storage, and self-hosted deployments for teams that need tighter control over their data.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+This Sealos template provisions the services needed for a self-hosted Cap deployment. Cap Web serves the user interface, API routes, authentication flow, and dashboard, while the media server handles media processing tasks used by the web app. Sealos also creates a MySQL database and an S3-compatible object storage bucket so metadata and recording assets survive restarts.
 
-## Access
+The deployment includes public HTTPS access, service discovery between components, generated application secrets, a database initialization job, and health checks for the web and media services.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Product Demos**: Record polished walkthroughs and share them with prospects, customers, or internal teams.
+- **Bug Reports**: Capture reproducible issues with screen, camera, and microphone context.
+- **Async Standups**: Replace status meetings with short video updates that teammates can watch on their schedule.
+- **Customer Onboarding**: Build reusable tutorials, feature tours, and help videos.
+- **Design and Engineering Reviews**: Share UI feedback, code walkthroughs, or implementation notes with comments attached to the recording.
+
+## Dependencies for Cap Hosting
+
+The Sealos template includes all required runtime dependencies for a basic self-hosted Cap deployment: Cap Web, Cap Media Server, MySQL, an S3-compatible object storage bucket, and an initialization job that prepares the `cap` database.
+
+### Deployment Dependencies
+
+- [Cap Website](https://cap.so) - Product website and downloads
+- [Cap Documentation](https://cap.so/docs) - Official product documentation
+- [Self-Hosting Guide](https://cap.so/docs/self-hosting) - Self-hosting notes and production configuration
+- [Cap GitHub Repository](https://github.com/CapSoftware/Cap) - Source code, issues, and releases
+- [Cap Discord](https://cap.link/discord) - Community support
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Cap Web**: The main Next.js web application that serves the dashboard, sharing pages, API routes, authentication, and database migrations.
+- **Cap Media Server**: A companion service used by Cap Web for media processing workflows.
+- **MySQL**: A KubeBlocks-managed MySQL database used for Cap metadata, users, recordings, and application state.
+- **MySQL Init Job**: A startup-safe job that waits for MySQL, creates the `cap` database, and configures MySQL authentication compatibility.
+- **Object Storage Bucket**: A Sealos S3-compatible bucket used for recording files and media assets.
+- **Ingress and App Link**: A public HTTPS endpoint and Sealos App resource for opening Cap from the dashboard.
+
+**Configuration:**
+
+Cap Web receives generated defaults for `DATABASE_ENCRYPTION_KEY`, `NEXTAUTH_SECRET`, and `MEDIA_SERVER_WEBHOOK_SECRET`. It connects to MySQL through KubeBlocks-managed connection secrets and uses Sealos object storage credentials for S3-compatible uploads.
+
+The template exposes optional `RESEND_API_KEY` and `RESEND_FROM_DOMAIN` inputs for email delivery. If these values are left empty, Cap still starts, but email verification messages are not sent through Resend; use the service logs to retrieve the development-mode verification code during testing.
+
+**License Information:**
+
+Cap is primarily licensed under AGPLv3, with selected capture-related crates under the MIT License. Review the [Cap license file](https://github.com/CapSoftware/Cap/blob/main/LICENSE) before using Cap in production.
+
+## Why Deploy Cap on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle from development to production deployment and operations. By deploying Cap on Sealos, you get:
+
+- **One-Click Deployment**: Deploy the full Cap stack without hand-writing Kubernetes manifests.
+- **Built-In Kubernetes Operations**: Run Cap on Kubernetes with managed networking, service discovery, and workload orchestration.
+- **Persistent Data Services**: Store metadata in MySQL and recording assets in S3-compatible object storage.
+- **Instant Public Access**: Get an automatic public URL with HTTPS certificates after deployment.
+- **Easy Customization**: Update environment variables, resources, and storage through the Canvas, AI dialog, or resource cards.
+- **Pay-as-You-Go Efficiency**: Start with a compact deployment and adjust resources as usage grows.
+- **Automated Platform Management**: Let Sealos handle common infrastructure tasks while you focus on using Cap.
+
+Deploy Cap on Sealos when you want a self-hosted screen recording platform without managing the Kubernetes plumbing yourself.
+
+## Deployment Guide
+
+1. Open the [Cap template](https://sealos.io/products/app-store/cap) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog. For production email delivery, set `RESEND_API_KEY` and `RESEND_FROM_DOMAIN`; for testing, you can leave them empty.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Access Cap via the provided public URL:
+   - **Cap Web**: Sign in with your email verification code or email link.
+   - **Desktop App Connection**: Point Cap Desktop to your deployed Cap URL from `Settings > Cap Server URL` when using a self-hosted server.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Cap through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AI Dialog**: Describe environment, resource, or domain changes and let AI apply updates.
+- **Resource Cards**: Open the Cap Web, Media Server, MySQL, or Object Storage cards to inspect and modify settings.
+- **Email Delivery**: Set `RESEND_API_KEY` and `RESEND_FROM_DOMAIN` to send login emails through Resend.
+- **Desktop Client**: Configure Cap Desktop to use your deployed URL as its Cap Server URL.
+- **Secrets and URLs**: Keep generated secrets stable after users start recording, because changing encryption or auth secrets can invalidate sessions or encrypted data.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+To scale Cap on Sealos:
 
-- Official website: https://github.com/CapSoftware/Cap
-- Source repository: https://github.com/CapSoftware/Cap
+1. Open the Canvas for your deployment.
+2. Click the Cap Web or Cap Media Server resource card.
+3. Adjust CPU, memory, or replica count based on traffic and processing needs.
+4. Apply the changes in the dialog and monitor the rollout from the Canvas.
+
+For larger teams, increase Cap Web resources first, then scale the media server if media processing becomes the bottleneck. Keep MySQL and object storage sized according to recording volume and retention requirements.
+
+## Troubleshooting
+
+### Common Issues
+
+**No login email arrives**
+- Cause: `RESEND_API_KEY` and `RESEND_FROM_DOMAIN` are empty or incorrect.
+- Solution: Configure Resend credentials. For test deployments without email, view the Cap Web logs from the Canvas resource card and copy the development-mode verification code.
+
+**Cap Web restarts during startup**
+- Cause: The web service may need more memory while Next.js starts and migrations run.
+- Solution: Increase the Cap Web memory limit from the resource card, then wait for the rollout to complete.
+
+**Recordings upload but cannot be viewed**
+- Cause: Object storage endpoint or bucket access settings may be incorrect.
+- Solution: Check the Object Storage bucket, S3 environment variables, and public endpoint configuration in the Cap Web resource card.
+
+### Getting Help
+
+- [Cap Documentation](https://cap.so/docs)
+- [Cap GitHub Issues](https://github.com/CapSoftware/Cap/issues)
+- [Cap Discord](https://cap.link/discord)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Cap Self-Hosting Guide](https://cap.so/docs/self-hosting)
+- [Cap Downloads](https://cap.so/download)
+- [Cap GitHub Repository](https://github.com/CapSoftware/Cap)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is maintained for the Sealos templates repository. Cap itself is primarily licensed under AGPLv3, with selected capture-related crates under the MIT License; see the [Cap license file](https://github.com/CapSoftware/Cap/blob/main/LICENSE) for details.

--- a/template/cap/README_zh.md
+++ b/template/cap/README_zh.md
@@ -1,28 +1,134 @@
-# Cap
+# 在 Sealos 上部署和托管 Cap
 
-## 应用概览
+Cap 是一款开源屏幕录制与视频分享平台，适合希望掌控录制流程和数据的团队。这个模板会在 Sealos Cloud 上部署 Cap Web、媒体服务器、MySQL 数据库和兼容 S3 的对象存储。
 
-Loom 的开源替代品。快速录制、编辑和分享视频。
+![Cap 应用预览](https://raw.githubusercontent.com/CapSoftware/Cap/refs/heads/main/apps/web/public/landing-cover.png)
 
-此 Sealos 模板会将 **Cap** 部署为 `cap` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于在 Sealos 上托管 Cap
 
-## 在 Sealos 上部署
+Cap 提供 Web 控制台，用来查看、分享和管理通过 Cap 桌面端录制的视频。它支持分享链接、团队协作、评论、字幕、分析、自定义存储以及自托管部署，适合对数据控制有更高要求的团队。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+这个 Sealos 模板会自动创建自托管 Cap 所需的服务。Cap Web 负责用户界面、API 路由、认证流程和控制台，媒体服务器负责 Web 应用所需的媒体处理任务。Sealos 还会创建 MySQL 数据库和兼容 S3 的对象存储桶，保证元数据和录制文件在重启后仍然保留。
 
-## 访问方式
+部署完成后，你会获得公开 HTTPS 访问地址、组件间服务发现、自动生成的应用密钥、数据库初始化任务，以及 Web 和媒体服务的健康检查。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
+
+- **产品演示**：录制清晰的功能 walkthrough，并分享给潜在客户、客户或内部团队。
+- **问题反馈**：用屏幕、摄像头和麦克风一起记录可复现的问题上下文。
+- **异步站会**：用短视频替代状态会议，让团队成员按自己的节奏查看更新。
+- **客户上手引导**：制作可复用的教程、功能介绍和帮助视频。
+- **设计与工程评审**：分享 UI 反馈、代码讲解或实现说明，并把评论附着在录制内容上。
+
+## Cap 托管依赖
+
+这个 Sealos 模板包含基础自托管 Cap 所需的运行依赖：Cap Web、Cap Media Server、MySQL、兼容 S3 的对象存储桶，以及用于准备 `cap` 数据库的初始化任务。
+
+### 部署依赖
+
+- [Cap 官网](https://cap.so) - 产品网站与客户端下载
+- [Cap 文档](https://cap.so/docs) - 官方产品文档
+- [自托管指南](https://cap.so/docs/self-hosting) - 自托管说明与生产配置
+- [Cap GitHub 仓库](https://github.com/CapSoftware/Cap) - 源码、Issue 与发布记录
+- [Cap Discord](https://cap.link/discord) - 社区支持
+
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下资源：
+
+- **Cap Web**：核心 Next.js Web 应用，提供控制台、分享页面、API 路由、认证和数据库迁移能力。
+- **Cap Media Server**：Cap Web 的配套服务，用于媒体处理流程。
+- **MySQL**：由 KubeBlocks 管理的 MySQL 数据库，用于保存 Cap 元数据、用户、录制记录和应用状态。
+- **MySQL 初始化任务**：启动安全的初始化任务，会等待 MySQL 就绪，创建 `cap` 数据库，并配置 MySQL 认证兼容性。
+- **对象存储桶**：Sealos 提供的兼容 S3 的存储桶，用于保存录制文件和媒体资源。
+- **Ingress 与应用入口**：公开 HTTPS 入口和 Sealos App 资源，方便从控制台直接打开 Cap。
+
+**配置：**
+
+Cap Web 会使用模板生成的 `DATABASE_ENCRYPTION_KEY`、`NEXTAUTH_SECRET` 和 `MEDIA_SERVER_WEBHOOK_SECRET`。它通过 KubeBlocks 管理的连接密钥访问 MySQL，并使用 Sealos 对象存储凭据完成兼容 S3 的上传。
+
+模板提供可选的 `RESEND_API_KEY` 和 `RESEND_FROM_DOMAIN` 输入项，用于邮件发送。如果留空，Cap 仍可启动，但不会通过 Resend 发送邮箱验证码；测试时可以在服务日志中查看开发模式验证码。
+
+**许可证信息：**
+
+Cap 主要采用 AGPLv3 许可证，部分录制相关 crate 使用 MIT 许可证。生产使用前，请阅读 [Cap 许可证文件](https://github.com/CapSoftware/Cap/blob/main/LICENSE)。
+
+## 为什么在 Sealos 上部署 Cap？
+
+Sealos 是基于 Kubernetes 构建的 AI 云操作系统，覆盖从开发到生产部署和运维的完整应用生命周期。在 Sealos 上部署 Cap，你可以获得：
+
+- **一键部署**：无需手写 Kubernetes 配置，即可部署完整 Cap 技术栈。
+- **内置 Kubernetes 运维能力**：获得托管网络、服务发现和工作负载编排能力。
+- **持久化数据服务**：用 MySQL 保存元数据，用兼容 S3 的对象存储保存录制资源。
+- **即时公网访问**：部署完成后自动获得带 HTTPS 证书的公网地址。
+- **易于调整配置**：可通过 Canvas、AI 对话或资源卡片修改环境变量、资源和存储设置。
+- **按量付费更高效**：从较小规格开始，随着使用量增长再逐步调整资源。
+- **平台自动化管理**：让 Sealos 处理常见基础设施工作，你专注使用 Cap 本身。
+
+如果你想自托管屏幕录制平台，又不想自己维护 Kubernetes 底层细节，Sealos 是一个合适的部署选择。
+
+## 部署指南
+
+1. 打开 [Cap 模板](https://sealos.io/products/app-store/cap)，点击 **Deploy Now**。
+2. 在弹窗中配置参数。生产环境建议填写 `RESEND_API_KEY` 和 `RESEND_FROM_DOMAIN`；测试环境可以留空。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas。后续如需修改配置，可以在对话框中描述需求让 AI 执行，也可以点击对应资源卡片调整设置。
+4. 通过系统提供的公网地址访问 Cap：
+   - **Cap Web**：使用邮箱验证码或邮件链接登录。
+   - **桌面端连接**：如果使用自托管服务，可在 Cap Desktop 的 `Settings > Cap Server URL` 中填写你的部署地址。
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+部署完成后，你可以通过以下方式配置 Cap：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- **AI 对话**：描述需要调整的环境变量、资源或域名，让 AI 帮你应用修改。
+- **资源卡片**：打开 Cap Web、Media Server、MySQL 或 Object Storage 资源卡片，查看并修改设置。
+- **邮件发送**：配置 `RESEND_API_KEY` 和 `RESEND_FROM_DOMAIN` 后，可通过 Resend 发送登录邮件。
+- **桌面客户端**：将 Cap Desktop 的 Cap Server URL 指向你的部署地址。
+- **密钥与 URL**：开始录制后应保持生成密钥稳定，因为修改加密或认证密钥可能导致会话失效或加密数据不可用。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+## 扩容
 
-## 官方链接
+在 Sealos 上扩容 Cap：
 
-- 官方网站: https://github.com/CapSoftware/Cap
-- 源码仓库: https://github.com/CapSoftware/Cap
+1. 打开该部署对应的 Canvas。
+2. 点击 Cap Web 或 Cap Media Server 资源卡片。
+3. 根据访问量和处理压力调整 CPU、内存或副本数。
+4. 在对话框中应用修改，并从 Canvas 观察滚动发布状态。
+
+团队规模变大时，建议先提升 Cap Web 资源；如果媒体处理成为瓶颈，再扩容媒体服务器。MySQL 和对象存储容量应根据录制量和保留周期调整。
+
+## 故障排查
+
+### 常见问题
+
+**收不到登录邮件**
+- 原因：`RESEND_API_KEY` 和 `RESEND_FROM_DOMAIN` 为空或配置错误。
+- 解决方法：配置 Resend 凭据。测试部署如果不配置邮件，可以从 Canvas 的 Cap Web 资源卡片查看日志，并复制开发模式验证码。
+
+**Cap Web 启动时反复重启**
+- 原因：Next.js 启动和数据库迁移阶段可能需要更多内存。
+- 解决方法：在资源卡片中提高 Cap Web 的内存限制，然后等待滚动发布完成。
+
+**录制文件能上传但无法观看**
+- 原因：对象存储端点或存储桶访问设置可能不正确。
+- 解决方法：检查 Object Storage 存储桶、Cap Web 资源卡片中的 S3 环境变量和公网端点配置。
+
+### 获取帮助
+
+- [Cap 文档](https://cap.so/docs)
+- [Cap GitHub Issues](https://github.com/CapSoftware/Cap/issues)
+- [Cap Discord](https://cap.link/discord)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Cap 自托管指南](https://cap.so/docs/self-hosting)
+- [Cap 下载](https://cap.so/download)
+- [Cap GitHub 仓库](https://github.com/CapSoftware/Cap)
+- [Sealos 文档](https://sealos.run/docs)
+
+## 许可证
+
+此 Sealos 模板由 Sealos templates 仓库维护。Cap 本身主要采用 AGPLv3 许可证，部分录制相关 crate 使用 MIT 许可证；详情请查看 [Cap 许可证文件](https://github.com/CapSoftware/Cap/blob/main/LICENSE)。

--- a/template/cap/index.yaml
+++ b/template/cap/index.yaml
@@ -6,7 +6,7 @@ spec:
   title: 'Cap'
   url: 'https://github.com/CapSoftware/Cap'
   gitRepo: 'https://github.com/CapSoftware/Cap'
-  author: 'sealos'
+  author: 'Sealos'
   description: 'Open source alternative to Loom. Record, edit and share videos in seconds.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/cap/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/cap/logo.svg'
@@ -14,7 +14,6 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Cap'
       description: 'Loom 的开源替代品。快速录制、编辑和分享视频。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/cap/README_zh.md'
   categories:
@@ -25,20 +24,34 @@ spec:
       value: cap-${{ random(8) }}
     app_host:
       type: string
-      value: ${{ random(8) }}
+      value: cap-${{ random(8) }}
     database_encryption_key:
       type: string
       value: ${{ random(64) }}
     nextauth_secret:
       type: string
       value: ${{ random(64) }}
+    media_server_webhook_secret:
+      type: string
+      value: ${{ random(64) }}
+  inputs:
+    RESEND_API_KEY:
+      description: 'Optional Resend API key for sending login emails'
+      type: string
+      default: ''
+      required: false
+    RESEND_FROM_DOMAIN:
+      description: 'Optional verified Resend sender domain'
+      type: string
+      default: ''
+      required: false
 ---
 apiVersion: objectstorage.sealos.io/v1
 kind: ObjectStorageBucket
 metadata:
   name: ${{ defaults.app_name }}
 spec:
-  policy: private
+  policy: publicRead
 
 ---
 apiVersion: v1
@@ -91,8 +104,9 @@ metadata:
   finalizers:
     - cluster.kubeblocks.io/finalizer
   labels:
+    kb.io/database: ac-mysql-8.0.30-1
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
+    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30-1
     sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
   annotations: {}
   name: ${{ defaults.app_name }}-mysql
@@ -101,13 +115,15 @@ spec:
     nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
+    topologyKeys:
+      - kubernetes.io/hostname
   clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterVersionRef: ac-mysql-8.0.30-1
   componentSpecs:
     - componentDefRef: mysql
       monitor: true
       name: mysql
+      noCreatePDB: false
       replicas: 1
       resources:
         limits:
@@ -117,6 +133,8 @@ spec:
           cpu: 50m
           memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mysql
+      switchPolicy:
+        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -138,9 +156,11 @@ spec:
   completions: 1
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: mysql-init
-          image: mysql:8.0-debian
+          image: mysql:8.0.46-debian
+          imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_PASSWORD
               valueFrom:
@@ -166,7 +186,11 @@ spec:
             - /bin/bash
             - -c
             - |
-              until mysql -h ${MYSQL_HOST} -P ${MYSQL_PORT} -u ${MYSQL_USER} -p${MYSQL_PASSWORD} -e "CREATE DATABASE IF NOT EXISTS planetscale; ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PASSWORD}';"; do sleep 1; done
+              until mysqladmin ping -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --silent; do sleep 2; done
+              mysql -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USER}" -p"${MYSQL_PASSWORD}" <<SQL
+              CREATE DATABASE IF NOT EXISTS cap CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+              ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PASSWORD}';
+              SQL
       restartPolicy: Never
   backoffLimit: 0
   ttlSecondsAfterFinished: 300
@@ -177,7 +201,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/capsoftware/cap-web@sha256:0e16ba2afad559c4bc460167b88ef14dbc980371ad172e9fa6bd0e109e9feae2
+    originImageName: ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -197,7 +221,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/capsoftware/cap-web@sha256:0e16ba2afad559c4bc460167b88ef14dbc980371ad172e9fa6bd0e109e9feae2
+          image: ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_PASSWORD
@@ -220,8 +244,28 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: username
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: object-storage-key
+                  key: accessKey
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: object-storage-key
+                  key: secretKey
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
+                  key: bucket
+            - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: object-storage-key
+                  key: external
             - name: DATABASE_URL
-              value: mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/planetscale?ssl={"rejectUnauthorized":false}
+              value: 'mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_HOST):$(MYSQL_PORT)/cap?ssl={"rejectUnauthorized":false}'
             - name: WEB_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
             - name: NEXTAUTH_URL
@@ -230,46 +274,126 @@ spec:
               value: ${{ defaults.database_encryption_key }}
             - name: NEXTAUTH_SECRET
               value: ${{ defaults.nextauth_secret }}
+            - name: MEDIA_SERVER_WEBHOOK_SECRET
+              value: ${{ defaults.media_server_webhook_secret }}
             - name: CAP_AWS_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: accessKey
+              value: $(S3_ACCESS_KEY_ID)
             - name: CAP_AWS_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: secretKey
+              value: $(S3_SECRET_ACCESS_KEY)
             - name: CAP_AWS_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
-                  key: bucket
+              value: $(S3_BUCKET)
             - name: CAP_AWS_REGION
               value: us-east-1
-            - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: external
-            - name: BACKEND_STORAGE_MINIO_INTERNAL_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: internal
             - name: S3_PUBLIC_ENDPOINT
               value: https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
             - name: S3_INTERNAL_ENDPOINT
-              value: https://$(BACKEND_STORAGE_MINIO_INTERNAL_ENDPOINT)
+              value: http://object-storage.objectstorage-system.svc.cluster.local
+            - name: S3_PATH_STYLE
+              value: 'true'
+            - name: RESEND_API_KEY
+              value: ${{ inputs.RESEND_API_KEY }}
+            - name: RESEND_FROM_DOMAIN
+              value: ${{ inputs.RESEND_FROM_DOMAIN }}
+            - name: MEDIA_SERVER_URL
+              value: http://${{ defaults.app_name }}-media-server.${{ SEALOS_NAMESPACE }}.svc.cluster.local:3456
+            - name: MEDIA_SERVER_WEBHOOK_URL
+              value: http://${{ defaults.app_name }}.${{ SEALOS_NAMESPACE }}.svc.cluster.local:3000
           ports:
             - containerPort: 3000
+              name: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3000
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 1000m
               memory: 1024Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-media-server
+  annotations:
+    originImageName: ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad
+    deploy.cloud.sealos.io/minReplicas: '1'
+    deploy.cloud.sealos.io/maxReplicas: '1'
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-media-server
+    app: ${{ defaults.app_name }}-media-server
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-media-server
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-media-server
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: ${{ defaults.app_name }}-media-server
+          image: ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: '3456'
+            - name: MEDIA_SERVER_WEBHOOK_SECRET
+              value: ${{ defaults.media_server_webhook_secret }}
+          ports:
+            - containerPort: 3456
+              name: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3456
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3456
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3456
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
 
 ---
 apiVersion: v1
@@ -278,11 +402,30 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 3000
+    - name: http
+      port: 3000
+      targetPort: 3000
   selector:
     app: ${{ defaults.app_name }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}-media-server
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-media-server
+    app: ${{ defaults.app_name }}-media-server
+spec:
+  ports:
+    - name: http
+      port: 3456
+      targetPort: 3456
+  selector:
+    app: ${{ defaults.app_name }}-media-server
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Update the Cap template with the current service topology, media server, object storage configuration, MySQL initialization, health probes, and bilingual README documentation.

Raise the docker-to-sealos KubeBlocks database resource baseline and update generator, validator, references, and tests to enforce it.