### PR TITLE
fix(rybbit): repair Sealos deployment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ scripts/test_template_logo_resolver.py
 scripts/test_template_metadata_rewrite.py
 scripts/test_template_readme_normalizer.py
 scripts/test_template_validation_gate.py
+
+# Sealos local deployment state
+.sealos/

--- a/template/rybbit/README.md
+++ b/template/rybbit/README.md
@@ -1,28 +1,133 @@
-# Rybbit
+# Deploy and Host Rybbit on Sealos
 
-## Overview
+Rybbit is a modern, open-source, privacy-friendly web and product analytics platform. This template deploys Rybbit with a separate web client, backend API, ClickHouse analytics storage, and PostgreSQL metadata database on Sealos Cloud.
 
-Rybbit is the modern open source and privacy friendly alternative to Google Analytics.
+## About Hosting Rybbit
 
-This Sealos template deploys **Rybbit** as the `rybbit` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Rybbit helps teams understand website and product usage without relying on invasive third-party analytics platforms. It supports traffic analytics, product events, session insights, and a privacy-focused analytics workflow for modern web applications.
 
-## Deploy on Sealos
+This Sealos template runs Rybbit as a multi-service deployment. The client serves the web dashboard, the backend API handles authentication and analytics APIs, ClickHouse stores high-volume analytics events, and PostgreSQL stores application metadata. Sealos automatically provisions public HTTPS access, internal service discovery, persistent storage, and database credentials.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The deployment is designed for a straightforward self-hosted setup. Signup is enabled by default so you can create the first account after deployment, while application secrets and database credentials are generated automatically by the template.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **Privacy-friendly website analytics**: Track page views, referrers, devices, locations, and visitor behavior without sending data to Google Analytics.
+- **Product analytics**: Collect and analyze product events to understand feature adoption and user journeys.
+- **Self-hosted analytics for SaaS products**: Keep analytics data under your own infrastructure while still using a modern dashboard.
+- **Lightweight analytics for content sites**: Monitor content performance, acquisition channels, and audience trends.
+- **Internal application monitoring**: Analyze usage patterns for private dashboards, portals, and internal tools.
+
+## Dependencies for Rybbit Hosting
+
+The Sealos template includes all required runtime components: Rybbit client, Rybbit backend API, ClickHouse for analytics event storage, PostgreSQL 16 for metadata storage, persistent volumes, internal Services, and HTTPS Ingress resources.
+
+### Deployment Dependencies
+
+- [Rybbit Website](https://rybbit.io/) - Product overview and hosted analytics information
+- [Rybbit GitHub Repository](https://github.com/rybbit-io/rybbit) - Source code, issues, and upstream project updates
+- [ClickHouse Documentation](https://clickhouse.com/docs) - ClickHouse database documentation
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/) - PostgreSQL database documentation
+- [Sealos Documentation](https://sealos.io/docs) - Sealos platform documentation
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Rybbit Client**: Next.js web dashboard exposed as the primary public application on port `3002`.
+- **Rybbit Backend**: API service exposed under the same public host at `/api` on port `3001`.
+- **ClickHouse**: Stateful analytics database using `clickhouse/clickhouse-server:25.4.2` with persistent storage for event data.
+- **PostgreSQL**: Kubeblocks-managed PostgreSQL 16 database used for Rybbit metadata and application state.
+- **PostgreSQL Init Job**: Idempotently creates the `analytics` database before the backend starts.
+- **Ingress and App Entry**: Sealos-managed HTTPS entrypoint for the Rybbit dashboard and backend API.
+
+**Configuration:**
+
+The template automatically generates the application name, public host, Better Auth secret, and ClickHouse password. PostgreSQL credentials are provided through Sealos-managed database secrets, and the backend reads them through Kubernetes `secretKeyRef` values.
+
+The client uses `NEXT_PUBLIC_BACKEND_URL` to point to the generated public URL. The backend uses `BASE_URL` with the same public host, connects to ClickHouse over the internal Kubernetes Service, and connects to PostgreSQL through the Kubeblocks connection secret.
+
+Signup is enabled by default with `DISABLE_SIGNUP=false`. After deployment, open the public Rybbit URL and register the first user account. Optional map-based features may require a Mapbox token if you choose to enable them later.
+
+**License Information:**
+
+Rybbit is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0). This Sealos template is provided as deployment configuration for running Rybbit on Sealos Cloud.
+
+## Why Deploy Rybbit on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle, from development and deployment to production operations. By deploying Rybbit on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Rybbit without manually writing Kubernetes manifests or wiring databases by hand.
+- **Kubernetes-Native Runtime**: Run the client, backend, ClickHouse, and PostgreSQL on a Kubernetes-based platform with service discovery and workload management.
+- **Persistent Storage Included**: Keep ClickHouse analytics data and PostgreSQL metadata available across restarts and upgrades.
+- **Instant Public Access**: Get an automatic HTTPS URL for the Rybbit dashboard and backend API.
+- **Easy Customization**: Adjust environment variables, resources, and storage from the Canvas using AI dialog or resource cards.
+- **Pay-as-You-Go Resources**: Allocate only the CPU, memory, and storage you need, then scale as your analytics workload grows.
+- **Simplified Operations**: Focus on analytics and product decisions while Sealos handles infrastructure provisioning and orchestration.
+
+Deploy Rybbit on Sealos when you want self-hosted analytics without spending time managing Kubernetes infrastructure directly.
+
+## Deployment Guide
+
+1. Open the [Rybbit template](https://sealos.io/products/app-store/rybbit) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog. The default generated values are enough for a standard deployment.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog, or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **Rybbit Dashboard**: Open the generated public URL and register your first account.
+   - **Backend API**: Available under the same host at `/api` for Rybbit client and tracking requests.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Rybbit through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AI Dialog**: Describe the changes you want, such as disabling signup or adding optional API tokens, and let AI apply updates.
+- **Resource Cards**: Open the backend Deployment card to adjust environment variables such as `DISABLE_SIGNUP`, `MAPBOX_TOKEN`, or resource limits.
+- **Canvas Resources**: Review the ClickHouse StatefulSet, PostgreSQL Cluster, Services, and Ingress resources created by the template.
+- **Rybbit Dashboard**: Create your first account, add websites or products, and follow Rybbit's in-app setup instructions to install tracking scripts.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+Rybbit includes separate client, backend, ClickHouse, and PostgreSQL resources. Start with the default deployment, then scale based on event volume and dashboard traffic.
 
-- Official website: https://rybbit.io/
-- Source repository: https://github.com/rybbit-io/rybbit
+1. Open the Canvas for your deployment.
+2. Click the client or backend Deployment card to adjust CPU, memory, or replica count.
+3. Click the ClickHouse StatefulSet card to increase CPU or memory for higher analytics query volume.
+4. Apply changes through the dialog and monitor readiness from the Canvas.
+
+For high-volume analytics workloads, prioritize ClickHouse CPU, memory, and storage capacity before increasing frontend replicas.
+
+## Troubleshooting
+
+### Signup is not available
+
+- Cause: `DISABLE_SIGNUP` may have been changed to `true` after the first account was created.
+- Solution: Set `DISABLE_SIGNUP=false` on the backend Deployment if you need to allow new account registration again.
+
+### Map or globe features ask for a token
+
+- Cause: Some map-based visualizations require `MAPBOX_TOKEN`.
+- Solution: Add your Mapbox token to the backend Deployment environment variables and restart the backend.
+
+### Backend is not ready
+
+- Cause: The backend waits for ClickHouse and PostgreSQL before starting.
+- Solution: Check the backend Deployment, ClickHouse StatefulSet, PostgreSQL Cluster, and PostgreSQL init Job from the Canvas. Make sure all database resources are running before troubleshooting the backend itself.
+
+### Getting Help
+
+- [Rybbit GitHub Issues](https://github.com/rybbit-io/rybbit/issues)
+- [Sealos Documentation](https://sealos.io/docs)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Rybbit Website](https://rybbit.io/)
+- [Rybbit Source Code](https://github.com/rybbit-io/rybbit)
+- [ClickHouse Documentation](https://clickhouse.com/docs)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+
+## License
+
+This Sealos template is provided as deployment configuration for Sealos users. Rybbit itself is licensed under the [GNU Affero General Public License v3.0](https://github.com/rybbit-io/rybbit/blob/master/LICENSE.md).

--- a/template/rybbit/README_zh.md
+++ b/template/rybbit/README_zh.md
@@ -1,28 +1,133 @@
-# Rybbit
+# 在 Sealos 上部署和托管 Rybbit
 
-## 应用概览
+Rybbit 是一款现代化、开源、注重隐私的网站与产品分析平台。这个模板会在 Sealos Cloud 上部署完整的 Rybbit 服务，包括独立的 Web 客户端、后端 API、ClickHouse 分析存储，以及 PostgreSQL 元数据数据库。
 
-Rybbit 是一款开源、注重隐私、比 Google Analytics 更直观的下一代替代品，用于网络和产品分析，并且易于安装和使用。
+## 关于 Rybbit 托管
 
-此 Sealos 模板会将 **Rybbit** 部署为 `rybbit` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Rybbit 可以帮助团队了解网站和产品的真实使用情况，同时避免依赖侵入式的第三方分析平台。它支持流量分析、产品事件、会话洞察，以及面向现代 Web 应用的隐私友好型分析流程。
 
-## 在 Sealos 上部署
+这个 Sealos 模板采用多服务架构运行 Rybbit：客户端负责提供 Web 控制台，后端 API 处理认证和分析接口，ClickHouse 存储高吞吐量的分析事件，PostgreSQL 存储应用元数据。Sealos 会自动配置公网 HTTPS 访问、内部服务发现、持久化存储和数据库凭据。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+模板面向直接可用的自托管场景设计。默认开启注册，部署完成后可以直接创建第一个账号；应用密钥和数据库凭据则由模板自动生成。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **隐私友好的网站分析**：统计页面访问、来源、设备、地区和访客行为，无需把数据发送到 Google Analytics。
+- **产品分析**：采集并分析产品事件，了解功能采用率和用户旅程。
+- **SaaS 产品自托管分析**：把分析数据留在自己的基础设施中，同时继续使用现代化的数据看板。
+- **内容站轻量分析**：监控内容表现、获客渠道和受众趋势。
+- **内部应用监测**：分析私有控制台、门户和内部工具的使用模式。
+
+## Rybbit 托管依赖
+
+这个 Sealos 模板已经包含运行 Rybbit 所需的全部组件：Rybbit 客户端、Rybbit 后端 API、用于分析事件存储的 ClickHouse、用于元数据存储的 PostgreSQL 16、持久化卷、内部 Service，以及 HTTPS Ingress 资源。
+
+### 部署依赖
+
+- [Rybbit 官网](https://rybbit.io/) - 产品介绍与托管版分析服务信息
+- [Rybbit GitHub 仓库](https://github.com/rybbit-io/rybbit) - 源码、问题反馈和上游项目更新
+- [ClickHouse 文档](https://clickhouse.com/docs) - ClickHouse 数据库文档
+- [PostgreSQL 文档](https://www.postgresql.org/docs/) - PostgreSQL 数据库文档
+- [Sealos 文档](https://sealos.io/docs) - Sealos 平台文档
+
+### 实现细节
+
+**架构组件：**
+
+模板会部署以下服务：
+
+- **Rybbit Client**：基于 Next.js 的 Web 控制台，作为主公网应用通过 `3002` 端口对外提供服务。
+- **Rybbit Backend**：API 服务，与客户端共用同一个公网域名，并通过 `/api` 路径和 `3001` 端口提供接口。
+- **ClickHouse**：使用 `clickhouse/clickhouse-server:25.4.2` 的有状态分析数据库，配备持久化存储，用于保存事件数据。
+- **PostgreSQL**：由 Kubeblocks 管理的 PostgreSQL 16 数据库，用于保存 Rybbit 元数据和应用状态。
+- **PostgreSQL Init Job**：在后端启动前以幂等方式创建 `analytics` 数据库。
+- **Ingress 和应用入口**：由 Sealos 管理的 HTTPS 入口，用于访问 Rybbit 控制台和后端 API。
+
+**配置方式：**
+
+模板会自动生成应用名称、公网域名、Better Auth 密钥和 ClickHouse 密码。PostgreSQL 凭据由 Sealos 托管的数据库密钥提供，后端通过 Kubernetes 的 `secretKeyRef` 读取。
+
+客户端使用 `NEXT_PUBLIC_BACKEND_URL` 指向生成的公网地址。后端使用同一个公网域名作为 `BASE_URL`，通过 Kubernetes 内部 Service 连接 ClickHouse，并通过 Kubeblocks 连接密钥访问 PostgreSQL。
+
+默认配置为 `DISABLE_SIGNUP=false`，也就是允许注册。部署完成后，打开 Rybbit 公网地址并注册第一个用户账号即可开始使用。如果后续需要启用地图相关能力，可以再按需配置 Mapbox token。
+
+**许可证信息：**
+
+Rybbit 使用 GNU Affero General Public License v3.0（AGPL-3.0）许可证。这个 Sealos 模板仅作为在 Sealos Cloud 上运行 Rybbit 的部署配置提供。
+
+## 为什么在 Sealos 上部署 Rybbit？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，覆盖从开发、部署到生产运维的完整应用生命周期。将 Rybbit 部署到 Sealos 后，你可以获得：
+
+- **一键部署**：无需手写 Kubernetes 清单，也不用手动连接数据库，即可完成 Rybbit 部署。
+- **Kubernetes 原生运行环境**：在基于 Kubernetes 的平台上运行客户端、后端、ClickHouse 和 PostgreSQL，并获得服务发现与工作负载管理能力。
+- **内置持久化存储**：ClickHouse 分析数据和 PostgreSQL 元数据会在重启和升级后继续保留。
+- **即时公网访问**：自动获得可访问 Rybbit 控制台和后端 API 的 HTTPS 地址。
+- **灵活自定义**：可在 Canvas 中通过 AI 对话或资源卡片调整环境变量、资源规格和存储。
+- **按需使用资源**：按实际需要分配 CPU、内存和存储，并随分析负载增长逐步扩容。
+- **简化运维**：把注意力放在分析和产品决策上，让 Sealos 处理基础设施创建与编排。
+
+如果你想自托管分析系统，但不想直接管理 Kubernetes 基础设施，Sealos 是部署 Rybbit 的合适选择。
+
+## 部署指南
+
+1. 打开 [Rybbit 模板](https://sealos.io/products/app-store/rybbit)，点击 **Deploy Now**。
+2. 在弹窗中配置参数。对于标准部署，保留默认生成值即可。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会自动跳转到 Canvas。后续如需修改配置，可以在 AI 对话中描述需求，或点击对应资源卡片调整设置。
+4. 通过系统提供的 URL 访问应用：
+   - **Rybbit 控制台**：打开生成的公网 URL，并注册第一个账号。
+   - **后端 API**：通过同一域名下的 `/api` 路径提供服务，用于 Rybbit 客户端和埋点请求。
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+部署完成后，可以通过以下方式配置 Rybbit：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- **AI 对话**：直接描述想要的变更，例如关闭注册、添加可选 API token，由 AI 帮你应用更新。
+- **资源卡片**：打开后端 Deployment 资源卡片，调整 `DISABLE_SIGNUP`、`MAPBOX_TOKEN`、资源限制等环境变量和配置。
+- **Canvas 资源视图**：查看模板创建的 ClickHouse StatefulSet、PostgreSQL Cluster、Service 和 Ingress 等资源。
+- **Rybbit 控制台**：创建第一个账号，添加网站或产品，并按照 Rybbit 应用内指引安装追踪脚本。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+## 扩容
 
-## 官方链接
+Rybbit 的客户端、后端、ClickHouse 和 PostgreSQL 资源彼此独立。建议先使用默认部署，之后再根据事件量和控制台访问量逐步扩容。
 
-- 官方网站: https://rybbit.io/
-- 源码仓库: https://github.com/rybbit-io/rybbit
+1. 打开当前部署的 Canvas。
+2. 点击客户端或后端 Deployment 资源卡片，调整 CPU、内存或副本数。
+3. 点击 ClickHouse StatefulSet 资源卡片，为更高的分析查询量增加 CPU 或内存。
+4. 通过对话应用变更，并在 Canvas 中观察资源就绪状态。
+
+对于高事件量分析场景，优先提升 ClickHouse 的 CPU、内存和存储容量，再考虑增加前端副本。
+
+## 故障排查
+
+### 无法注册账号
+
+- 原因：创建第一个账号后，`DISABLE_SIGNUP` 可能被改成了 `true`。
+- 解决办法：如果需要重新开放注册，请在后端 Deployment 中将 `DISABLE_SIGNUP` 设置为 `false`。
+
+### 地图或地球视图提示需要 token
+
+- 原因：部分地图可视化能力需要配置 `MAPBOX_TOKEN`。
+- 解决办法：将 Mapbox token 添加到后端 Deployment 的环境变量中，并重启后端服务。
+
+### 后端没有就绪
+
+- 原因：后端启动前需要等待 ClickHouse 和 PostgreSQL 可用。
+- 解决办法：在 Canvas 中检查后端 Deployment、ClickHouse StatefulSet、PostgreSQL Cluster 和 PostgreSQL 初始化 Job。先确认所有数据库资源正常运行，再继续排查后端服务。
+
+### 获取帮助
+
+- [Rybbit GitHub Issues](https://github.com/rybbit-io/rybbit/issues)
+- [Sealos 文档](https://sealos.io/docs)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Rybbit 官网](https://rybbit.io/)
+- [Rybbit 源码](https://github.com/rybbit-io/rybbit)
+- [ClickHouse 文档](https://clickhouse.com/docs)
+- [PostgreSQL 文档](https://www.postgresql.org/docs/)
+
+## 许可证
+
+这个 Sealos 模板作为部署配置提供给 Sealos 用户使用。Rybbit 本身基于 [GNU Affero General Public License v3.0](https://github.com/rybbit-io/rybbit/blob/master/LICENSE.md) 授权。

--- a/template/rybbit/index.yaml
+++ b/template/rybbit/index.yaml
@@ -7,60 +7,101 @@ spec:
   url: 'https://rybbit.io/'
   gitRepo: 'https://github.com/rybbit-io/rybbit'
   author: 'Sealos'
-  description: 'Rybbit is the modern open source and privacy friendly alternative to Google Analytics.'
+  description: 'Rybbit is a modern, open-source, privacy-friendly web and product analytics platform.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rybbit/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rybbit/logo.png'
   templateType: inline
   locale: en
   i18n:
     zh:
-      description: 'Rybbit 是一款开源、注重隐私、比 Google Analytics 更直观的下一代替代品，用于网络和产品分析，并且易于安装和使用。'
+      description: 'Rybbit 是一款现代化、开源、注重隐私的网站与产品分析平台。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rybbit/README_zh.md'
   categories:
     - tool
   defaults:
     app_host:
-      # number or string..
       type: string
       value: rybbit-${{ random(8) }}
     app_name:
       type: string
       value: rybbit-${{ random(8) }}
+    better_auth_secret:
+      type: string
+      value: ${{ random(48) }}
+    clickhouse_password:
+      type: string
+      value: ${{ random(32) }}
+    disable_signup:
+      type: string
+      value: 'false'
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: ${{ defaults.app_name }}-pg
-
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ defaults.app_name }}-pg
+subjects:
+  - kind: ServiceAccount
+    name: ${{ defaults.app_name }}-pg
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
   name: ${{ defaults.app_name }}-pg
+  labels:
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 spec:
   affinity:
-    nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
+  terminationPolicy: Delete
   componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
       resources:
         limits:
           cpu: 500m
@@ -68,9 +109,6 @@ spec:
         requests:
           cpu: 50m
           memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -79,86 +117,78 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-pg
-subjects:
-  - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-pg
-
+            storageClassName: openebs-backup
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${{ defaults.app_name }}-pg-init
 spec:
-  completions: 1
+  backoffLimit: 5
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
-        - name: pgsql-init
-          image: senzing/postgresql-client:2.2.4
+        - name: pg-init
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_DATABASE
+              value: analytics
+            - name: PGPASSWORD
+              value: $(PG_PASSWORD)
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE analytics;' &>/dev/null; do sleep 1; done
+              until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; do
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='analytics'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "analytics";'
+              fi
       restartPolicy: Never
-  backoffLimit: 0
   ttlSecondsAfterFinished: 300
-
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ${{ defaults.app_name }}-clickhouse
+  labels:
+    app: ${{ defaults.app_name }}-clickhouse
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-clickhouse
 data:
-  vn-etcvn-clickhouse-servervn-configvn-dvn-enable-jsonvn-xml: |-
+  vn-etcvn-clickhousevn-servervn-configvn-dvn-networkvn-xml: |-
+    <clickhouse>
+        <listen_host>0.0.0.0</listen_host>
+    </clickhouse>
+  vn-etcvn-clickhousevn-servervn-configvn-dvn-enablevn-jsonvn-xml: |-
     <clickhouse>
         <settings>
             <enable_json_type>1</enable_json_type>
         </settings>
     </clickhouse>
-  vn-etcvn-clickhouse-servervn-configvn-dvn-logging-rulesvn-xml: |-
+  vn-etcvn-clickhousevn-servervn-configvn-dvn-loggingvn-77db84fe: |-
     <clickhouse>
       <logger>
           <level>warning</level>
@@ -172,21 +202,27 @@ data:
       <asynchronous_metric_log remove="remove"/>
       <session_log remove="remove"/>
       <part_log remove="remove"/>
+      <latency_log remove="remove"/>
+      <processors_profile_log remove="remove"/>
     </clickhouse>
-  vn-etcvn-clickhouse-servervn-configvn-dvn-networkvn-xml: |-
-    <clickhouse>
-        <listen_host>0.0.0.0</listen_host>
-    </clickhouse>
-  vn-etcvn-clickhouse-servervn-usersvn-dvn-user-loggingvn-xml: |-
+  vn-etcvn-clickhousevn-servervn-usersvn-dvn-uservn-l-87e45283: |-
     <clickhouse>
       <profiles>
         <default>
           <log_queries>0</log_queries>
           <log_query_threads>0</log_query_threads>
+          <log_processors_profiles>0</log_processors_profiles>
         </default>
       </profiles>
     </clickhouse>
-
+  vn-etcvn-clickhousevn-servervn-usersvn-dvn-defaultvn-password: |-
+    <clickhouse>
+      <users>
+        <default>
+          <password>${{ defaults.clickhouse_password }}</password>
+        </default>
+      </users>
+    </clickhouse>
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -197,8 +233,8 @@ metadata:
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-clickhouse
     app: ${{ defaults.app_name }}-clickhouse
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-clickhouse
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -212,118 +248,151 @@ spec:
       labels:
         app: ${{ defaults.app_name }}-clickhouse
     spec:
-      terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-clickhouse
           image: clickhouse/clickhouse-server:25.4.2
+          imagePullPolicy: IfNotPresent
           env:
             - name: CLICKHOUSE_DB
               value: analytics
             - name: CLICKHOUSE_USER
               value: default
             - name: CLICKHOUSE_PASSWORD
-              value: frog
+              value: ${{ defaults.clickhouse_password }}
           resources:
-            requests:
-              cpu: 100m
-              memory: 204Mi
             limits:
-              cpu: 1000m
-              memory: 2048Mi
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            failureThreshold: 30
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 51Mi
+          ports:
+            - name: http
+              containerPort: 8123
+              protocol: TCP
+            - name: tcp
+              containerPort: 9000
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          livenessProbe:
             httpGet:
               path: /ping
               port: 8123
               scheme: HTTP
             periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
           volumeMounts:
-            - name: vn-etcvn-clickhouse-servervn-configvn-dvn-enable-jsonvn-xml
-              mountPath: /etc/clickhouse-server/config.d/enable_json.xml
-              subPath: ./etc/clickhouse-server/config.d/enable_json.xml
-            - name: vn-etcvn-clickhouse-servervn-configvn-dvn-logging-rulesvn-xml
-              mountPath: /etc/clickhouse-server/config.d/logging_rules.xml
-              subPath: ./etc/clickhouse-server/config.d/logging_rules.xml
-            - name: vn-etcvn-clickhouse-servervn-configvn-dvn-networkvn-xml
-              mountPath: /etc/clickhouse-server/config.d/network.xml
-              subPath: ./etc/clickhouse-server/config.d/network.xml
-            - name: vn-etcvn-clickhouse-servervn-usersvn-dvn-user-loggingvn-xml
-              mountPath: /etc/clickhouse-server/users.d/user_logging.xml
-              subPath: ./etc/clickhouse-server/users.d/user_logging.xml
             - name: vn-varvn-libvn-clickhouse
               mountPath: /var/lib/clickhouse
+            - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-networkvn-xml
+              mountPath: /etc/clickhouse-server/config.d/network.xml
+              subPath: network.xml
+            - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-enablevn-jsonvn-xml
+              mountPath: /etc/clickhouse-server/config.d/enable_json.xml
+              subPath: enable_json.xml
+            - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-loggingvn-77db84fe
+              mountPath: /etc/clickhouse-server/config.d/logging_rules.xml
+              subPath: logging_rules.xml
+            - name: vn-etcvn-clickhousevn-servervn-usersvn-dvn-uservn-l-87e45283
+              mountPath: /etc/clickhouse-server/users.d/user_logging.xml
+              subPath: user_logging.xml
+            - name: vn-etcvn-clickhousevn-servervn-usersvn-dvn-defaultvn-password
+              mountPath: /etc/clickhouse-server/users.d/default-password.xml
+              subPath: default-password.xml
       volumes:
-        - name: vn-etcvn-clickhouse-servervn-configvn-dvn-enable-jsonvn-xml
+        - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-networkvn-xml
           configMap:
             name: ${{ defaults.app_name }}-clickhouse
             items:
-              - key: vn-etcvn-clickhouse-servervn-configvn-dvn-enable-jsonvn-xml
-                path: ./etc/clickhouse-server/config.d/enable_json.xml
-        - name: vn-etcvn-clickhouse-servervn-configvn-dvn-logging-rulesvn-xml
+              - key: vn-etcvn-clickhousevn-servervn-configvn-dvn-networkvn-xml
+                path: network.xml
+        - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-enablevn-jsonvn-xml
           configMap:
             name: ${{ defaults.app_name }}-clickhouse
             items:
-              - key: vn-etcvn-clickhouse-servervn-configvn-dvn-logging-rulesvn-xml
-                path: ./etc/clickhouse-server/config.d/logging_rules.xml
-        - name: vn-etcvn-clickhouse-servervn-configvn-dvn-networkvn-xml
+              - key: vn-etcvn-clickhousevn-servervn-configvn-dvn-enablevn-jsonvn-xml
+                path: enable_json.xml
+        - name: vn-etcvn-clickhousevn-servervn-configvn-dvn-loggingvn-77db84fe
           configMap:
             name: ${{ defaults.app_name }}-clickhouse
             items:
-              - key: vn-etcvn-clickhouse-servervn-configvn-dvn-networkvn-xml
-                path: ./etc/clickhouse-server/config.d/network.xml
-        - name: vn-etcvn-clickhouse-servervn-usersvn-dvn-user-loggingvn-xml
+              - key: vn-etcvn-clickhousevn-servervn-configvn-dvn-loggingvn-77db84fe
+                path: logging_rules.xml
+        - name: vn-etcvn-clickhousevn-servervn-usersvn-dvn-uservn-l-87e45283
           configMap:
             name: ${{ defaults.app_name }}-clickhouse
             items:
-              - key: vn-etcvn-clickhouse-servervn-usersvn-dvn-user-loggingvn-xml
-                path: ./etc/clickhouse-server/users.d/user_logging.xml
+              - key: vn-etcvn-clickhousevn-servervn-usersvn-dvn-uservn-l-87e45283
+                path: user_logging.xml
+        - name: vn-etcvn-clickhousevn-servervn-usersvn-dvn-defaultvn-password
+          configMap:
+            name: ${{ defaults.app_name }}-clickhouse
+            items:
+              - key: vn-etcvn-clickhousevn-servervn-usersvn-dvn-defaultvn-password
+                path: default-password.xml
   volumeClaimTemplates:
     - metadata:
+        name: vn-varvn-libvn-clickhouse
         annotations:
           path: /var/lib/clickhouse
           value: '1'
-        name: vn-varvn-libvn-clickhouse
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
             storage: 1Gi
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}-clickhouse
   labels:
+    app: ${{ defaults.app_name }}-clickhouse
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-clickhouse
 spec:
   ports:
     - name: http
-      targetPort: 8123
       port: 8123
-    - name: admin
-      targetPort: 9000
+      targetPort: 8123
+      protocol: TCP
+    - name: tcp
       port: 9000
+      targetPort: 9000
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}-clickhouse
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-backend
   annotations:
-    originImageName: ghcr.io/rybbit-io/rybbit-backend:sha-a863cc3
+    originImageName: ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
     app: ${{ defaults.app_name }}-backend
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -341,12 +410,38 @@ spec:
         app: ${{ defaults.app_name }}-backend
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       initContainers:
-        - name: wait-for-postgres
-          image: postgres:14-alpine
-          command: ['sh', '-c', 
-            'until pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER; do echo waiting for postgres; sleep 2; done;']
+        - name: wait-for-clickhouse
+          image: clickhouse/clickhouse-server:25.4.2
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until wget --no-verbose --tries=1 --spider "http://${CLICKHOUSE_HOST}:8123/ping"; do
+                sleep 2
+              done
           env:
+            - name: CLICKHOUSE_HOST
+              value: ${{ defaults.app_name }}-clickhouse.${{ SEALOS_NAMESPACE }}.svc.cluster.local
+        - name: wait-for-postgres
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d analytics >/dev/null 2>&1; do
+                sleep 2
+              done
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
@@ -357,11 +452,6 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: username
-            - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
@@ -369,21 +459,29 @@ spec:
                   key: password
       containers:
         - name: ${{ defaults.app_name }}-backend
-          image: ghcr.io/rybbit-io/rybbit-backend:sha-a863cc3
+          image: ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba
+          imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
-              value: 'production'
+              value: production
             - name: CLICKHOUSE_HOST
-              value: 'http://${{ defaults.app_name }}-clickhouse.${{ SEALOS_NAMESPACE }}.svc.cluster.local:8123'
+              value: http://${{ defaults.app_name }}-clickhouse.${{ SEALOS_NAMESPACE }}.svc.cluster.local:8123
             - name: CLICKHOUSE_DB
-              value: 'analytics'
+              value: analytics
             - name: CLICKHOUSE_PASSWORD
-              value: 'frog'
+              value: ${{ defaults.clickhouse_password }}
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: port
+            - name: POSTGRES_DB
+              value: analytics
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -394,47 +492,67 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: POSTGRES_DB
-              value: 'analytics'
             - name: BETTER_AUTH_SECRET
-              value: 'iu6lZsxtU4c0AfGJsD7Jrr3eafD11Ah7'
-            - name: DISABLE_SIGNUP
-              value: 'false'
+              value: ${{ defaults.better_auth_secret }}
             - name: BASE_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: DISABLE_SIGNUP
+              value: ${{ defaults.disable_signup }}
+            - name: DISABLE_TELEMETRY
+              value: 'true'
+            - name: MAPBOX_TOKEN
+              value: ''
           resources:
-            requests:
-              cpu: 20m
-              memory: 25Mi
             limits:
               cpu: 200m
               memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
           ports:
             - name: http
-              protocol: TCP
               containerPort: 3001
-          imagePullPolicy: IfNotPresent
-
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: 3001
+              scheme: HTTP
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 36
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3001
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3001
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}-backend
   labels:
+    app: ${{ defaults.app_name }}-backend
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
 spec:
   ports:
     - name: http
-      targetPort: 3001
       port: 3001
+      targetPort: 3001
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}-backend
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -442,9 +560,8 @@ metadata:
   name: ${{ defaults.app_name }}-backend
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}-backend
+    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -467,7 +584,7 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /api/(.*)
+            path: /api
             backend:
               service:
                 name: ${{ defaults.app_name }}-backend
@@ -477,25 +594,24 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${{ defaults.app_name }}-client
+  name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/rybbit-io/rybbit-client:sha-a863cc3
+    originImageName: ghcr.io/rybbit-io/rybbit-client:sha-aa404ba
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-client
-    app: ${{ defaults.app_name }}-client
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: ${{ defaults.app_name }}-client
+      app: ${{ defaults.app_name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -504,62 +620,81 @@ spec:
   template:
     metadata:
       labels:
-        app: ${{ defaults.app_name }}-client
+        app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
-        - name: ${{ defaults.app_name }}-client
-          image: ghcr.io/rybbit-io/rybbit-client:sha-a863cc3
+        - name: ${{ defaults.app_name }}
+          image: ghcr.io/rybbit-io/rybbit-client:sha-aa404ba
+          imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
-              value: 'production'
+              value: production
             - name: NEXT_PUBLIC_BACKEND_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: NEXT_PUBLIC_DISABLE_SIGNUP
+              value: ${{ defaults.disable_signup }}
           resources:
-            requests:
-              cpu: 20m
-              memory: 12Mi
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
           ports:
             - name: http
-              protocol: TCP
               containerPort: 3002
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            failureThreshold: 30
+              protocol: TCP
+          startupProbe:
             httpGet:
               path: /
               port: 3002
               scheme: HTTP
-            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3002
+              scheme: HTTP
             periodSeconds: 10
             timeoutSeconds: 3
-
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3002
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}-client
+  name: ${{ defaults.app_name }}
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-client
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
     - name: http
-      targetPort: 3002
       port: 3002
+      targetPort: 3002
+      protocol: TCP
   selector:
-    app: ${{ defaults.app_name }}-client
-
+    app: ${{ defaults.app_name }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${{ defaults.app_name }}-client
+  name: ${{ defaults.app_name }}
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-client
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}-client
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
@@ -586,14 +721,13 @@ spec:
             path: /
             backend:
               service:
-                name: ${{ defaults.app_name }}-client
+                name: ${{ defaults.app_name }}
                 port:
                   number: 3002
   tls:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -605,6 +739,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rybbit/logo.png"
-  name: "Rybbit"
+  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rybbit/logo.png'
+  name: 'Rybbit'
   type: link


### PR DESCRIPTION
## Summary
- repair the Rybbit Sealos template configuration for a working deployment
- add generated ClickHouse credentials and path-safe config volume names
- refresh the English and Chinese deployment README files

## Verification
- verified deployed Rybbit instance returns HTTP 200 for / and /api/health
- ran git diff --check for README changes