### PR TITLE
fix(flarum): tune Sealos template resources

### DIFF
--- a/template/flarum/README.md
+++ b/template/flarum/README.md
@@ -4,7 +4,7 @@
 
 Flarum is a delightfully simple discussion platform for your website.
 
-This Sealos template deploys **Flarum** as the `flarum` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+This Sealos template deploys **Flarum** as a single application backed by an ApeCloud MySQL 8.0 database. It keeps deployment, networking, storage, and the first-run database bootstrap inside the template.
 
 ## Deploy on Sealos
 
@@ -18,11 +18,12 @@ After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN
 
 The following user-facing inputs are available during deployment:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+You can set `FLARUM_FORUM_TITLE` to choose the initial forum title. The default value is `Flarum`.
 
 Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
 
 ## Official Links
 
 - Official website: https://flarum.org/
-- Source repository: https://github.com/crazy-max/docker-flarum
+- Source repository: https://github.com/flarum/framework
+- Container image: https://github.com/crazy-max/docker-flarum

--- a/template/flarum/README.md
+++ b/template/flarum/README.md
@@ -1,29 +1,145 @@
-# Flarum
+# Deploy and Host Flarum on Sealos
 
-## Overview
+Flarum is a lightweight, extensible forum platform for online communities. This template deploys Flarum with persistent storage and an ApeCloud MySQL 8.0 database on Sealos Cloud.
 
-Flarum is a delightfully simple discussion platform for your website.
+![Flarum Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/website-screenshot.webp)
 
-This Sealos template deploys **Flarum** as a single application backed by an ApeCloud MySQL 8.0 database. It keeps deployment, networking, storage, and the first-run database bootstrap inside the template.
+## About Hosting Flarum
 
-## Deploy on Sealos
+Flarum provides a clean discussion experience with topics, replies, tags, moderation tools, user groups, and an admin dashboard. Its extension system lets you add features such as Markdown formatting, file uploads, single sign-on, custom themes, and realtime behavior as your community grows.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+This Sealos template provisions the Flarum application, a MySQL database, persistent `/data` storage, public HTTPS ingress, and a Sealos desktop app entry. The template waits for MySQL during startup and creates the `flarum` database automatically, so the forum can complete its first installation without a separate manual database step.
 
-## Access
+The deployment is tuned for small community forums and starter deployments. The Flarum container uses a compact `200m` CPU and `256Mi` memory limit, while the database keeps the Sealos Kubeblocks default profile for reliability.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Community Forum**: Host product, creator, or open-source community discussions with categories and moderation.
+- **Support Forum**: Give users a searchable place to ask questions, share solutions, and track common issues.
+- **Knowledge Community**: Build a lightweight Q&A and discussion layer around docs, courses, or internal knowledge.
+- **Membership Space**: Use groups and permissions to separate public, member-only, and moderator workflows.
+- **Extension-Based Forum**: Start small, then add Flarum extensions for uploads, authentication, formatting, or custom integrations.
+
+## Dependencies for Flarum Hosting
+
+The Sealos template includes the required runtime and platform resources:
+
+- **Flarum application**: `crazymax/flarum:1.8.10`, serving HTTP on port `8000`
+- **Database**: ApeCloud MySQL `ac-mysql-8.0.30-1`
+- **Persistent storage**: `1Gi` mounted at `/data` for Flarum assets, extensions, and storage
+- **Public access**: HTTPS ingress and Sealos App link
+- **Startup bootstrap**: Init container that waits for MySQL and creates the `flarum` database with `utf8mb4`
+
+### Deployment Dependencies
+
+- [Flarum Documentation](https://docs.flarum.org/) - Official Flarum documentation
+- [Flarum Extensions](https://docs.flarum.org/extensions/) - Extension management guide
+- [Flarum Community](https://discuss.flarum.org/) - Community support and extension discussions
+- [Docker Image Repository](https://github.com/crazy-max/docker-flarum) - Container image used by this template
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Flarum StatefulSet**: Runs the forum application with Nginx, PHP-FPM, and Flarum data mounted at `/data`.
+- **MySQL Cluster**: Stores discussions, users, permissions, extension state, and forum configuration.
+- **Init Container**: Waits for the MySQL endpoint and creates the initial database before Flarum starts.
+- **Service and Ingress**: Expose Flarum on port `8000` through the generated Sealos HTTPS domain.
+- **Sealos App Entry**: Adds a clickable app shortcut that opens the forum URL.
+
+**Configuration:**
+
+- `FLARUM_FORUM_TITLE` sets the initial forum title during the first installation.
+- `FLARUM_BASE_URL` is generated from the Sealos domain: `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`.
+- Database host, port, username, and password are read from the Sealos-managed MySQL connection secret.
+- Flarum starts with debug mode disabled, `256M` PHP memory, and `16M` upload size.
+- The container image creates the default first admin user `flarum` with password `flarum`; change this password after first login.
+
+**License Information:**
+
+Flarum is released under the MIT license. This Sealos template is provided as part of the Sealos templates repository.
+
+## Why Deploy Flarum on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes. It lets you deploy and operate applications without manually writing Kubernetes manifests for every service.
+
+- **One-Click Deployment**: Open the App Store template, configure the forum title, and deploy without hand-writing YAML.
+- **Managed Runtime Resources**: Sealos creates the app, database, storage, ingress, and desktop entry from one template.
+- **Persistent Storage Included**: Forum assets, extension files, and generated storage persist across restarts.
+- **Instant Public Access**: Each deployment gets an HTTPS URL under your Sealos Cloud domain.
+- **Resource Efficiency**: The template uses a tested small-footprint Flarum profile suitable for starter communities.
+- **Canvas + AI Ops**: After deployment, use the Canvas, AI dialog, and resource cards to inspect or adjust resources.
+- **Kubernetes Foundation**: You get Kubernetes scheduling, service discovery, and storage primitives without managing them directly.
+
+## Deployment Guide
+
+1. Open the [Flarum template](https://sealos.io/products/app-store/flarum) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - `FLARUM_FORUM_TITLE`: Initial forum title. Default: `Flarum`.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment starts, Sealos redirects you to the Canvas. For later changes, describe the update in the AI dialog or click the relevant resource card to modify settings.
+4. Access your application via the provided URL:
+   - **Forum URL**: `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`
+   - **Admin Panel**: `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/admin`
+5. Log in with the initial administrator account and change the password immediately:
+   - Username: `flarum`
+   - Password: `flarum`
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Flarum through:
 
-You can set `FLARUM_FORUM_TITLE` to choose the initial forum title. The default value is `Flarum`.
+- **Flarum Admin Panel**: Manage extensions, tags, permissions, mail settings, and appearance at `/admin`.
+- **AI Dialog**: Describe infrastructure changes and let Sealos help apply them.
+- **Resource Cards**: Adjust the StatefulSet, MySQL cluster, ingress, and storage resources from the Canvas.
+- **Flarum Extensions**: Install extensions from the admin dashboard or through container-level maintenance workflows.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+For production communities, configure outbound mail, review registration settings, set forum permissions, and change the default administrator password before inviting users.
 
-## Official Links
+## Scaling
 
-- Official website: https://flarum.org/
-- Source repository: https://github.com/flarum/framework
-- Container image: https://github.com/crazy-max/docker-flarum
+To scale or resize Flarum on Sealos:
+
+1. Open the Canvas for your deployment.
+2. Click the Flarum StatefulSet resource card.
+3. Adjust CPU and memory resources based on traffic, extension count, and upload usage.
+4. Click the MySQL resource card if your forum needs more database capacity.
+5. Apply the changes in the dialog and monitor the application after rollout.
+
+For most small forums, start with the template defaults. Increase memory first if you install many extensions or see PHP memory pressure.
+
+## Troubleshooting
+
+### First login uses default credentials
+
+- Cause: The container image creates the initial administrator account on first launch.
+- Solution: Log in with `flarum` / `flarum`, then change the password immediately in the admin panel.
+
+### Forum does not finish startup
+
+- Cause: MySQL may still be initializing, or database credentials may not be ready yet.
+- Solution: Wait a few minutes and check the Flarum StatefulSet logs. The init container waits for MySQL before the app starts.
+
+### Uploads or extensions need more space
+
+- Cause: Flarum stores assets, extensions, and generated files under `/data`.
+- Solution: Resize the persistent storage from the Canvas resource card before heavy upload or extension usage.
+
+### Getting Help
+
+- [Flarum Documentation](https://docs.flarum.org/)
+- [Flarum Community](https://discuss.flarum.org/)
+- [Flarum Extensions Guide](https://docs.flarum.org/extensions/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Flarum Website](https://flarum.org/)
+- [Flarum Source Repository](https://github.com/flarum/framework)
+- [Flarum Docker Image](https://github.com/crazy-max/docker-flarum)
+- [Sealos App Store](https://sealos.io/products/app-store/flarum)
+
+## License
+
+This Sealos template is provided as part of the Sealos templates repository. Flarum and the `crazymax/flarum` container image are released under the MIT license.

--- a/template/flarum/README_zh.md
+++ b/template/flarum/README_zh.md
@@ -1,29 +1,145 @@
-# Flarum
+# 在 Sealos 上部署和托管 Flarum
 
-## 应用概览
+Flarum 是一款轻量、可扩展的在线社区论坛平台。此模板会在 Sealos Cloud 上部署 Flarum，并自动配置持久化存储和 ApeCloud MySQL 8.0 数据库。
 
-Flarum 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+![Flarum 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/website-screenshot.webp)
 
-此 Sealos 模板会将 **Flarum** 部署为单应用，并使用 ApeCloud MySQL 8.0 作为数据库。部署、网络、存储和首次启动所需的数据库初始化都由模板维护。
+## 关于在 Sealos 上托管 Flarum
 
-## 在 Sealos 上部署
+Flarum 提供简洁的社区讨论体验，支持主题、回复、标签、内容管理、用户组和管理员后台。它的扩展体系可以按需加入 Markdown、文件上传、单点登录、自定义主题和实时交互等能力，适合从小型社区逐步扩展。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+此 Sealos 模板会创建 Flarum 应用、MySQL 数据库、持久化 `/data` 存储、公网 HTTPS 入口和 Sealos 桌面应用入口。模板会在启动阶段等待 MySQL 就绪，并自动创建 `flarum` 数据库，因此首次安装不需要手动初始化数据库。
 
-## 访问方式
+此部署配置适合小型社区和起步阶段的论坛。Flarum 容器使用经过测试的轻量资源规格：`200m` CPU 和 `256Mi` 内存上限；数据库保留 Sealos Kubeblocks 默认规格，以保证稳定性。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
 
-## 配置说明
+- **社区论坛**：为产品、创作者或开源项目搭建分类清晰、便于管理的讨论区。
+- **用户支持论坛**：让用户集中提问、共享解决方案，并沉淀常见问题。
+- **知识型社区**：围绕文档、课程或内部知识库构建轻量问答和讨论层。
+- **会员空间**：使用用户组和权限管理公开、会员专属和管理员工作流。
+- **扩展型论坛**：先用轻量核心上线，再通过 Flarum 扩展加入上传、认证、格式化或自定义集成。
 
-部署时可以配置以下用户可见输入项：
+## Flarum 托管依赖
 
-可以通过 `FLARUM_FORUM_TITLE` 设置初始论坛标题，默认值为 `Flarum`。
+此 Sealos 模板包含运行 Flarum 所需的运行时和平台资源：
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+- **Flarum 应用**：`crazymax/flarum:1.8.10`，通过 `8000` 端口提供 HTTP 服务
+- **数据库**：ApeCloud MySQL `ac-mysql-8.0.30-1`
+- **持久化存储**：`1Gi`，挂载到 `/data`，用于保存 Flarum 资源、扩展和运行数据
+- **公网访问**：HTTPS Ingress 和 Sealos 应用入口
+- **启动初始化**：Init Container 会等待 MySQL 并用 `utf8mb4` 创建 `flarum` 数据库
 
-## 官方链接
+### 部署依赖
 
-- 官方网站: https://flarum.org/
-- 源码仓库: https://github.com/flarum/framework
-- 容器镜像: https://github.com/crazy-max/docker-flarum
+- [Flarum 文档](https://docs.flarum.org/) - Flarum 官方文档
+- [Flarum 扩展](https://docs.flarum.org/extensions/) - 扩展管理指南
+- [Flarum 社区](https://discuss.flarum.org/) - 社区支持和扩展讨论
+- [Docker 镜像仓库](https://github.com/crazy-max/docker-flarum) - 此模板使用的容器镜像
+
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Flarum StatefulSet**：运行论坛应用，包含 Nginx、PHP-FPM，并将 Flarum 数据挂载到 `/data`。
+- **MySQL Cluster**：保存讨论、用户、权限、扩展状态和论坛配置。
+- **Init Container**：等待 MySQL 端点就绪，并在 Flarum 启动前创建初始数据库。
+- **Service 和 Ingress**：通过生成的 Sealos HTTPS 域名暴露 `8000` 端口。
+- **Sealos 应用入口**：在桌面中添加可点击的论坛快捷入口。
+
+**配置说明：**
+
+- `FLARUM_FORUM_TITLE` 用于设置首次安装时的论坛标题。
+- `FLARUM_BASE_URL` 会根据 Sealos 域名生成：`https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。
+- 数据库地址、端口、用户名和密码来自 Sealos 管理的 MySQL 连接密钥。
+- Flarum 默认关闭调试模式，PHP 内存为 `256M`，上传大小上限为 `16M`。
+- 容器镜像会创建初始管理员用户 `flarum`，密码为 `flarum`；首次登录后请立即修改密码。
+
+**许可证信息：**
+
+Flarum 使用 MIT 许可证发布。此 Sealos 模板随 Sealos templates 仓库提供。
+
+## 为什么在 Sealos 上部署 Flarum？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统。它可以让你部署和运维应用，而不必为每个服务手写 Kubernetes 配置。
+
+- **一键部署**：打开应用商店模板，配置论坛标题，即可完成部署，无需手写 YAML。
+- **托管运行资源**：Sealos 会从一个模板中创建应用、数据库、存储、入口和桌面快捷方式。
+- **内置持久化存储**：论坛资源、扩展文件和生成数据会在重启后保留。
+- **即时公网访问**：每个部署都会获得当前 Sealos Cloud 域名下的 HTTPS 地址。
+- **资源更省**：模板使用经过测试的小规格 Flarum 配置，适合起步阶段的社区。
+- **Canvas 与 AI 运维**：部署后可以通过 Canvas、AI 对话和资源卡片检查或调整资源。
+- **Kubernetes 底座**：无需直接管理 Kubernetes，也能使用调度、服务发现和存储能力。
+
+## 部署指南
+
+1. 打开 [Flarum 模板](https://sealos.run/products/app-store/flarum)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - `FLARUM_FORUM_TITLE`：初始论坛标题，默认值为 `Flarum`。
+3. 等待部署完成，通常需要 2-3 分钟。部署开始后，Sealos 会跳转到 Canvas。后续如需调整配置，可以在 AI 对话中描述需求，或点击对应资源卡片修改设置。
+4. 通过以下地址访问应用：
+   - **论坛地址**：`https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`
+   - **管理员后台**：`https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/admin`
+5. 使用初始管理员账号登录，并立即修改密码：
+   - 用户名：`flarum`
+   - 密码：`flarum`
+
+## 配置
+
+部署完成后，可以通过以下方式配置 Flarum：
+
+- **Flarum 管理后台**：在 `/admin` 管理扩展、标签、权限、邮件设置和外观。
+- **AI 对话**：描述基础设施变更需求，让 Sealos 辅助应用调整。
+- **资源卡片**：在 Canvas 中调整 StatefulSet、MySQL 集群、Ingress 和存储资源。
+- **Flarum 扩展**：通过管理后台或容器级维护流程安装扩展。
+
+用于生产社区前，建议先配置出站邮件、检查注册策略、设置论坛权限，并修改默认管理员密码。
+
+## 扩缩容
+
+在 Sealos 上调整 Flarum 资源：
+
+1. 打开当前部署的 Canvas。
+2. 点击 Flarum StatefulSet 资源卡片。
+3. 根据访问量、扩展数量和上传使用情况调整 CPU 与内存。
+4. 如果论坛需要更多数据库容量，点击 MySQL 资源卡片调整数据库资源。
+5. 在对话中应用变更，并在滚动更新后观察应用状态。
+
+对于大多数小型论坛，建议先使用模板默认值。如果安装了较多扩展或出现 PHP 内存压力，优先增加内存。
+
+## 故障排查
+
+### 首次登录使用默认账号
+
+- 原因：容器镜像会在首次启动时创建初始管理员账号。
+- 解决方法：使用 `flarum` / `flarum` 登录，然后立即在管理后台修改密码。
+
+### 论坛长时间未完成启动
+
+- 原因：MySQL 可能仍在初始化，或数据库连接密钥尚未就绪。
+- 解决方法：等待几分钟后检查 Flarum StatefulSet 日志。Init Container 会在应用启动前等待 MySQL 可用。
+
+### 上传或扩展需要更多空间
+
+- 原因：Flarum 会将资源、扩展和生成文件保存到 `/data`。
+- 解决方法：在大量上传文件或安装较多扩展前，通过 Canvas 资源卡片扩容持久化存储。
+
+### 获取帮助
+
+- [Flarum 文档](https://docs.flarum.org/)
+- [Flarum 社区](https://discuss.flarum.org/)
+- [Flarum 扩展指南](https://docs.flarum.org/extensions/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Flarum 官网](https://flarum.org/)
+- [Flarum 源码仓库](https://github.com/flarum/framework)
+- [Flarum Docker 镜像](https://github.com/crazy-max/docker-flarum)
+- [Sealos 应用商店](https://sealos.run/products/app-store/flarum)
+
+## 许可证
+
+此 Sealos 模板随 Sealos templates 仓库提供。Flarum 和 `crazymax/flarum` 容器镜像均使用 MIT 许可证发布。

--- a/template/flarum/README_zh.md
+++ b/template/flarum/README_zh.md
@@ -4,7 +4,7 @@
 
 Flarum 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
 
-此 Sealos 模板会将 **Flarum** 部署为 `flarum` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+此 Sealos 模板会将 **Flarum** 部署为单应用，并使用 ApeCloud MySQL 8.0 作为数据库。部署、网络、存储和首次启动所需的数据库初始化都由模板维护。
 
 ## 在 Sealos 上部署
 
@@ -18,11 +18,12 @@ Flarum 是一个可在 Sealos 上一键部署的应用，模板会创建所需�
 
 部署时可以配置以下用户可见输入项：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+可以通过 `FLARUM_FORUM_TITLE` 设置初始论坛标题，默认值为 `Flarum`。
 
 请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
 
 ## 官方链接
 
 - 官方网站: https://flarum.org/
-- 源码仓库: https://github.com/crazy-max/docker-flarum
+- 源码仓库: https://github.com/flarum/framework
+- 容器镜像: https://github.com/crazy-max/docker-flarum

--- a/template/flarum/index.yaml
+++ b/template/flarum/index.yaml
@@ -4,62 +4,104 @@ metadata:
   name: flarum
 spec:
   title: Flarum
-  description: 'Flarum is a delightfully simple discussion platform for your website.'
-  url: 'https://flarum.org/'
-  gitRepo: 'https://github.com/crazy-max/docker-flarum'
-  author: 'Sealos'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/logo.png'
+  description: Flarum is a delightfully simple discussion platform for your website.
+  url: https://flarum.org/
+  gitRepo: https://github.com/flarum/framework
+  author: Sealos
+  readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/README.md
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/logo.png
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/website-screenshot.webp'
+    - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/website-screenshot.webp
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: Flarum 是一个简洁、快速且易于扩展的开源论坛与社区讨论平台。
+      readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/README_zh.md
   categories:
     - blog
   defaults:
     app_host:
       type: string
-      value: ${{ random(8) }}
+      value: flarum-${{ random(8) }}
     app_name:
       type: string
       value: flarum-${{ random(8) }}
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/README_zh.md'
+  inputs:
+    FLARUM_FORUM_TITLE:
+      description: Initial forum title used during first installation.
+      type: string
+      default: Flarum
+      required: false
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ${{ defaults.app_name }}-mysql
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
     app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
     app.kubernetes.io/managed-by: kbcli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: ${{ defaults.app_name }}-mysql
-
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
+    app.kubernetes.io/managed-by: kbcli
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${{ defaults.app_name }}-mysql
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
+    app.kubernetes.io/managed-by: kbcli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ defaults.app_name }}-mysql
+subjects:
+  - kind: ServiceAccount
+    name: ${{ defaults.app_name }}-mysql
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
-    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
-  annotations: {}
   name: ${{ defaults.app_name }}-mysql
+  labels:
+    kb.io/database: ac-mysql-8.0.30-1
+    clusterdefinition.kubeblocks.io/name: apecloud-mysql
+    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30-1
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
 spec:
   affinity:
     nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
+    topologyKeys:
+      - kubernetes.io/hostname
   clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterVersionRef: ac-mysql-8.0.30-1
   componentSpecs:
-    - componentDefRef: mysql
+    - name: mysql
+      componentDefRef: mysql
       monitor: true
-      name: mysql
+      noCreatePDB: false
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-mysql
+      switchPolicy:
+        type: Noop
       resources:
         limits:
           cpu: 500m
@@ -67,7 +109,6 @@ spec:
         requests:
           cpu: 50m
           memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-mysql
       volumeClaimTemplates:
         - name: data
           spec:
@@ -76,99 +117,21 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-
+            storageClassName: openebs-backup
   terminationPolicy: Delete
   tolerations: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-mysql
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-mysql
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-mysql
-subjects:
-  - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-mysql
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-mysql-init
-spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: mysql-init
-          image: joseluisq/mysql-client:8.0.30
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: MYSQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-mysql-conn-credential
-                  key: username
-            - name: MYSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-mysql-conn-credential
-                  key: password
-            - name: MYSQL_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-mysql-conn-credential
-                  key: host
-            - name: MYSQL_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-mysql-conn-credential
-                  key: port
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USER -p$MYSQL_PASSWORD -e 'CREATE DATABASE IF NOT EXISTS flarum;'; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
-
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: crazymax/flarum:1.8.0
+    originImageName: crazymax/flarum:1.8.10
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -181,27 +144,94 @@ spec:
     metadata:
       labels:
         app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     spec:
-      terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
-      containers:
+      imagePullSecrets:
         - name: ${{ defaults.app_name }}
-          image: crazymax/flarum:1.8.0
+      terminationGracePeriodSeconds: 30
+      initContainers:
+        - name: ${{ defaults.app_name }}-mysql-init
+          image: mysql:8.0.30
+          imagePullPolicy: IfNotPresent
           env:
-            - name: FLARUM_PORT
+            - name: MYSQL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: host
+            - name: MYSQL_PORT
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: port
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MYSQL_DATABASE
+              value: flarum
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              for i in $(seq 1 90); do
+                if mysqladmin ping -h"${MYSQL_HOST}" -P"${MYSQL_PORT}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --silent; then
+                  break
+                fi
+                sleep 2
+              done
+              mysql -h"${MYSQL_HOST}" -P"${MYSQL_PORT}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" \
+                -e "CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: crazymax/flarum:1.8.10
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: TZ
+              value: UTC
+            - name: PUID
+              value: '1000'
+            - name: PGID
+              value: '1000'
+            - name: MEMORY_LIMIT
+              value: 256M
+            - name: UPLOAD_MAX_SIZE
+              value: 16M
             - name: FLARUM_DEBUG
-              value: "false"
+              value: 'false'
             - name: FLARUM_BASE_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: FLARUM_FORUM_TITLE
+              value: ${{ inputs.FLARUM_FORUM_TITLE }}
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: host
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
             - name: DB_NAME
               value: flarum
             - name: DB_USER
@@ -214,66 +244,78 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: password
-            - name: DB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-mysql-conn-credential
-                  key: port
+            - name: DB_PREFIX
+              value: flarum_
+            - name: DB_TIMEOUT
+              value: '90'
           resources:
-            requests:
-              cpu: 100m
-              memory: 102Mi
             limits:
-              cpu: 1000m
-              memory: 1024Mi
-          command: []
-          args: []
-          ports:
-            - containerPort: 8000
-          imagePullPolicy: IfNotPresent
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+          startupProbe:
+            tcpSocket:
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
-            - name: vn-rootvn-vn-flarum
+            - name: vn-data
               mountPath: /data
-      volumes: []
   volumeClaimTemplates:
     - metadata:
+        name: vn-data
         annotations:
           path: /data
           value: '1'
-        name: vn-rootvn-vn-flarum
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
             storage: 1Gi
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 8000
+    - name: tcp-8000
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
-    higress.io/response-header-control-remove: X-Frame-Options
-    higress.io/response-header-control-update: |
-      Content-Security-Policy "default-src * blob: data: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; img-src * data: blob: resource: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://${{ SEALOS_CLOUD_DOMAIN }} https://*.${{ SEALOS_CLOUD_DOMAIN }}"
-      X-Xss-Protection "1; mode=block"
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -286,9 +328,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; img-src * data: blob: resource: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://${{ SEALOS_CLOUD_DOMAIN }} https://*.${{ SEALOS_CLOUD_DOMAIN }}";
-      more_set_headers "X-Xss-Protection: 1; mode=block";
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
         add_header Cache-Control "public";
@@ -309,7 +348,6 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -321,6 +359,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/logo.png"
-  name: "Flarum"
-  type: iframe
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/flarum/logo.png
+  name: Flarum
+  type: link


### PR DESCRIPTION
## Summary

**Flarum template stabilization**
- Updates the Flarum image from `crazymax/flarum:1.8.0` to `crazymax/flarum:1.8.10`.
- Replaces the separate MySQL init Job with a StatefulSet init container that waits for MySQL and creates the `flarum` database with `utf8mb4`.
- Adds `FLARUM_FORUM_TITLE` as a deploy-time input.
- Reduces the Flarum app quota to the smallest deployed-and-tested stable app size: `200m` CPU and `256Mi` memory limit, with `20m` CPU and `25Mi` memory request.
- Keeps the MySQL Kubeblocks default resources at `500m` CPU, `512Mi` memory, and `1Gi` storage to satisfy template rules.
- Switches the Sealos App entry to `type: link` and keeps the public URL behavior intact.

**Documentation**
- Rewrites the English and Chinese Flarum README files using the Sealos template README structure.
- Documents architecture, dependencies, deployment steps, configuration, scaling, troubleshooting, and license details.
- Uses language-specific Sealos App Store domains: `sealos.io` for English and `sealos.run` for Chinese.

## Test Coverage

Template and documentation change. No application code paths were added.

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: Optimize the Flarum Sealos template, deploy-test it, tune the minimum stable resource settings, and write production-quality template README docs.

Delivered: Flarum template resources, bootstrap flow, metadata, English README, and Chinese README now match the tested Sealos deployment.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `check_consistency.py` passed: 38 rules.
- [x] `quality_gate.py` passed: path converter self-test, consistency validator tests, compose converter tests, MUST coverage tests, rule consistency, and MUST coverage.
- [x] Sealos dry-run deploy passed with HTTP 200 from `https://template.usw-1.sealos.io/api/v2alpha/templates/raw`.
- [x] README validation passed: UTF-8 without BOM, required Sealos links, deployment entry, Canvas/AI Ops references, `FLARUM_FORUM_TITLE`, and template URL variables are present.
- [x] Prior live deployment test passed at `https://flarum-ypxcwebt.usw-1.sealos.app` with HTTP 200.
- [x] Minimum resource tuning found `200m/256Mi` stable for the Flarum app; `150m/192Mi` was unstable and `100m/160Mi` failed.

## TODOS

No TODO file exists in this repository, and no TODO items were completed in this PR.

## Documentation

Updated:
- `template/flarum/README.md`
- `template/flarum/README_zh.md`

Documentation now follows the Sealos README format and describes the MySQL-backed Flarum architecture, deploy-time forum title input, default admin credentials warning, scaling path, and troubleshooting steps.

## Test plan

- [x] Validate Sealos template consistency.
- [x] Run docker-to-sealos quality gate.
- [x] Run Sealos template deploy dry-run.
- [x] Validate English and Chinese README structure and required Sealos documentation rules.
- [x] Confirm live Sealos deployment behavior from the deployed test instance.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)
