### PR TITLE
fix(excalidraw): align template resources and docs

### DIFF
--- a/template/excalidraw/README.md
+++ b/template/excalidraw/README.md
@@ -1,28 +1,124 @@
-# Excalidraw
+# Deploy and Host Excalidraw on Sealos
 
-## Overview
+Excalidraw is an open source virtual whiteboard for sketching hand-drawn diagrams, workflows, and visual notes. This template deploys Excalidraw as a lightweight single-service web application on Sealos Cloud.
 
-An open source virtual hand-drawn style whiteboard. Collaborative and end-to-end encrypted.
+![Excalidraw Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/excalidraw/website-screenshot.webp)
 
-This Sealos template deploys **Excalidraw** as the `excalidraw` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Excalidraw
 
-## Deploy on Sealos
+Excalidraw runs as a stateless web service that serves the browser-based drawing interface over HTTP. The application stores drawings primarily in the browser or in user-managed export files, so this template does not provision a database or persistent volume.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The Sealos template creates a Deployment, Service, Ingress, and App entry for Excalidraw. Sealos automatically provides the public HTTPS endpoint, TLS certificate integration, Kubernetes scheduling, and resource management through the Canvas.
 
-## Access
+This deployment is suitable for teams that need a quick shared diagramming surface without managing servers, reverse proxies, or Kubernetes manifests manually.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Architecture Sketching**: Draw system diagrams, deployment flows, and service relationships during planning sessions.
+- **Product and UX Ideation**: Capture wireframes, user flows, and interface ideas in a hand-drawn style.
+- **Meeting Whiteboards**: Use a browser-based canvas for workshops, standups, and remote collaboration.
+- **Documentation Diagrams**: Export diagrams for README files, design docs, and engineering proposals.
+- **Teaching and Explainers**: Build simple visual explanations for technical or non-technical audiences.
+
+## Dependencies for Excalidraw Hosting
+
+The Sealos template includes the Excalidraw web container and the Kubernetes resources needed to expose it publicly. It does not require PostgreSQL, MySQL, Redis, object storage, or persistent volumes.
+
+### Deployment Dependencies
+
+- [Official Website](https://excalidraw.com/) - Hosted Excalidraw editor and product information
+- [Source Repository](https://github.com/excalidraw/excalidraw) - Application source code and release activity
+- [Excalidraw Documentation](https://docs.excalidraw.com/) - Product and developer documentation
+- [GitHub Issues](https://github.com/excalidraw/excalidraw/issues) - Community support and issue tracking
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Excalidraw Web App**: A single container serving the Excalidraw browser application on port 80.
+- **Service**: Routes internal cluster traffic to the Excalidraw container.
+- **Ingress**: Provides the public HTTPS endpoint through the Sealos-managed domain.
+- **App Entry**: Adds a clickable Excalidraw link in the Sealos dashboard.
+
+**Configuration:**
+
+The template uses generated defaults for `app_name` and `app_host`, so each deployment receives a unique application name and public hostname. No extra user inputs are required during deployment.
+
+The workload uses health probes on `/`, disables automatic service account token mounting, and uses minimal resource settings appropriate for a lightweight static web application.
+
+**License Information:**
+
+Excalidraw is licensed under the MIT License. This Sealos template is provided as part of the Sealos templates repository.
+
+## Why Deploy Excalidraw on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle, from deployment to ongoing operations. By deploying Excalidraw on Sealos, you get:
+
+- **One-Click Deployment**: Open the template page, click **Deploy Now**, and let Sealos create the required Kubernetes resources.
+- **Instant Public Access**: Each deployment receives an HTTPS URL with certificate handling built in.
+- **Zero Kubernetes Expertise Required**: Run Excalidraw on Kubernetes without writing or maintaining manifests yourself.
+- **Resource Efficiency**: Use pay-as-you-go cloud resources with lightweight CPU and memory settings.
+- **Easy Customization**: After deployment, use the Canvas, AI dialog, or resource cards to adjust resources and runtime settings.
+- **Built-In Operations View**: Inspect the Deployment, Service, Ingress, and App entry from the Sealos dashboard.
+
+Deploy Excalidraw on Sealos and focus on drawing ideas instead of managing infrastructure.
+
+## Deployment Guide
+
+1. Open the [Excalidraw template](https://sealos.io/products/app-store/excalidraw) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog. The default values are enough for a standard deployment.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **Excalidraw Web UI**: Open the generated HTTPS endpoint and start drawing in your browser.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Excalidraw through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AI Dialog**: Describe changes such as resource adjustments and let AI apply updates.
+- **Resource Cards**: Click the Deployment, Service, or Ingress cards to inspect and modify settings.
+- **Application URL**: Use the generated Sealos HTTPS URL to access the whiteboard.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+Excalidraw itself does not require an admin account or database configuration for the default web editor experience.
 
-## Official Links
+## Scaling
 
-- Official website: https://excalidraw.com/
-- Source repository: https://github.com/excalidraw/excalidraw
+To scale or resize the deployment:
+
+1. Open the Canvas for your Excalidraw deployment.
+2. Click the Deployment resource card.
+3. Adjust CPU, memory, or replica count based on your expected traffic.
+4. Apply the changes in the dialog.
+
+For most small teams and personal workspaces, the default single-replica deployment is sufficient.
+
+## Troubleshooting
+
+### The Excalidraw page does not open after deployment
+
+- Cause: The container or Ingress may still be starting.
+- Solution: Wait until the Deployment is ready in the Canvas, then reopen the application URL.
+
+### Browser data is not shared across users
+
+- Cause: The default Excalidraw web app is primarily browser-based and does not provision a backend database in this template.
+- Solution: Export diagrams as files or use Excalidraw's supported sharing features when needed.
+
+### Getting Help
+
+- [Excalidraw Documentation](https://docs.excalidraw.com/)
+- [Excalidraw GitHub Issues](https://github.com/excalidraw/excalidraw/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Excalidraw Official Website](https://excalidraw.com/)
+- [Excalidraw Source Repository](https://github.com/excalidraw/excalidraw)
+- [Excalidraw Blog](https://plus.excalidraw.com/blog)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is provided as part of the Sealos templates repository. Excalidraw itself is licensed under the [MIT License](https://github.com/excalidraw/excalidraw/blob/master/LICENSE).

--- a/template/excalidraw/README_zh.md
+++ b/template/excalidraw/README_zh.md
@@ -1,28 +1,124 @@
-# Excalidraw
+# 在 Sealos 上部署和托管 Excalidraw
 
-## 应用概览
+Excalidraw 是一个开源虚拟白板，用于绘制手绘风格的图表、流程和视觉笔记。此模板会在 Sealos Cloud 上将 Excalidraw 部署为轻量级单服务 Web 应用。
 
-Excalidraw 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+![Excalidraw 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/excalidraw/website-screenshot.webp)
 
-此 Sealos 模板会将 **Excalidraw** 部署为 `excalidraw` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于托管 Excalidraw
 
-## 在 Sealos 上部署
+Excalidraw 以无状态 Web 服务运行，通过 HTTP 提供基于浏览器的绘图界面。应用主要将绘图内容保存在浏览器中，或由用户自行导出文件，因此此模板不会创建数据库或持久化存储卷。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+Sealos 模板会为 Excalidraw 创建 Deployment、Service、Ingress 和 App 入口。Sealos 会自动提供公网 HTTPS 访问入口、TLS 证书集成、Kubernetes 调度能力，以及 Canvas 中的资源管理能力。
 
-## 访问方式
+此部署适合需要快速搭建共享图表白板的团队，无需手动管理服务器、反向代理或 Kubernetes 清单。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
 
-## 配置说明
+- **架构草图**：在规划阶段绘制系统图、部署流程和服务关系。
+- **产品与 UX 构思**：用手绘风格记录线框图、用户流程和界面想法。
+- **会议白板**：为工作坊、站会和远程协作提供浏览器白板。
+- **文档图表**：导出图表用于 README、设计文档和工程方案。
+- **教学与讲解**：为技术或非技术受众制作简单直观的视觉说明。
 
-部署时可以配置以下用户可见输入项：
+## Excalidraw 托管依赖
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+Sealos 模板包含 Excalidraw Web 容器，以及公开访问所需的 Kubernetes 资源。它不依赖 PostgreSQL、MySQL、Redis、对象存储或持久化存储卷。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖
 
-## 官方链接
+- [官方网站](https://excalidraw.com/) - Excalidraw 在线编辑器和产品信息
+- [源码仓库](https://github.com/excalidraw/excalidraw) - 应用源码和版本动态
+- [Excalidraw 文档](https://docs.excalidraw.com/) - 产品和开发者文档
+- [GitHub Issues](https://github.com/excalidraw/excalidraw/issues) - 社区支持和问题反馈
 
-- 官方网站: https://excalidraw.com/
-- 源码仓库: https://github.com/excalidraw/excalidraw
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Excalidraw Web 应用**：单容器服务，在 80 端口提供 Excalidraw 浏览器应用。
+- **Service**：将集群内部流量转发到 Excalidraw 容器。
+- **Ingress**：通过 Sealos 管理的域名提供公网 HTTPS 访问入口。
+- **App 入口**：在 Sealos 控制台中添加可点击的 Excalidraw 链接。
+
+**配置：**
+
+模板使用生成的默认值设置 `app_name` 和 `app_host`，因此每次部署都会获得唯一的应用名称和公网主机名。部署时不需要额外填写用户输入项。
+
+工作负载在 `/` 上配置健康检查，禁用自动挂载 Service Account Token，并使用适合轻量级静态 Web 应用的最小资源配置。
+
+**许可证信息：**
+
+Excalidraw 使用 MIT License。此 Sealos 模板作为 Sealos templates 仓库的一部分提供。
+
+## 为什么在 Sealos 上部署 Excalidraw？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一应用从部署到持续运维的生命周期。在 Sealos 上部署 Excalidraw，你可以获得：
+
+- **一键部署**：打开模板页面，点击 **Deploy Now**，Sealos 会创建所需的 Kubernetes 资源。
+- **即时公网访问**：每次部署都会获得自动配置证书的 HTTPS 访问地址。
+- **无需 Kubernetes 经验**：无需自己编写或维护清单，也能在 Kubernetes 上运行 Excalidraw。
+- **资源高效**：使用按量计费的云资源，并采用轻量级 CPU 和内存配置。
+- **便捷自定义**：部署后可通过 Canvas、AI 对话框或资源卡片调整资源和运行时设置。
+- **内置运维视图**：可在 Sealos 控制台中查看 Deployment、Service、Ingress 和 App 入口。
+
+在 Sealos 上部署 Excalidraw，把精力放在表达想法上，而不是管理基础设施。
+
+## 部署指南
+
+1. 打开 [Excalidraw 模板](https://sealos.run/products/app-store/excalidraw)，点击 **Deploy Now**。
+2. 在弹出的对话框中配置参数。标准部署保留默认值即可。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后，你会被重定向到 Canvas。后续如需修改，可在对话框中描述需求让 AI 应用变更，或点击相关资源卡片修改设置。
+4. 通过提供的访问地址打开应用：
+   - **Excalidraw Web UI**：打开生成的 HTTPS 访问入口，即可在浏览器中开始绘图。
+
+## 配置
+
+部署完成后，你可以通过以下方式配置 Excalidraw：
+
+- **AI 对话框**：描述资源调整等变更需求，让 AI 应用更新。
+- **资源卡片**：点击 Deployment、Service 或 Ingress 资源卡片，查看和修改设置。
+- **应用访问地址**：使用 Sealos 生成的 HTTPS 地址访问白板。
+
+默认 Web 编辑器体验不需要管理员账号或数据库配置。
+
+## 扩缩容
+
+如需扩缩容或调整资源：
+
+1. 打开 Excalidraw 部署对应的 Canvas。
+2. 点击 Deployment 资源卡片。
+3. 根据预期流量调整 CPU、内存或副本数。
+4. 在对话框中应用变更。
+
+对于大多数小团队和个人工作区，默认单副本部署已经足够。
+
+## 故障排查
+
+### 部署后 Excalidraw 页面无法打开
+
+- 原因：容器或 Ingress 可能仍在启动。
+- 解决方案：等待 Canvas 中的 Deployment 就绪后，再重新打开应用访问地址。
+
+### 浏览器数据没有在用户之间共享
+
+- 原因：默认 Excalidraw Web 应用主要基于浏览器运行，此模板不会创建后端数据库。
+- 解决方案：按需将图表导出为文件，或使用 Excalidraw 支持的共享能力。
+
+### 获取帮助
+
+- [Excalidraw 文档](https://docs.excalidraw.com/)
+- [Excalidraw GitHub Issues](https://github.com/excalidraw/excalidraw/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [Excalidraw 官方网站](https://excalidraw.com/)
+- [Excalidraw 源码仓库](https://github.com/excalidraw/excalidraw)
+- [Excalidraw 博客](https://plus.excalidraw.com/blog)
+- [Sealos 文档](https://sealos.run/docs)
+
+## 许可证
+
+此 Sealos 模板作为 Sealos templates 仓库的一部分提供。Excalidraw 本身使用 [MIT License](https://github.com/excalidraw/excalidraw/blob/master/LICENSE)。

--- a/template/excalidraw/index.yaml
+++ b/template/excalidraw/index.yaml
@@ -13,19 +13,19 @@ spec:
   screenshots:
     - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/excalidraw/website-screenshot.webp'
   templateType: inline
+  locale: en
   categories:
     - tool
   defaults:
     app_host:
-      # number or string..
       type: string
       value: excalidraw-${{ random(8) }}
     app_name:
       type: string
       value: excalidraw-${{ random(8) }}
-
   i18n:
     zh:
+      description: '开源的手绘风格虚拟白板，支持协作和端到端加密。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/excalidraw/README_zh.md'
 ---
 apiVersion: apps/v1
@@ -56,21 +56,50 @@ spec:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}
           image: excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f
           resources:
             requests:
               cpu: 10m
-              memory: 6Mi
+              memory: 12Mi
             limits:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
           ports:
-            - containerPort: 80
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           imagePullPolicy: IfNotPresent
-          volumeMounts: []
-      volumes: []
 
 
 ---
@@ -79,10 +108,14 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
 
@@ -93,13 +126,10 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
-    higress.io/response-header-control-remove: X-Frame-Options
-    higress.io/response-header-control-update: |
-      Content-Security-Policy "default-src * blob: data: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; img-src * data: blob: resource: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://${{ SEALOS_CLOUD_DOMAIN }} https://*.${{ SEALOS_CLOUD_DOMAIN }}"
-      X-Xss-Protection "1; mode=block"
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -107,15 +137,11 @@ metadata:
       large_client_header_buffers 4 128k;
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; img-src * data: blob: resource: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://${{ SEALOS_CLOUD_DOMAIN }} https://*.${{ SEALOS_CLOUD_DOMAIN }}";
-      more_set_headers "X-Xss-Protection: 1; mode=block";
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
         add_header Cache-Control "public";
@@ -126,7 +152,7 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /()(.*)
+            path: /
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -150,4 +176,4 @@ spec:
   displayType: normal
   icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/excalidraw/logo.svg"
   name: Excalidraw
-  type: iframe
+  type: link


### PR DESCRIPTION
## Summary

This PR updates the Excalidraw Sealos template and documentation.

- Aligns the template with current docker-to-sealos requirements: locale metadata, Chinese description, app-scoped imagePullSecret, named service port, standard Ingress shape, App `type: link`, and workload health probes.
- Tunes Excalidraw resource settings to the minimum valid Sealos resource ladder after live deployment probing.
- Rewrites the English and Chinese README files with deployment guidance, architecture notes, use cases, troubleshooting, and language-specific Sealos domains.

## Test Coverage

No application code paths changed. This PR changes a Sealos template and documentation.

## Pre-Landing Review

Template validation and README checks passed locally.

## Design Review

No frontend source files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Plan Completion

No plan file detected.

## Verification Results

- [x] docker-to-sealos `path_converter.py --self-test`
- [x] docker-to-sealos `test_check_consistency.py`
- [x] docker-to-sealos `test_compose_to_template.py`
- [x] docker-to-sealos `test_check_must_coverage.py`
- [x] docker-to-sealos `check_consistency.py --artifacts template/excalidraw/index.yaml`
- [x] docker-to-sealos `quality_gate.py` with `DOCKER_TO_SEALOS_ARTIFACTS=template/excalidraw/index.yaml`
- [x] README structure/domain checks
- [x] Live deployment test: `https://excalidraw-ncsrezdm.usw-1.sealos.app` returned HTTP 200 during resource tuning

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] Template consistency checks pass
- [x] docker-to-sealos quality gate passes
- [x] Bilingual README checks pass
- [x] Live Excalidraw deployment remains ready with tuned resources

🤖 Generated with [OpenAI Codex](https://openai.com/codex)
