### PR TITLE
fix(happy-server): stabilize Sealos template

### DIFF
--- a/template/happy-server/README.md
+++ b/template/happy-server/README.md
@@ -1,31 +1,112 @@
-# Happy Server
+# Deploy and Host Happy Server on Sealos
 
-## Overview
+![Happy Server screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/website-screenshot.webp)
 
-Minimal backend for open-source end-to-end encrypted Claude Code clients.
+## About Happy Server
 
-This Sealos template deploys **Happy Server** as the `happy-server` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Happy Server is the self-hosted synchronization backend for open-source, end-to-end encrypted Happy clients for Claude Code. Clients encrypt conversation and session data before it leaves the device; the server stores and relays encrypted payloads, coordinates authentication, and keeps devices in sync through HTTP APIs and WebSocket connections.
 
-## Deploy on Sealos
+This Sealos template deploys Happy Server with managed PostgreSQL, Redis, S3-compatible Object Storage, HTTPS ingress, and an App Launcher shortcut.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Use Cases
 
-## Access
+- Self-host the Happy sync API for teams that want infrastructure control.
+- Keep encrypted Claude Code client data on your own Sealos workspace.
+- Provide real-time multi-device sync through Redis-backed WebSocket sessions.
+- Store encrypted attachments or artifacts in S3-compatible Object Storage.
+- Run a reproducible backend stack without maintaining Kubernetes manifests by hand.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies
+
+The template creates these resources:
+
+- **Happy Server**: Node.js/Fastify application container pinned to a GHCR image digest.
+- **PostgreSQL 16.4**: Persistent relational database for accounts, sessions, feed events, keys, and metadata.
+- **Redis 7.2**: Cache and pub/sub backend for real-time coordination.
+- **ObjectStorageBucket**: Public-read S3-compatible bucket used for file and artifact URLs.
+- **Ingress + Service + App**: Public HTTPS endpoint and Sealos App Launcher entry.
+
+## Implementation Details
+
+- Runtime image: `ghcr.io/yangchuansheng/happy-server` pinned by digest.
+- Application port: `3005`.
+- Health check: `/health`, which validates database connectivity.
+- Database bootstrap: an idempotent PostgreSQL init Job creates the `happy-server` database and required tables before the application becomes ready.
+- Secret handling: database credentials, Redis credentials, and object storage credentials are read from Sealos-managed secrets.
+- Resource baseline: the app container uses `200m` CPU and `256Mi` memory after deployment testing; `128Mi` was rejected because the Node.js process was OOM-killed during startup.
+
+## Why Deploy on Sealos
+
+Sealos gives this template managed runtime primitives that fit Happy Server well:
+
+- One-click deployment from the App Store.
+- Managed PostgreSQL, Redis, object storage, HTTPS ingress, and persistent volumes.
+- Automatic domain, TLS, logs, and resource controls from the Sealos dashboard.
+- A Kubernetes-native manifest that remains portable and auditable.
+
+## Deployment Guide
+
+### Step 1: Open the template
+
+Open [Happy Server on the Sealos App Store](https://sealos.io/products/app-store/happy-server), then click **Deploy Now**.
+
+### Step 2: Review generated values
+
+The template generates:
+
+- `app_name`: Kubernetes resource name prefix.
+- `app_host`: public hostname prefix.
+- `seed`: random server-side secret used by Happy Server.
+
+The generated values are safe defaults for a fresh deployment. Change `app_name` or `app_host` only if you need a stable name.
+
+### Step 3: Deploy
+
+Click **Deploy**. Sealos creates the object storage bucket, PostgreSQL cluster, Redis cluster, database initialization Job, application Deployment, Service, Ingress, and App Launcher entry.
+
+### Step 4: Verify the service
+
+After deployment completes, open the generated Sealos App URL. You can also verify the health endpoint:
+
+```bash
+curl https://<your-happy-server-domain>/health
+```
+
+A healthy response looks like:
+
+```json
+{"status":"ok","service":"happy-server"}
+```
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+| Item | Source | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | Sealos PostgreSQL secret | Connects Happy Server to the `happy-server` database. |
+| `REDIS_URL` | Sealos Redis secret and service DNS | Enables Redis-backed real-time coordination. |
+| `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET`, `S3_HOST` | Sealos Object Storage secrets | Enables artifact and file storage. |
+| `PUBLIC_URL` | Generated Sealos HTTPS domain | Public base URL for the service. |
+| `HANDY_MASTER_SECRET` | Generated template seed | Server-side secret material. |
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `node_env` | Node environment | `true` | `production` |
-| `seed` | Seed for token generation | `true` | `${{ random(32) }}` |
+## Scaling
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+The default template runs one Happy Server replica. Increase replicas only after confirming the Redis-backed real-time workflow and your client traffic pattern. PostgreSQL and Redis are deployed with persistent storage and Sealos-managed service endpoints.
 
-## Official Links
+## Troubleshooting
 
-- Official website: https://github.com/slopus/happy/tree/main/packages/happy-server
-- Source repository: https://github.com/slopus/happy/tree/main/packages/happy-server
+- **Health check returns 503**: PostgreSQL is not ready or the init Job has not completed. Wait for the PostgreSQL cluster and `*-pg-init` Job to finish.
+- **Application restarts during startup**: confirm Redis service DNS resolves and object storage secrets exist. The expected Redis service is `*-redis-redis-redis`.
+- **OOMKilled at startup**: keep the app limit at `256Mi` or higher. A `128Mi` test limit was insufficient for the current Node.js image.
+- **File URLs fail**: confirm the ObjectStorageBucket exists and uses `publicRead`, because Happy Server returns public object URLs.
+- **Image pull warning**: the image is public and pinned by digest. If your workspace requires registry credentials, create the generated image pull secret through Sealos.
+
+## Resources
+
+- Happy project: [https://github.com/slopus/happy](https://github.com/slopus/happy)
+- Happy Server package: [https://github.com/slopus/happy/tree/main/packages/happy-server](https://github.com/slopus/happy/tree/main/packages/happy-server)
+- Sealos: [https://sealos.io](https://sealos.io)
+- Template source: [https://github.com/labring-actions/templates/tree/kb-0.9/template/happy-server](https://github.com/labring-actions/templates/tree/kb-0.9/template/happy-server)
+
+## License
+
+Happy Server is released under the MIT License. This Sealos template follows the license of the template repository.

--- a/template/happy-server/README_zh.md
+++ b/template/happy-server/README_zh.md
@@ -1,31 +1,112 @@
-# Happy Server
+# 在 Sealos 上部署并托管 Happy Server
 
-## 应用概览
+![Happy Server 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/website-screenshot.webp)
 
-专为 Claude Code 开源、端到端加密客户端打造的极简后端。
+## 关于 Happy Server
 
-此 Sealos 模板会将 **Happy Server** 部署为 `happy-server` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Happy Server 是面向 Claude Code 开源 Happy 客户端的自托管同步后端。客户端会在本地完成端到端加密，服务端只存储和转发加密后的数据，并负责认证、会话同步、HTTP API 与 WebSocket 实时连接。
 
-## 在 Sealos 上部署
+此 Sealos 模板会部署一套完整的 Happy Server 后端，包括托管 PostgreSQL、Redis、S3 兼容对象存储、HTTPS Ingress 和应用启动入口。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 使用场景
 
-## 访问方式
+- 为需要基础设施控制权的团队自托管 Happy 同步 API。
+- 将加密后的 Claude Code 客户端数据保存在自己的 Sealos 工作区。
+- 通过 Redis 支撑 WebSocket 实时多设备同步。
+- 使用 S3 兼容对象存储保存加密附件或产物。
+- 无需手动维护 Kubernetes 清单，即可部署可复现的后端栈。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 依赖组件
+
+模板会创建以下资源：
+
+- **Happy Server**：固定到 GHCR 镜像 digest 的 Node.js/Fastify 应用容器。
+- **PostgreSQL 16.4**：持久化关系数据库，用于账号、会话、动态流、密钥和元数据。
+- **Redis 7.2**：用于实时协同的缓存和发布订阅后端。
+- **ObjectStorageBucket**：publicRead 的 S3 兼容对象存储桶，用于文件和产物 URL。
+- **Ingress + Service + App**：公网 HTTPS 入口与 Sealos 应用启动项。
+
+## 实现细节
+
+- 运行镜像：`ghcr.io/yangchuansheng/happy-server`，按 digest 固定版本。
+- 应用端口：`3005`。
+- 健康检查：`/health`，会校验数据库连接。
+- 数据库初始化：幂等 PostgreSQL init Job 会创建 `happy-server` 数据库和所需表结构，然后应用才进入可用状态。
+- 密钥管理：数据库、Redis 和对象存储凭据均来自 Sealos 托管 Secret。
+- 资源基线：部署测试后应用容器使用 `200m` CPU 和 `256Mi` 内存；`128Mi` 在启动阶段会触发 OOMKilled，因此不作为最小可用配置。
+
+## 为什么在 Sealos 上部署
+
+Sealos 为 Happy Server 提供了适合自托管后端的托管能力：
+
+- 可从应用商店一键部署。
+- 托管 PostgreSQL、Redis、对象存储、HTTPS Ingress 和持久化存储。
+- 通过 Sealos 控制台管理域名、TLS、日志和资源配额。
+- 使用 Kubernetes 原生清单，便于审计和迁移。
+
+## 部署指南
+
+### 步骤 1：打开模板
+
+打开 [Sealos 应用商店中的 Happy Server 模板](https://sealos.io/products/app-store/happy-server)，然后点击 **Deploy Now**。
+
+### 步骤 2：检查生成值
+
+模板会生成：
+
+- `app_name`：Kubernetes 资源名称前缀。
+- `app_host`：公网访问域名前缀。
+- `seed`：Happy Server 使用的随机服务端密钥。
+
+默认生成值适合全新部署。只有在需要固定资源名或域名前缀时，才需要修改 `app_name` 或 `app_host`。
+
+### 步骤 3：部署
+
+点击 **Deploy**。Sealos 会创建对象存储桶、PostgreSQL 集群、Redis 集群、数据库初始化 Job、应用 Deployment、Service、Ingress 和 App 启动项。
+
+### 步骤 4：验证服务
+
+部署完成后，打开 Sealos 生成的应用 URL。也可以访问健康检查接口：
+
+```bash
+curl https://<你的-happy-server-域名>/health
+```
+
+健康响应示例：
+
+```json
+{"status":"ok","service":"happy-server"}
+```
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+| 配置项 | 来源 | 用途 |
+| --- | --- | --- |
+| `DATABASE_URL` | Sealos PostgreSQL Secret | 连接 `happy-server` 数据库。 |
+| `REDIS_URL` | Sealos Redis Secret 和服务 DNS | 支撑 Redis 实时协同能力。 |
+| `S3_ACCESS_KEY`、`S3_SECRET_KEY`、`S3_BUCKET`、`S3_HOST` | Sealos Object Storage Secret | 启用文件和产物存储。 |
+| `PUBLIC_URL` | Sealos 生成的 HTTPS 域名 | 服务公网基础 URL。 |
+| `HANDY_MASTER_SECRET` | 模板生成的 `seed` | 服务端密钥材料。 |
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `node_env` | `node_env` 部署参数。 | `是` | `production` |
-| `seed` | `seed` 部署参数。 | `是` | `${{ random(32) }}` |
+## 扩缩容
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+默认模板运行 1 个 Happy Server 副本。只有在确认 Redis 实时同步链路和客户端流量模式后，才建议增加副本数。PostgreSQL 和 Redis 使用持久化存储，并由 Sealos 提供托管服务端点。
 
-## 官方链接
+## 故障排查
 
-- 官方网站: https://github.com/slopus/happy/tree/main/packages/happy-server
-- 源码仓库: https://github.com/slopus/happy/tree/main/packages/happy-server
+- **健康检查返回 503**：PostgreSQL 尚未就绪，或初始化 Job 尚未完成。等待 PostgreSQL 集群和 `*-pg-init` Job 完成。
+- **应用启动后反复重启**：检查 Redis 服务 DNS 是否可解析，以及对象存储 Secret 是否已创建。Redis 服务名应为 `*-redis-redis-redis`。
+- **启动阶段 OOMKilled**：保持应用内存限制不低于 `256Mi`。当前 Node.js 镜像在 `128Mi` 下无法稳定启动。
+- **文件 URL 无法访问**：确认 ObjectStorageBucket 已创建且策略为 `publicRead`，因为 Happy Server 会返回公开对象 URL。
+- **镜像拉取告警**：模板使用公开且按 digest 固定的镜像。如果工作区要求 registry 凭据，请通过 Sealos 创建生成的镜像拉取 Secret。
+
+## 相关资源
+
+- Happy 项目：[https://github.com/slopus/happy](https://github.com/slopus/happy)
+- Happy Server 包：[https://github.com/slopus/happy/tree/main/packages/happy-server](https://github.com/slopus/happy/tree/main/packages/happy-server)
+- Sealos：[https://sealos.io](https://sealos.io)
+- 模板源码：[https://github.com/labring-actions/templates/tree/kb-0.9/template/happy-server](https://github.com/labring-actions/templates/tree/kb-0.9/template/happy-server)
+
+## 许可证
+
+Happy Server 使用 MIT License 发布。此 Sealos 模板遵循模板仓库的许可证。

--- a/template/happy-server/index.yaml
+++ b/template/happy-server/index.yaml
@@ -1,842 +1,915 @@
 apiVersion: app.sealos.io/v1
 kind: Template
 metadata:
-  name: happy-server
+    name: happy-server
 spec:
-  title: 'Happy Server'
-  url: 'https://happy.engineering'
-  gitRepo: 'https://github.com/slopus/happy/tree/main/packages/happy-server'
-  author: 'Sealos'
-  description: 'Minimal backend for open-source end-to-end encrypted Claude Code clients.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/logo.png'
-  screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/website-screenshot.webp'
-  templateType: inline
-  locale: en
-  categories:
-    - ai
-  i18n:
-    zh:
-      description: '专为 Claude Code 开源、端到端加密客户端打造的极简后端。'
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/README_zh.md'
-  defaults:
-    app_name:
-      type: string
-      value: happy-server-${{ random(8) }}
-    app_host:
-      type: string
-      value: happy-server-${{ random(8) }}
-  inputs:
-    seed:
-      description: 'Seed for token generation'
-      type: string
-      default: ${{ random(32) }}
-      required: true
-    node_env:
-      description: 'Node environment'
-      type: choice
-      default: 'production'
-      options:
-        - production
-        - development
-      required: true
+    title: Happy Server
+    url: https://happy.engineering
+    gitRepo: https://github.com/slopus/happy/tree/main/packages/happy-server
+    author: Sealos
+    description: Self-hosted synchronization backend for end-to-end encrypted Happy clients for Claude Code.
+    readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/README.md
+    icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/logo.png
+    screenshots:
+        - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/website-screenshot.webp
+    templateType: inline
+    locale: en
+    categories:
+        - ai
+    i18n:
+        zh:
+            description: 面向 Happy Claude Code 客户端的自托管同步后端，支持端到端加密数据同步。
+            readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/README_zh.md
+    defaults:
+        app_name:
+            type: string
+            value: happy-server-${{ random(8) }}
+        app_host:
+            type: string
+            value: happy-server-${{ random(8) }}
+        seed:
+            type: string
+            value: ${{ random(32) }}
 ---
 apiVersion: objectstorage.sealos.io/v1
 kind: ObjectStorageBucket
 metadata:
-  name: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
 spec:
-  policy: private
-
+    policy: publicRead
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
+    name: ${{ defaults.app_name }}-pg
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
+    name: ${{ defaults.app_name }}-pg
 rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
+    - apiGroups:
+          - "*"
+      resources:
+          - "*"
+      verbs:
+          - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-pg
-subjects:
-  - kind: ServiceAccount
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
     name: ${{ defaults.app_name }}-pg
-
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: ${{ defaults.app_name }}-pg
+subjects:
+    - kind: ServiceAccount
+      name: ${{ defaults.app_name }}-pg
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  name: ${{ defaults.app_name }}-pg
+    finalizers:
+        - cluster.kubeblocks.io/finalizer
+    labels:
+        clusterdefinition.kubeblocks.io/name: postgresql
+        clusterversion.kubeblocks.io/name: postgresql-16.4.0
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        kb.io/database: postgresql-16.4.0
+    name: ${{ defaults.app_name }}-pg
 spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
+    affinity:
+        podAntiAffinity: Preferred
+        tenancy: SharedNode
+    clusterDefinitionRef: postgresql
+    clusterVersionRef: postgresql-16.4.0
+    componentSpecs:
+        - componentDefRef: postgresql
+          name: postgresql
+          replicas: 1
+          resources:
+              limits:
+                  cpu: 500m
+                  memory: 512Mi
               requests:
-                storage: 1Gi
-  terminationPolicy: Delete
-  tolerations: []
-
+                  cpu: 50m
+                  memory: 51Mi
+          serviceAccountName: ${{ defaults.app_name }}-pg
+          switchPolicy:
+              type: Noop
+          volumeClaimTemplates:
+              - name: data
+                spec:
+                    accessModes:
+                        - ReadWriteOnce
+                    resources:
+                        requests:
+                            storage: 1Gi
+                    storageClassName: openebs-backup
+          disableExporter: true
+          enabledLogs:
+              - running
+    terminationPolicy: Delete
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ${{ defaults.app_name }}-pg-init
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-init
+    name: ${{ defaults.app_name }}-pg-init
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-init
+        app: ${{ defaults.app_name }}-pg-init
 data:
-  vn-initvn-sql: |
-    CREATE OR REPLACE FUNCTION update_updated_at_column()
-    RETURNS TRIGGER AS $$
-    BEGIN
-       NEW."updatedAt" = now();
-       RETURN NEW;
-    END;
-    $$ language 'plpgsql';
+    vn-initvn-sql: |
+        CREATE OR REPLACE FUNCTION update_updated_at_column()
+        RETURNS TRIGGER AS $$
+        BEGIN
+           NEW."updatedAt" = now();
+           RETURN NEW;
+        END;
+        $$ language 'plpgsql';
 
-    CREATE TYPE "RelationshipStatus" AS ENUM ('none', 'requested', 'pending', 'friend', 'rejected');
+        DO $$
+        BEGIN
+          CREATE TYPE "RelationshipStatus" AS ENUM ('none', 'requested', 'pending', 'friend', 'rejected');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
 
-    CREATE TABLE IF NOT EXISTS "GithubUser" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "profile" JSONB NOT NULL,
-        "token" BYTEA,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
-    DROP TRIGGER IF EXISTS update_githubuser_updated_at ON "GithubUser";
-    CREATE TRIGGER update_githubuser_updated_at
-    BEFORE UPDATE ON "GithubUser"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "GithubUser" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "profile" JSONB NOT NULL,
+            "token" BYTEA,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        DROP TRIGGER IF EXISTS update_githubuser_updated_at ON "GithubUser";
+        CREATE TRIGGER update_githubuser_updated_at
+        BEFORE UPDATE ON "GithubUser"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "GithubOrganization" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "profile" JSONB NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
-    DROP TRIGGER IF EXISTS update_githuborganization_updated_at ON "GithubOrganization";
-    CREATE TRIGGER update_githuborganization_updated_at
-    BEFORE UPDATE ON "GithubOrganization"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "GithubOrganization" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "profile" JSONB NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        DROP TRIGGER IF EXISTS update_githuborganization_updated_at ON "GithubOrganization";
+        CREATE TRIGGER update_githuborganization_updated_at
+        BEFORE UPDATE ON "GithubOrganization"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "Account" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "publicKey" TEXT NOT NULL UNIQUE,
-        "seq" INTEGER NOT NULL DEFAULT 0,
-        "feedSeq" BIGINT NOT NULL DEFAULT 0,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "settings" TEXT,
-        "settingsVersion" INTEGER NOT NULL DEFAULT 0,
-        "githubUserId" TEXT UNIQUE,
-        "firstName" TEXT,
-        "lastName" TEXT,
-        "username" TEXT UNIQUE,
-        "avatar" JSONB,
-        CONSTRAINT "Account_githubUserId_fkey" FOREIGN KEY ("githubUserId") REFERENCES "GithubUser"("id") ON DELETE SET NULL ON UPDATE CASCADE
-    );
-    DROP TRIGGER IF EXISTS update_account_updated_at ON "Account";
-    CREATE TRIGGER update_account_updated_at
-    BEFORE UPDATE ON "Account"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "Account" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "publicKey" TEXT NOT NULL UNIQUE,
+            "seq" INTEGER NOT NULL DEFAULT 0,
+            "feedSeq" BIGINT NOT NULL DEFAULT 0,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "settings" TEXT,
+            "settingsVersion" INTEGER NOT NULL DEFAULT 0,
+            "githubUserId" TEXT UNIQUE,
+            "firstName" TEXT,
+            "lastName" TEXT,
+            "username" TEXT UNIQUE,
+            "avatar" JSONB,
+            CONSTRAINT "Account_githubUserId_fkey" FOREIGN KEY ("githubUserId") REFERENCES "GithubUser"("id") ON DELETE SET NULL ON UPDATE CASCADE
+        );
+        DROP TRIGGER IF EXISTS update_account_updated_at ON "Account";
+        CREATE TRIGGER update_account_updated_at
+        BEFORE UPDATE ON "Account"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "TerminalAuthRequest" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "publicKey" TEXT NOT NULL UNIQUE,
-        "supportsV2" BOOLEAN NOT NULL DEFAULT false,
-        "response" TEXT,
-        "responseAccountId" TEXT,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "TerminalAuthRequest_responseAccountId_fkey" FOREIGN KEY ("responseAccountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE
-    );
-    DROP TRIGGER IF EXISTS update_terminalauthrequest_updated_at ON "TerminalAuthRequest";
-    CREATE TRIGGER update_terminalauthrequest_updated_at
-    BEFORE UPDATE ON "TerminalAuthRequest"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "TerminalAuthRequest" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "publicKey" TEXT NOT NULL UNIQUE,
+            "supportsV2" BOOLEAN NOT NULL DEFAULT false,
+            "response" TEXT,
+            "responseAccountId" TEXT,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "TerminalAuthRequest_responseAccountId_fkey" FOREIGN KEY ("responseAccountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE
+        );
+        DROP TRIGGER IF EXISTS update_terminalauthrequest_updated_at ON "TerminalAuthRequest";
+        CREATE TRIGGER update_terminalauthrequest_updated_at
+        BEFORE UPDATE ON "TerminalAuthRequest"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "AccountAuthRequest" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "publicKey" TEXT NOT NULL UNIQUE,
-        "response" TEXT,
-        "responseAccountId" TEXT,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "AccountAuthRequest_responseAccountId_fkey" FOREIGN KEY ("responseAccountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE
-    );
-    DROP TRIGGER IF EXISTS update_accountauthrequest_updated_at ON "AccountAuthRequest";
-    CREATE TRIGGER update_accountauthrequest_updated_at
-    BEFORE UPDATE ON "AccountAuthRequest"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "AccountAuthRequest" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "publicKey" TEXT NOT NULL UNIQUE,
+            "response" TEXT,
+            "responseAccountId" TEXT,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "AccountAuthRequest_responseAccountId_fkey" FOREIGN KEY ("responseAccountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE
+        );
+        DROP TRIGGER IF EXISTS update_accountauthrequest_updated_at ON "AccountAuthRequest";
+        CREATE TRIGGER update_accountauthrequest_updated_at
+        BEFORE UPDATE ON "AccountAuthRequest"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "AccountPushToken" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "token" TEXT NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "AccountPushToken_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("accountId", "token")
-    );
-    DROP TRIGGER IF EXISTS update_accountpushtoken_updated_at ON "AccountPushToken";
-    CREATE TRIGGER update_accountpushtoken_updated_at
-    BEFORE UPDATE ON "AccountPushToken"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "AccountPushToken" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "token" TEXT NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "AccountPushToken_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("accountId", "token")
+        );
+        DROP TRIGGER IF EXISTS update_accountpushtoken_updated_at ON "AccountPushToken";
+        CREATE TRIGGER update_accountpushtoken_updated_at
+        BEFORE UPDATE ON "AccountPushToken"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "Session" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "tag" TEXT NOT NULL,
-        "accountId" TEXT NOT NULL,
-        "metadata" TEXT NOT NULL,
-        "metadataVersion" INTEGER NOT NULL DEFAULT 0,
-        "agentState" TEXT,
-        "agentStateVersion" INTEGER NOT NULL DEFAULT 0,
-        "dataEncryptionKey" BYTEA,
-        "seq" INTEGER NOT NULL DEFAULT 0,
-        "active" BOOLEAN NOT NULL DEFAULT true,
-        "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "Session_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("accountId", "tag")
-    );
-    DROP TRIGGER IF EXISTS update_session_updated_at ON "Session";
-    CREATE TRIGGER update_session_updated_at
-    BEFORE UPDATE ON "Session"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "Session" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "tag" TEXT NOT NULL,
+            "accountId" TEXT NOT NULL,
+            "metadata" TEXT NOT NULL,
+            "metadataVersion" INTEGER NOT NULL DEFAULT 0,
+            "agentState" TEXT,
+            "agentStateVersion" INTEGER NOT NULL DEFAULT 0,
+            "dataEncryptionKey" BYTEA,
+            "seq" INTEGER NOT NULL DEFAULT 0,
+            "active" BOOLEAN NOT NULL DEFAULT true,
+            "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "Session_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("accountId", "tag")
+        );
+        DROP TRIGGER IF EXISTS update_session_updated_at ON "Session";
+        CREATE TRIGGER update_session_updated_at
+        BEFORE UPDATE ON "Session"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "SessionMessage" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "sessionId" TEXT NOT NULL,
-        "localId" TEXT,
-        "seq" INTEGER NOT NULL,
-        "content" JSONB NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "SessionMessage_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("sessionId", "localId")
-    );
-    DROP TRIGGER IF EXISTS update_sessionmessage_updated_at ON "SessionMessage";
-    CREATE TRIGGER update_sessionmessage_updated_at
-    BEFORE UPDATE ON "SessionMessage"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "SessionMessage" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "sessionId" TEXT NOT NULL,
+            "localId" TEXT,
+            "seq" INTEGER NOT NULL,
+            "content" JSONB NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "SessionMessage_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("sessionId", "localId")
+        );
+        DROP TRIGGER IF EXISTS update_sessionmessage_updated_at ON "SessionMessage";
+        CREATE TRIGGER update_sessionmessage_updated_at
+        BEFORE UPDATE ON "SessionMessage"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "GlobalLock" (
-        "key" TEXT NOT NULL PRIMARY KEY,
-        "value" TEXT NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "expiresAt" TIMESTAMP(3) NOT NULL
-    );
-    DROP TRIGGER IF EXISTS update_globallock_updated_at ON "GlobalLock";
-    CREATE TRIGGER update_globallock_updated_at
-    BEFORE UPDATE ON "GlobalLock"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "GlobalLock" (
+            "key" TEXT NOT NULL PRIMARY KEY,
+            "value" TEXT NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "expiresAt" TIMESTAMP(3) NOT NULL
+        );
+        DROP TRIGGER IF EXISTS update_globallock_updated_at ON "GlobalLock";
+        CREATE TRIGGER update_globallock_updated_at
+        BEFORE UPDATE ON "GlobalLock"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "RepeatKey" (
-        "key" TEXT NOT NULL PRIMARY KEY,
-        "value" TEXT NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "expiresAt" TIMESTAMP(3) NOT NULL
-    );
+        CREATE TABLE IF NOT EXISTS "RepeatKey" (
+            "key" TEXT NOT NULL PRIMARY KEY,
+            "value" TEXT NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "expiresAt" TIMESTAMP(3) NOT NULL
+        );
 
-    CREATE TABLE IF NOT EXISTS "SimpleCache" (
-        "key" TEXT NOT NULL PRIMARY KEY,
-        "value" TEXT NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
-    );
-    DROP TRIGGER IF EXISTS update_simplecache_updated_at ON "SimpleCache";
-    CREATE TRIGGER update_simplecache_updated_at
-    BEFORE UPDATE ON "SimpleCache"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "SimpleCache" (
+            "key" TEXT NOT NULL PRIMARY KEY,
+            "value" TEXT NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        DROP TRIGGER IF EXISTS update_simplecache_updated_at ON "SimpleCache";
+        CREATE TRIGGER update_simplecache_updated_at
+        BEFORE UPDATE ON "SimpleCache"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "UsageReport" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "key" TEXT NOT NULL,
-        "accountId" TEXT NOT NULL,
-        "sessionId" TEXT,
-        "data" JSONB NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "UsageReport_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        CONSTRAINT "UsageReport_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE SET NULL ON UPDATE CASCADE,
-        UNIQUE ("accountId", "sessionId", "key")
-    );
-    DROP TRIGGER IF EXISTS update_usagereport_updated_at ON "UsageReport";
-    CREATE TRIGGER update_usagereport_updated_at
-    BEFORE UPDATE ON "UsageReport"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "UsageReport" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "key" TEXT NOT NULL,
+            "accountId" TEXT NOT NULL,
+            "sessionId" TEXT,
+            "data" JSONB NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "UsageReport_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            CONSTRAINT "UsageReport_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+            UNIQUE ("accountId", "sessionId", "key")
+        );
+        DROP TRIGGER IF EXISTS update_usagereport_updated_at ON "UsageReport";
+        CREATE TRIGGER update_usagereport_updated_at
+        BEFORE UPDATE ON "UsageReport"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "Machine" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "metadata" TEXT NOT NULL,
-        "metadataVersion" INTEGER NOT NULL DEFAULT 0,
-        "daemonState" TEXT,
-        "daemonStateVersion" INTEGER NOT NULL DEFAULT 0,
-        "dataEncryptionKey" BYTEA,
-        "seq" INTEGER NOT NULL DEFAULT 0,
-        "active" BOOLEAN NOT NULL DEFAULT true,
-        "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "Machine_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("accountId", "id")
-    );
-    DROP TRIGGER IF EXISTS update_machine_updated_at ON "Machine";
-    CREATE TRIGGER update_machine_updated_at
-    BEFORE UPDATE ON "Machine"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "Machine" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "metadata" TEXT NOT NULL,
+            "metadataVersion" INTEGER NOT NULL DEFAULT 0,
+            "daemonState" TEXT,
+            "daemonStateVersion" INTEGER NOT NULL DEFAULT 0,
+            "dataEncryptionKey" BYTEA,
+            "seq" INTEGER NOT NULL DEFAULT 0,
+            "active" BOOLEAN NOT NULL DEFAULT true,
+            "lastActiveAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "Machine_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("accountId", "id")
+        );
+        DROP TRIGGER IF EXISTS update_machine_updated_at ON "Machine";
+        CREATE TRIGGER update_machine_updated_at
+        BEFORE UPDATE ON "Machine"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "UploadedFile" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "path" TEXT NOT NULL,
-        "width" INTEGER,
-        "height" INTEGER,
-        "thumbhash" TEXT,
-        "reuseKey" TEXT,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "UploadedFile_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("accountId", "path")
-    );
-    DROP TRIGGER IF EXISTS update_uploadedfile_updated_at ON "UploadedFile";
-    CREATE TRIGGER update_uploadedfile_updated_at
-    BEFORE UPDATE ON "UploadedFile"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "UploadedFile" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "path" TEXT NOT NULL,
+            "width" INTEGER,
+            "height" INTEGER,
+            "thumbhash" TEXT,
+            "reuseKey" TEXT,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "UploadedFile_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("accountId", "path")
+        );
+        DROP TRIGGER IF EXISTS update_uploadedfile_updated_at ON "UploadedFile";
+        CREATE TRIGGER update_uploadedfile_updated_at
+        BEFORE UPDATE ON "UploadedFile"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "ServiceAccountToken" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "vendor" TEXT NOT NULL,
-        "token" BYTEA NOT NULL,
-        "metadata" JSONB,
-        "lastUsedAt" TIMESTAMP(3),
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "ServiceAccountToken_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-        UNIQUE ("accountId", "vendor")
-    );
-    DROP TRIGGER IF EXISTS update_serviceaccounttoken_updated_at ON "ServiceAccountToken";
-    CREATE TRIGGER update_serviceaccounttoken_updated_at
-    BEFORE UPDATE ON "ServiceAccountToken"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "ServiceAccountToken" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "vendor" TEXT NOT NULL,
+            "token" BYTEA NOT NULL,
+            "metadata" JSONB,
+            "lastUsedAt" TIMESTAMP(3),
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "ServiceAccountToken_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+            UNIQUE ("accountId", "vendor")
+        );
+        DROP TRIGGER IF EXISTS update_serviceaccounttoken_updated_at ON "ServiceAccountToken";
+        CREATE TRIGGER update_serviceaccounttoken_updated_at
+        BEFORE UPDATE ON "ServiceAccountToken"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "Artifact" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "header" BYTEA NOT NULL,
-        "headerVersion" INTEGER NOT NULL DEFAULT 0,
-        "body" BYTEA NOT NULL,
-        "bodyVersion" INTEGER NOT NULL DEFAULT 0,
-        "dataEncryptionKey" BYTEA NOT NULL,
-        "seq" INTEGER NOT NULL DEFAULT 0,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "Artifact_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE
-    );
-    DROP TRIGGER IF EXISTS update_artifact_updated_at ON "Artifact";
-    CREATE TRIGGER update_artifact_updated_at
-    BEFORE UPDATE ON "Artifact"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "Artifact" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "header" BYTEA NOT NULL,
+            "headerVersion" INTEGER NOT NULL DEFAULT 0,
+            "body" BYTEA NOT NULL,
+            "bodyVersion" INTEGER NOT NULL DEFAULT 0,
+            "dataEncryptionKey" BYTEA NOT NULL,
+            "seq" INTEGER NOT NULL DEFAULT 0,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "Artifact_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+        );
+        DROP TRIGGER IF EXISTS update_artifact_updated_at ON "Artifact";
+        CREATE TRIGGER update_artifact_updated_at
+        BEFORE UPDATE ON "Artifact"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "AccessKey" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "machineId" TEXT NOT NULL,
-        "sessionId" TEXT NOT NULL,
-        "data" TEXT NOT NULL,
-        "dataVersion" INTEGER NOT NULL DEFAULT 0,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "AccessKey_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        CONSTRAINT "AccessKey_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        CONSTRAINT "AccessKey_accountId_machineId_fkey" FOREIGN KEY ("accountId", "machineId") REFERENCES "Machine"("accountId", "id") ON DELETE RESTRICT ON UPDATE CASCADE,
-        UNIQUE ("accountId", "machineId", "sessionId")
-    );
-    DROP TRIGGER IF EXISTS update_accesskey_updated_at ON "AccessKey";
-    CREATE TRIGGER update_accesskey_updated_at
-    BEFORE UPDATE ON "AccessKey"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "AccessKey" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "machineId" TEXT NOT NULL,
+            "sessionId" TEXT NOT NULL,
+            "data" TEXT NOT NULL,
+            "dataVersion" INTEGER NOT NULL DEFAULT 0,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "AccessKey_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            CONSTRAINT "AccessKey_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            CONSTRAINT "AccessKey_accountId_machineId_fkey" FOREIGN KEY ("accountId", "machineId") REFERENCES "Machine"("accountId", "id") ON DELETE RESTRICT ON UPDATE CASCADE,
+            UNIQUE ("accountId", "machineId", "sessionId")
+        );
+        DROP TRIGGER IF EXISTS update_accesskey_updated_at ON "AccessKey";
+        CREATE TRIGGER update_accesskey_updated_at
+        BEFORE UPDATE ON "AccessKey"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "UserRelationship" (
-        "fromUserId" TEXT NOT NULL,
-        "toUserId" TEXT NOT NULL,
-        "status" "RelationshipStatus" NOT NULL DEFAULT 'pending',
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "acceptedAt" TIMESTAMP(3),
-        "lastNotifiedAt" TIMESTAMP(3),
-        PRIMARY KEY ("fromUserId", "toUserId"),
-        CONSTRAINT "UserRelationship_fromUserId_fkey" FOREIGN KEY ("fromUserId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-        CONSTRAINT "UserRelationship_toUserId_fkey" FOREIGN KEY ("toUserId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE
-    );
-    DROP TRIGGER IF EXISTS update_userrelationship_updated_at ON "UserRelationship";
-    CREATE TRIGGER update_userrelationship_updated_at
-    BEFORE UPDATE ON "UserRelationship"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "UserRelationship" (
+            "fromUserId" TEXT NOT NULL,
+            "toUserId" TEXT NOT NULL,
+            "status" "RelationshipStatus" NOT NULL DEFAULT 'pending',
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "acceptedAt" TIMESTAMP(3),
+            "lastNotifiedAt" TIMESTAMP(3),
+            PRIMARY KEY ("fromUserId", "toUserId"),
+            CONSTRAINT "UserRelationship_fromUserId_fkey" FOREIGN KEY ("fromUserId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT "UserRelationship_toUserId_fkey" FOREIGN KEY ("toUserId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE
+        );
+        DROP TRIGGER IF EXISTS update_userrelationship_updated_at ON "UserRelationship";
+        CREATE TRIGGER update_userrelationship_updated_at
+        BEFORE UPDATE ON "UserRelationship"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "UserFeedItem" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "userId" TEXT NOT NULL,
-        "counter" BIGINT NOT NULL,
-        "repeatKey" TEXT,
-        "body" JSONB NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "UserFeedItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-        UNIQUE ("userId", "counter"),
-        UNIQUE ("userId", "repeatKey")
-    );
-    DROP TRIGGER IF EXISTS update_userfeeditem_updated_at ON "UserFeedItem";
-    CREATE TRIGGER update_userfeeditem_updated_at
-    BEFORE UPDATE ON "UserFeedItem"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "UserFeedItem" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "userId" TEXT NOT NULL,
+            "counter" BIGINT NOT NULL,
+            "repeatKey" TEXT,
+            "body" JSONB NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "UserFeedItem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+            UNIQUE ("userId", "counter"),
+            UNIQUE ("userId", "repeatKey")
+        );
+        DROP TRIGGER IF EXISTS update_userfeeditem_updated_at ON "UserFeedItem";
+        CREATE TRIGGER update_userfeeditem_updated_at
+        BEFORE UPDATE ON "UserFeedItem"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE TABLE IF NOT EXISTS "UserKVStore" (
-        "id" TEXT NOT NULL PRIMARY KEY,
-        "accountId" TEXT NOT NULL,
-        "key" TEXT NOT NULL,
-        "value" BYTEA,
-        "version" INTEGER NOT NULL DEFAULT 0,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "UserKVStore_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-        UNIQUE ("accountId", "key")
-    );
-    DROP TRIGGER IF EXISTS update_userkvstore_updated_at ON "UserKVStore";
-    CREATE TRIGGER update_userkvstore_updated_at
-    BEFORE UPDATE ON "UserKVStore"
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+        CREATE TABLE IF NOT EXISTS "UserKVStore" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "key" TEXT NOT NULL,
+            "value" BYTEA,
+            "version" INTEGER NOT NULL DEFAULT 0,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "UserKVStore_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+            UNIQUE ("accountId", "key")
+        );
+        DROP TRIGGER IF EXISTS update_userkvstore_updated_at ON "UserKVStore";
+        CREATE TRIGGER update_userkvstore_updated_at
+        BEFORE UPDATE ON "UserKVStore"
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
 
-    CREATE INDEX IF NOT EXISTS "Session_accountId_updatedAt_idx" ON "Session"("accountId", "updatedAt" DESC);
-    CREATE INDEX IF NOT EXISTS "SessionMessage_sessionId_seq_idx" ON "SessionMessage"("sessionId", "seq");
-    CREATE INDEX IF NOT EXISTS "UsageReport_accountId_idx" ON "UsageReport"("accountId");
-    CREATE INDEX IF NOT EXISTS "UsageReport_sessionId_idx" ON "UsageReport"("sessionId");
-    CREATE INDEX IF NOT EXISTS "Machine_accountId_idx" ON "Machine"("accountId");
-    CREATE INDEX IF NOT EXISTS "UploadedFile_accountId_idx" ON "UploadedFile"("accountId");
-    CREATE INDEX IF NOT EXISTS "ServiceAccountToken_accountId_idx" ON "ServiceAccountToken"("accountId");
-    CREATE INDEX IF NOT EXISTS "Artifact_accountId_idx" ON "Artifact"("accountId");
-    CREATE INDEX IF NOT EXISTS "Artifact_accountId_updatedAt_idx" ON "Artifact"("accountId", "updatedAt" DESC);
-    CREATE INDEX IF NOT EXISTS "AccessKey_accountId_idx" ON "AccessKey"("accountId");
-    CREATE INDEX IF NOT EXISTS "AccessKey_sessionId_idx" ON "AccessKey"("sessionId");
-    CREATE INDEX IF NOT EXISTS "AccessKey_machineId_idx" ON "AccessKey"("machineId");
-    CREATE INDEX IF NOT EXISTS "UserRelationship_toUserId_status_idx" ON "UserRelationship"("toUserId", "status");
-    CREATE INDEX IF NOT EXISTS "UserRelationship_fromUserId_status_idx" ON "UserRelationship"("fromUserId", "status");
-    CREATE INDEX IF NOT EXISTS "UserFeedItem_userId_counter_idx" ON "UserFeedItem"("userId", "counter" DESC);
-    CREATE INDEX IF NOT EXISTS "UserKVStore_accountId_idx" ON "UserKVStore"("accountId");
+        CREATE TABLE IF NOT EXISTS "VoiceConversation" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "accountId" TEXT NOT NULL,
+            "elevenLabsConversationId" TEXT NOT NULL UNIQUE,
+            "durationSecs" INTEGER,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT "VoiceConversation_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+        );
 
+        CREATE INDEX IF NOT EXISTS "Session_accountId_updatedAt_idx" ON "Session"("accountId", "updatedAt" DESC);
+        CREATE INDEX IF NOT EXISTS "SessionMessage_sessionId_seq_idx" ON "SessionMessage"("sessionId", "seq");
+        CREATE INDEX IF NOT EXISTS "UsageReport_accountId_idx" ON "UsageReport"("accountId");
+        CREATE INDEX IF NOT EXISTS "UsageReport_sessionId_idx" ON "UsageReport"("sessionId");
+        CREATE INDEX IF NOT EXISTS "Machine_accountId_idx" ON "Machine"("accountId");
+        CREATE INDEX IF NOT EXISTS "UploadedFile_accountId_idx" ON "UploadedFile"("accountId");
+        CREATE INDEX IF NOT EXISTS "ServiceAccountToken_accountId_idx" ON "ServiceAccountToken"("accountId");
+        CREATE INDEX IF NOT EXISTS "Artifact_accountId_idx" ON "Artifact"("accountId");
+        CREATE INDEX IF NOT EXISTS "Artifact_accountId_updatedAt_idx" ON "Artifact"("accountId", "updatedAt" DESC);
+        CREATE INDEX IF NOT EXISTS "AccessKey_accountId_idx" ON "AccessKey"("accountId");
+        CREATE INDEX IF NOT EXISTS "AccessKey_sessionId_idx" ON "AccessKey"("sessionId");
+        CREATE INDEX IF NOT EXISTS "AccessKey_machineId_idx" ON "AccessKey"("machineId");
+        CREATE INDEX IF NOT EXISTS "UserRelationship_toUserId_status_idx" ON "UserRelationship"("toUserId", "status");
+        CREATE INDEX IF NOT EXISTS "UserRelationship_fromUserId_status_idx" ON "UserRelationship"("fromUserId", "status");
+        CREATE INDEX IF NOT EXISTS "UserFeedItem_userId_counter_idx" ON "UserFeedItem"("userId", "counter" DESC);
+        CREATE INDEX IF NOT EXISTS "UserKVStore_accountId_idx" ON "UserKVStore"("accountId");
+        CREATE INDEX IF NOT EXISTS "VoiceConversation_accountId_createdAt_idx" ON "VoiceConversation"("accountId", "createdAt" DESC);
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ${{ defaults.app_name }}-pg-init
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-init
+    name: ${{ defaults.app_name }}-pg-init
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-init
 spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: pgsql-init
-          image: postgres:15-alpine
-          env:
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE "happy-server";' &>/dev/null; do sleep 1; done
-              psql ${DATABASE_URL}/happy-server -f /init/init.sql
-          volumeMounts:
-            - name: vn-initvn-sql
-              mountPath: /init/init.sql
-              subPath: ./init.sql
-      volumes:
-        - name: vn-initvn-sql
-          configMap:
-            name: ${{ defaults.app_name }}-pg-init
-            items:
-              - key: vn-initvn-sql
-                path: ./init.sql
-            defaultMode: 420
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
-
+    completions: 1
+    template:
+        spec:
+            containers:
+                - name: ${{ defaults.app_name }}-pg-init
+                  image: postgres:16.4-alpine
+                  env:
+                      - name: PG_HOST
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: host
+                      - name: PG_PORT
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: port
+                      - name: PG_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: username
+                      - name: PG_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: password
+                      - name: PG_DATABASE
+                        value: happy-server
+                      - name: PGPASSWORD
+                        value: $(PG_PASSWORD)
+                  command:
+                      - /bin/sh
+                      - -ec
+                      - |
+                          until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres >/dev/null 2>&1; do
+                            sleep 2
+                          done
+                          if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='happy-server'" | grep -q 1; then
+                            psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "happy-server";'
+                          fi
+                          psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d "$PG_DATABASE" -v ON_ERROR_STOP=1 -f /init/init.sql
+                  volumeMounts:
+                      - name: vn-initvn-sql
+                        mountPath: /init/init.sql
+                        subPath: ./init.sql
+                  imagePullPolicy: IfNotPresent
+                  resources:
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi
+                      requests:
+                          cpu: 10m
+                          memory: 12Mi
+            volumes:
+                - name: vn-initvn-sql
+                  configMap:
+                      name: ${{ defaults.app_name }}-pg-init
+                      items:
+                          - key: vn-initvn-sql
+                            path: ./init.sql
+                      defaultMode: 420
+            restartPolicy: OnFailure
+            automountServiceAccountToken: false
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 300
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
-
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/managed-by: kbcli
+    name: ${{ defaults.app_name }}-redis
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/managed-by: kbcli
+    name: ${{ defaults.app_name }}-redis
 rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
+    - apiGroups:
+          - "*"
+      resources:
+          - "*"
+      verbs:
+          - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-redis
-subjects:
-  - kind: ServiceAccount
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/managed-by: kbcli
     name: ${{ defaults.app_name }}-redis
-
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: ${{ defaults.app_name }}-redis
+subjects:
+    - kind: ServiceAccount
+      name: ${{ defaults.app_name }}-redis
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  name: ${{ defaults.app_name }}-redis
-  labels:
-    clusterdefinition.kubeblocks.io/name: redis
-    kb.io/database: redis-7.2.7
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
-    app.kubernetes.io/version: 7.2.7
-    helm.sh/chart: redis-cluster-0.9.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    finalizers:
+        - cluster.kubeblocks.io/finalizer
+    name: ${{ defaults.app_name }}-redis
+    labels:
+        clusterdefinition.kubeblocks.io/name: redis
+        kb.io/database: redis-7.2.7
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+        app.kubernetes.io/version: 7.2.7
+        helm.sh/chart: redis-cluster-0.9.0
+        sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+        clusterversion.kubeblocks.io/name: redis-7.2.7
 spec:
-  clusterDefinitionRef: redis
-  affinity:
-    podAntiAffinity: Preferred
-    topologyKeys:
-      - kubernetes.io/hostname
-  tolerations:
-    - key: kb-data
-      operator: Equal
-      value: "true"
-      effect: NoSchedule
-  componentSpecs:
-    - name: redis
-      componentDef: redis-7
-      enabledLogs:
-        - running
-      env:
-        - name: CUSTOM_SENTINEL_MASTER_NAME
-      serviceVersion: 7.2.7
-      serviceAccountName: ${{ defaults.app_name }}-redis
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
+    clusterDefinitionRef: redis
+    affinity:
+        podAntiAffinity: Preferred
+        topologyKeys:
+            - kubernetes.io/hostname
+        tenancy: SharedNode
+    componentSpecs:
+        - name: redis
+          componentDef: redis-7
+          enabledLogs:
+              - running
+          env:
+              - name: CUSTOM_SENTINEL_MASTER_NAME
+          serviceVersion: 7.2.7
+          serviceAccountName: ${{ defaults.app_name }}-redis
+          replicas: 1
+          resources:
+              limits:
+                  cpu: 500m
+                  memory: 512Mi
               requests:
-                storage: 1Gi
-    - componentDef: redis-sentinel-7
-      name: redis-sentinel
-      replicas: 1
-      resources:
-        limits:
-          cpu: 100m
-          memory: 100Mi
-        requests:
-          cpu: 10m
-          memory: 10Mi
-      serviceVersion: 7.2.7
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
+                  cpu: 50m
+                  memory: 51Mi
+          volumeClaimTemplates:
+              - name: data
+                spec:
+                    accessModes:
+                        - ReadWriteOnce
+                    resources:
+                        requests:
+                            storage: 1Gi
+                    storageClassName: openebs-backup
+          switchPolicy:
+              type: Noop
+        - componentDef: redis-sentinel-7
+          name: redis-sentinel
+          replicas: 1
+          resources:
+              limits:
+                  cpu: 500m
+                  memory: 512Mi
               requests:
-                storage: 1Gi
-  terminationPolicy: Delete
-  topology: replication
-
+                  cpu: 50m
+                  memory: 51Mi
+          serviceVersion: 7.2.7
+          volumeClaimTemplates:
+              - name: data
+                spec:
+                    accessModes:
+                        - ReadWriteOnce
+                    resources:
+                        requests:
+                            storage: 1Gi
+                    storageClassName: openebs-backup
+          serviceAccountName: ${{ defaults.app_name }}-redis
+    terminationPolicy: Delete
+    topology: replication
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${{ defaults.app_name }}
-  annotations:
-    originImageName: ghcr.io/yangchuansheng/happy-server:20250930080708
-    deploy.cloud.sealos.io/minReplicas: '1'
-    deploy.cloud.sealos.io/maxReplicas: '1'
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app: ${{ defaults.app_name }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 1
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}
-  template:
-    metadata:
-      labels:
+    name: ${{ defaults.app_name }}
+    annotations:
+        originImageName: ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe
+        deploy.cloud.sealos.io/minReplicas: "1"
+        deploy.cloud.sealos.io/maxReplicas: "1"
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
         app: ${{ defaults.app_name }}
-    spec:
-      automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: ghcr.io/yangchuansheng/happy-server:20250930080708
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: NODE_ENV
-              value: ${{ inputs.node_env }}
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: PG_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: PG_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/happy-server
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-redis-redis-account-default
-                  key: password
-            - name: REDIS_URL
-              value: redis://:$(REDIS_PASSWORD)@${{ defaults.app_name }}-redis-redis.${{ SEALOS_NAMESPACE }}.svc:6379
-            - name: S3_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: accessKey
-            - name: S3_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: secretKey
-            - name: S3_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
-                  key: bucket
-            - name: S3_EXTERNAL_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: external
-            - name: S3_INTERNAL_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key
-                  key: internal
-            - name: S3_HOST
-              value: $(S3_EXTERNAL_ENDPOINT)
-            - name: S3_PORT
-              value: '443'
-            - name: S3_USE_SSL
-              value: 'true'
-            - name: S3_PUBLIC_URL
-              value: https://$(S3_EXTERNAL_ENDPOINT)/$(S3_BUCKET)
-            - name: HANDY_MASTER_SECRET
-              value: ${{ inputs.seed }}
-            - name: PORT
-              value: '3000'
-          ports:
-            - containerPort: 3000
-          resources:
-            requests:
-              cpu: 20m
-              memory: 256Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
-
+spec:
+    replicas: 1
+    revisionHistoryLimit: 1
+    selector:
+        matchLabels:
+            app: ${{ defaults.app_name }}
+    template:
+        metadata:
+            labels:
+                app: ${{ defaults.app_name }}
+        spec:
+            automountServiceAccountToken: false
+            containers:
+                - name: ${{ defaults.app_name }}
+                  image: ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: NODE_ENV
+                        value: production
+                      - name: HOST
+                        value: 0.0.0.0
+                      - name: PUBLIC_URL
+                        value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+                      - name: PG_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: username
+                      - name: PG_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: password
+                      - name: PG_HOST
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: host
+                      - name: PG_PORT
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: port
+                      - name: DATABASE_URL
+                        value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/happy-server
+                      - name: REDIS_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-redis-redis-account-default
+                                key: username
+                      - name: REDIS_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-redis-redis-account-default
+                                key: password
+                      - name: REDIS_HOST
+                        value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
+                      - name: REDIS_PORT
+                        value: "6379"
+                      - name: REDIS_URL
+                        value: redis://$(REDIS_USERNAME):$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
+                      - name: S3_ACCESS_KEY_ID
+                        valueFrom:
+                            secretKeyRef:
+                                name: object-storage-key
+                                key: accessKey
+                      - name: S3_SECRET_ACCESS_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: object-storage-key
+                                key: secretKey
+                      - name: S3_BUCKET
+                        valueFrom:
+                            secretKeyRef:
+                                name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
+                                key: bucket
+                      - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: object-storage-key
+                                key: external
+                      - name: S3_ACCESS_KEY
+                        value: $(S3_ACCESS_KEY_ID)
+                      - name: S3_SECRET_KEY
+                        value: $(S3_SECRET_ACCESS_KEY)
+                      - name: S3_HOST
+                        value: $(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
+                      - name: S3_USE_SSL
+                        value: "true"
+                      - name: S3_PUBLIC_URL
+                        value: https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)/$(S3_BUCKET)
+                      - name: HANDY_MASTER_SECRET
+                        value: ${{ defaults.seed }}
+                      - name: METRICS_ENABLED
+                        value: "false"
+                      - name: PORT
+                        value: "3005"
+                  ports:
+                      - name: http
+                        containerPort: 3005
+                        protocol: TCP
+                  resources:
+                      limits:
+                          cpu: 200m
+                          memory: 256Mi
+                      requests:
+                          cpu: 20m
+                          memory: 25Mi
+                  startupProbe:
+                      httpGet:
+                          path: /health
+                          port: 3005
+                          scheme: HTTP
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 24
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: 3005
+                          scheme: HTTP
+                      periodSeconds: 30
+                      timeoutSeconds: 5
+                      failureThreshold: 6
+                  readinessProbe:
+                      httpGet:
+                          path: /health
+                          port: 3005
+                          scheme: HTTP
+                      periodSeconds: 10
+                      timeoutSeconds: 3
+                      failureThreshold: 6
+            imagePullSecrets:
+                - name: ${{ defaults.app_name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+        app: ${{ defaults.app_name }}
 spec:
-  ports:
-    - port: 3000
-      targetPort: 3000
-  selector:
-    app: ${{ defaults.app_name }}
-
+    ports:
+        - name: http
+          port: 3005
+          targetPort: 3005
+          protocol: TCP
+    selector:
+        app: ${{ defaults.app_name }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 32m
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 64k;
-      large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
-    nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
-        expires 30d;
-        add_header Cache-Control "public";
-      }
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
+        app: ${{ defaults.app_name }}
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-body-size: 32m
+        nginx.ingress.kubernetes.io/server-snippet: |
+            client_header_buffer_size 64k;
+            large_client_header_buffers 4 128k;
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: HTTP
+        nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
+        nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+            if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
+              expires 30d;
+              add_header Cache-Control "public";
+            }
 spec:
-  rules:
-    - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      http:
-        paths:
-          - pathType: Prefix
-            path: /
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 3000
-  tls:
-    - hosts:
-        - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
+    rules:
+        - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+          http:
+              paths:
+                  - pathType: Prefix
+                    path: /
+                    backend:
+                        service:
+                            name: ${{ defaults.app_name }}
+                            port:
+                                number: 3005
+    tls:
+        - hosts:
+              - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+          secretName: ${{ SEALOS_CERT_SECRET_NAME }}
 ---
 apiVersion: app.sealos.io/v1
 kind: App
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  data:
-    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-  displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/logo.png"
-  name: "Happy Server"
-  type: link
+    data:
+        url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+    displayType: normal
+    icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/happy-server/logo.png
+    name: Happy Server
+    type: link


### PR DESCRIPTION
## Summary

Stabilizes the Happy Server Sealos template so it can be deployed from App Store with the runtime dependencies the server actually needs.

- Adds bilingual App Store README docs and local template assets for Happy Server.
- Pins the Happy Server runtime image by digest instead of a floating timestamp tag.
- Updates the template to use PostgreSQL 16.4, Redis 7.2, and S3-compatible Object Storage.
- Fixes runtime wiring for `DATABASE_URL`, Redis, object storage, `PORT=3005`, probes, service, and ingress.
- Sets the deploy-tested app baseline to `200m` CPU and `256Mi` memory. A `128Mi` test limit OOM-killed during startup.
- Keeps the Chinese README template link on the `sealos.io` domain.

## Test Coverage

No application code changed. This PR changes a Sealos template, README files, and static assets.

Validation covered:

- `docker-to-sealos` quality gate: pass
- YAML/README smoke checks: pass
- Sealos deploy health test from the prior run: `/health` returned HTTP 200 and `/` returned `Welcome to Happy Server!`

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: Optimize and ship the Happy Server Sealos template with deploy-tested resources and bilingual docs.

Delivered: Updates only `template/happy-server` manifest, README files, icon, and screenshot assets.

## Plan Completion

No plan file detected. The work follows the direct user request from this thread.

## Verification Results

- [x] `docker-to-sealos` quality gate passed
- [x] `check_consistency.py` passed, 38 rules
- [x] `check_must_coverage.py` passed
- [x] `template/happy-server/index.yaml` parses as 16 YAML documents
- [x] README checks passed, including the Chinese `sealos.io` template link

## Test plan

- [x] Validate template with `docker-to-sealos` quality gate
- [x] Validate Happy Server YAML structure and key deployment fields
- [x] Validate English and Chinese README links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
