### PR TITLE
feat(formbricks): update Sealos template to 4.9.7

### DIFF
--- a/template/formbricks/README.md
+++ b/template/formbricks/README.md
@@ -1,32 +1,141 @@
-# Formbricks
+# Deploy and Host Formbricks on Sealos
 
-## Overview
+Formbricks is an open-source experience management platform for in-app, website, link, and email surveys. This template deploys Formbricks with PostgreSQL, Redis, persistent uploads, public HTTPS access, and Sealos-managed application resources.
 
-Formbricks provides a free and open source surveying platform. Gather feedback at every point in the user journey with beautiful in-app, website, link and email surveys.
+![Formbricks Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/formbricks/website-screenshot.webp)
 
-This Sealos template deploys **Formbricks** as the `formbricks` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Formbricks
 
-## Deploy on Sealos
+Formbricks helps product teams collect feedback across the user journey, from targeted in-product surveys to public link surveys and email campaigns. The application stores survey definitions, responses, users, and workspace data in PostgreSQL, while Redis supports server-side caching and rate-limiting workflows.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+This Sealos template provisions the complete runtime: a Formbricks StatefulSet, PostgreSQL 16, Redis 7, database bootstrap and migration init containers, persistent upload storage, and an HTTPS Ingress. Formbricks runs with signup enabled by default so the first workspace can be created after deployment. There is no default username or password; create the first account from the web UI and then use that email and password to log in.
 
-## Access
+The template also creates the additional SAML database expected by the Formbricks container startup flow. Email verification and password reset are disabled by default because SMTP is not configured in this template.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **In-app product feedback**: Trigger targeted surveys inside your product to learn why users convert, churn, or get blocked.
+- **Website and landing page surveys**: Embed surveys on public pages to collect visitor feedback and lead qualification data.
+- **Link-based research**: Share standalone survey links with customers, beta users, or internal teams.
+- **Customer experience tracking**: Run recurring NPS, CSAT, or product-market-fit surveys from one self-hosted platform.
+- **Privacy-conscious feedback operations**: Keep feedback data in your own Sealos-hosted environment instead of relying only on SaaS hosting.
+
+## Dependencies for Formbricks Hosting
+
+The Sealos template includes all required dependencies: the Formbricks web application container, PostgreSQL 16 for application data, Redis 7 for caching and rate-limit support, persistent volumes for uploaded files and SAML connection data, and an HTTPS Ingress for public access.
+
+### Deployment Dependencies
+
+- [Formbricks Documentation](https://formbricks.com/docs) - Official Formbricks documentation
+- [Formbricks Self-Hosting Guide](https://formbricks.com/docs/self-hosting) - Self-hosting and configuration guidance
+- [Formbricks GitHub Repository](https://github.com/formbricks/formbricks) - Source code and issue tracker
+- [Sealos App Store](https://sealos.io/products/app-store) - Sealos application templates
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Formbricks StatefulSet**: Runs `ghcr.io/formbricks/formbricks:4.9.7`, serves the web UI and API on port `3000`, and mounts persistent storage for uploads and SAML connection files.
+- **PostgreSQL Cluster**: Stores Formbricks application data in the `formbricks` database and creates a separate `formbricks-saml` database for SAML support.
+- **PostgreSQL Init Job**: Waits for PostgreSQL readiness and creates both databases idempotently.
+- **Formbricks Migration Init Container**: Runs the official database migration command before the web container handles steady-state traffic, allowing the application container to skip startup migrations.
+- **Redis Cluster**: Provides Redis 7 with Sentinel topology for server-side caching and rate-limit related runtime features.
+- **Service and Ingress**: Exposes the Formbricks HTTP service through a Sealos-managed HTTPS domain.
+- **App Resource**: Registers the deployment in the Sealos desktop for one-click access after installation.
+
+**Configuration:**
+
+The application composes `DATABASE_URL`, `MIGRATE_DATABASE_URL`, `SAML_DATABASE_URL`, and `REDIS_URL` from Sealos-managed database secrets and service DNS names. Generated defaults provide `NEXTAUTH_SECRET`, `ENCRYPTION_KEY`, and `CRON_SECRET`, while legal-page URLs are exposed as optional deployment inputs.
+
+Default runtime settings disable Docker cron jobs, email verification, password reset, and telemetry. Signup and invitations remain enabled so the instance can be initialized from the web UI after deployment. No administrator credentials are generated by the template.
+
+**License Information:**
+
+Formbricks is licensed under the AGPL-3.0 license. This Sealos template is provided as part of the Sealos templates repository.
+
+## Why Deploy Formbricks on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, public access, storage, and operations. By deploying Formbricks on Sealos, you get:
+
+- **One-Click Deployment**: Start Formbricks from the App Store without manually writing Kubernetes YAML.
+- **Managed Dependencies**: PostgreSQL, Redis, persistent volumes, Services, Ingress, and the App entry are created together from one template.
+- **Instant Public Access**: Each deployment receives a public HTTPS URL through Sealos-managed Ingress and certificates.
+- **Persistent Data**: Database data, uploads, and SAML connection files survive application restarts.
+- **Canvas + AI Operations**: After deployment, use the Canvas, AI dialog, and resource cards to adjust configuration or resources.
+- **Pay-As-You-Go Resources**: Tune CPU, memory, and storage to fit your workload without over-provisioning.
+- **Kubernetes Reliability**: Run Formbricks on Kubernetes primitives while Sealos handles the operational interface.
+
+Deploy Formbricks on Sealos and focus on feedback workflows instead of infrastructure setup.
+
+## Deployment Guide
+
+1. Open the [Formbricks template](https://sealos.io/products/app-store/formbricks) and click **Deploy Now**.
+2. Configure the optional legal-page parameters in the popup dialog:
+   - `PRIVACY_URL`: URL for your privacy policy page.
+   - `TERMS_URL`: URL for your terms of service page.
+   - `IMPRINT_URL`: URL for your imprint page.
+3. Wait for deployment to complete, typically 3-5 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog, or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **Formbricks Web UI**: Open the App entry or the generated `https://<your-app-host>.<sealos-cloud-domain>` URL, then create the initial account and workspace.
+
+## Sign-up and Login
+
+This template does not create a default username or password. Registration is enabled by default, and email verification is disabled because SMTP is not configured.
+
+To initialize the instance, open the Formbricks URL after deployment, choose **Sign up** or **Create account**, enter your email and password, and create the first workspace. After that, use the same email and password on the login page.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Formbricks through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `IMPRINT_URL` | URL for your imprint page | `false` | `https://www.formbricks.com/imprint` |
-| `PRIVACY_URL` | URL for your privacy policy page | `false` | `https://www.formbricks.com/privacy` |
-| `TERMS_URL` | URL for your terms of service page | `false` | `https://www.formbricks.com/terms` |
+- **Formbricks Web UI**: Create teams, products, environments, surveys, and integrations from the application interface.
+- **AI Dialog**: Describe environment variable or resource changes and let Sealos apply updates.
+- **Resource Cards**: Open the StatefulSet, database, Redis, Service, or Ingress cards in Canvas to inspect and update settings.
+- **Legal URLs**: Set `PRIVACY_URL`, `TERMS_URL`, and `IMPRINT_URL` during deployment to point users to your own legal pages.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+SMTP is not configured by default. If you enable email verification or password reset later, add the required Formbricks SMTP environment variables first.
 
-## Official Links
+## Scaling
 
-- Official website: https://formbricks.com
-- Source repository: https://github.com/formbricks/formbricks
+This template runs one Formbricks replica by default, which matches the bundled persistent upload storage and migration init-container flow. To adjust resources:
+
+1. Open the Canvas for your deployment.
+2. Click the Formbricks StatefulSet resource card.
+3. Adjust CPU and memory resources based on your traffic and survey volume. The template uses the smallest passing test profile found for Formbricks 4.9.7: a 500m CPU / 512Mi memory migration init container and a 300m CPU / 256Mi memory web container.
+4. Apply the changes in the dialog and wait for the pod to become ready again.
+
+For larger installations, review Formbricks self-hosting guidance before increasing replicas, especially around shared uploads, background jobs, and database capacity.
+
+## Troubleshooting
+
+### Common Issues
+
+**The first startup takes longer than expected**
+- Cause: The PostgreSQL bootstrap job and Formbricks migration init container must finish before the web UI becomes fully ready.
+- Solution: Wait for the migration init container to complete and for the StatefulSet pod logs to show the server is listening. If startup repeatedly fails, inspect the PostgreSQL, migration init container, and Formbricks logs from the Canvas.
+
+**Email verification or password reset does not send messages**
+- Cause: SMTP settings are not included by default, and email verification/password reset are disabled.
+- Solution: Add Formbricks SMTP environment variables before enabling those features. Until then, initialize the instance through the built-in sign-up flow and keep track of the first account credentials.
+
+**Uploads or SAML connection files must persist**
+- Cause: These files are stored on mounted persistent volumes.
+- Solution: Keep the generated volume claims attached to the StatefulSet and avoid deleting them unless you intend to remove stored files.
+
+### Getting Help
+
+- [Formbricks Documentation](https://formbricks.com/docs)
+- [Formbricks GitHub Issues](https://github.com/formbricks/formbricks/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Formbricks Self-Hosting](https://formbricks.com/docs/self-hosting)
+- [Formbricks Developer Documentation](https://formbricks.com/docs/developer-docs)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is provided under the repository license. Formbricks itself is licensed under the [AGPL-3.0 license](https://github.com/formbricks/formbricks/blob/main/LICENSE).

--- a/template/formbricks/README_zh.md
+++ b/template/formbricks/README_zh.md
@@ -1,32 +1,141 @@
-# Formbricks
+# 在 Sealos 上部署和托管 Formbricks
 
-## 应用概览
+Formbricks 是一个开源体验管理平台，支持应用内、网站、链接和邮件问卷。此模板会在 Sealos Cloud 上部署带 PostgreSQL、Redis、持久化上传目录、公网 HTTPS 访问和 Sealos 应用资源的 Formbricks。
 
-Formbricks 是一个免费的开源问卷调研平台，旨在帮助你轻松获取用户反馈，深入了解他们的体验。
+![Formbricks 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/formbricks/website-screenshot.webp)
 
-此 Sealos 模板会将 **Formbricks** 部署为 `formbricks` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于托管 Formbricks
 
-## 在 Sealos 上部署
+Formbricks 帮助产品团队在用户旅程中收集反馈，从产品内定向问卷到公开链接问卷和邮件活动都可以覆盖。应用会把问卷定义、回答、用户和工作区数据存储在 PostgreSQL 中，并使用 Redis 支撑服务端缓存和限流相关流程。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+此 Sealos 模板会创建完整运行环境：Formbricks StatefulSet、PostgreSQL 16、Redis 7、数据库初始化 Job、迁移 initContainer、持久化上传存储，以及 HTTPS Ingress。Formbricks 默认启用注册，因此部署后可以直接创建第一个工作区。模板不会生成默认用户名或密码；请在 Web UI 中创建第一个账号，然后用该邮箱和密码登录。
 
-## 访问方式
+模板还会创建 Formbricks 容器启动流程所需的额外 SAML 数据库。由于此模板未配置 SMTP，默认关闭邮件验证和密码重置。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
 
-## 配置说明
+- **产品内反馈收集**：在产品中触发定向问卷，了解用户转化、流失或受阻原因。
+- **网站和落地页问卷**：在公开页面嵌入问卷，收集访客反馈和线索信息。
+- **链接式用户研究**：向客户、测试用户或内部团队分享独立问卷链接。
+- **客户体验追踪**：在一个自托管平台中运行 NPS、CSAT 或产品市场匹配度问卷。
+- **注重隐私的反馈运营**：将反馈数据保存在自己的 Sealos 托管环境中，而不是完全依赖 SaaS 托管。
 
-部署时可以配置以下用户可见输入项：
+## Formbricks 托管依赖
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `IMPRINT_URL` | `IMPRINT_URL` 部署参数。 | `否` | `https://www.formbricks.com/imprint` |
-| `PRIVACY_URL` | `PRIVACY_URL` 部署参数。 | `否` | `https://www.formbricks.com/privacy` |
-| `TERMS_URL` | `TERMS_URL` 部署参数。 | `否` | `https://www.formbricks.com/terms` |
+此 Sealos 模板包含全部必需依赖：Formbricks Web 应用容器、用于应用数据的 PostgreSQL 16、用于缓存和限流支持的 Redis 7、用于上传文件和 SAML 连接数据的持久卷，以及用于公网访问的 HTTPS Ingress。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖
 
-## 官方链接
+- [Formbricks 文档](https://formbricks.com/docs) - Formbricks 官方文档
+- [Formbricks 自托管指南](https://formbricks.com/docs/self-hosting) - 自托管和配置说明
+- [Formbricks GitHub 仓库](https://github.com/formbricks/formbricks) - 源码和问题追踪
+- [Sealos 应用商店](https://sealos.io/products/app-store) - Sealos 应用模板
 
-- 官方网站: https://formbricks.com
-- 源码仓库: https://github.com/formbricks/formbricks
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Formbricks StatefulSet**：运行 `ghcr.io/formbricks/formbricks:4.9.7`，在 `3000` 端口提供 Web UI 和 API，并挂载上传文件与 SAML 连接文件的持久化存储。
+- **PostgreSQL 集群**：在 `formbricks` 数据库中存储 Formbricks 应用数据，并创建独立的 `formbricks-saml` 数据库用于 SAML 支持。
+- **PostgreSQL 初始化 Job**：等待 PostgreSQL 就绪，并以幂等方式创建两个数据库。
+- **Formbricks 迁移 initContainer**：运行官方数据库迁移命令，再由 Web 容器承担稳定运行流量，使应用容器可以跳过启动迁移。
+- **Redis 集群**：提供带 Sentinel 拓扑的 Redis 7，用于服务端缓存和限流相关运行时能力。
+- **Service 和 Ingress**：通过 Sealos 托管的 HTTPS 域名暴露 Formbricks HTTP 服务。
+- **App 资源**：在 Sealos 桌面中注册应用入口，部署后可一键访问。
+
+**配置：**
+
+应用会通过 Sealos 管理的数据库 Secret 和服务 DNS 组合出 `DATABASE_URL`、`MIGRATE_DATABASE_URL`、`SAML_DATABASE_URL` 和 `REDIS_URL`。生成默认值会提供 `NEXTAUTH_SECRET`、`ENCRYPTION_KEY` 和 `CRON_SECRET`，法律页面 URL 则作为可选部署输入暴露。
+
+默认运行设置会关闭 Docker cron、邮件验证、密码重置和遥测。注册和邀请保持启用，便于部署后从 Web UI 初始化实例。模板不会生成管理员账号。
+
+**许可信息：**
+
+Formbricks 使用 AGPL-3.0 许可证。此 Sealos 模板作为 Sealos templates 仓库的一部分提供。
+
+## 为什么在 Sealos 上部署 Formbricks？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用部署、公网访问、存储和运维。将 Formbricks 部署在 Sealos 上，你可以获得：
+
+- **一键部署**：从应用商店启动 Formbricks，无需手写 Kubernetes YAML。
+- **托管依赖**：PostgreSQL、Redis、持久卷、Service、Ingress 和 App 入口会随模板一起创建。
+- **即时公网访问**：每个部署都会通过 Sealos 托管的 Ingress 和证书获得公网 HTTPS URL。
+- **持久化数据**：数据库数据、上传文件和 SAML 连接文件会在应用重启后保留。
+- **Canvas + AI 运维**：部署后可使用 Canvas、AI 对话和资源卡调整配置或资源。
+- **按需付费资源**：按工作负载调节 CPU、内存和存储，避免过度配置。
+- **Kubernetes 可靠性**：使用 Kubernetes 原语运行 Formbricks，同时由 Sealos 提供更直观的运维界面。
+
+在 Sealos 上部署 Formbricks，把精力放在反馈流程，而不是基础设施搭建上。
+
+## 部署指南
+
+1. 打开 [Formbricks 模板](https://sealos.io/products/app-store/formbricks)，点击 **立即部署**。
+2. 在弹窗中配置可选的法律页面参数：
+   - `PRIVACY_URL`：隐私政策页面 URL。
+   - `TERMS_URL`：服务条款页面 URL。
+   - `IMPRINT_URL`：法律声明页面 URL。
+3. 等待部署完成，通常需要 3-5 分钟。部署后会跳转到 Canvas。后续如需修改，可在 AI 对话中描述需求，或点击相关资源卡调整设置。
+4. 通过提供的 URL 访问应用：
+   - **Formbricks Web UI**：打开 App 入口或生成的 `https://<your-app-host>.<sealos-cloud-domain>` URL，然后创建初始账号和工作区。
+
+## 注册和登录
+
+此模板不会创建默认用户名或密码。默认启用注册，并且由于未配置 SMTP，邮件验证处于关闭状态。
+
+初始化实例时，部署完成后打开 Formbricks URL，选择 **注册** 或 **创建账号**，输入邮箱和密码，然后创建第一个工作区。之后在登录页使用同一邮箱和密码登录。
+
+## 配置
+
+部署后，你可以通过以下方式配置 Formbricks：
+
+- **Formbricks Web UI**：在应用界面中创建团队、产品、环境、问卷和集成。
+- **AI 对话**：描述需要修改的环境变量或资源，让 Sealos 应用更新。
+- **资源卡**：在 Canvas 中打开 StatefulSet、数据库、Redis、Service 或 Ingress 资源卡，查看并更新设置。
+- **法律 URL**：部署时设置 `PRIVACY_URL`、`TERMS_URL` 和 `IMPRINT_URL`，指向你自己的法律页面。
+
+默认不配置 SMTP。如果后续启用邮件验证或密码重置，请先添加 Formbricks 所需的 SMTP 环境变量。
+
+## 扩缩容
+
+此模板默认运行 1 个 Formbricks 副本，与内置的持久化上传存储和迁移 initContainer 流程保持一致。如需调整资源：
+
+1. 打开当前部署的 Canvas。
+2. 点击 Formbricks StatefulSet 资源卡。
+3. 根据访问量和问卷规模调整 CPU 与内存资源。此模板使用 Formbricks 4.9.7 测试通过的最小资源组合：迁移 initContainer 为 500m CPU / 512Mi 内存，Web 容器为 300m CPU / 256Mi 内存。
+4. 在对话中应用变更，并等待 Pod 重新就绪。
+
+对于更大规模的安装，请先阅读 Formbricks 自托管指南，尤其要关注共享上传目录、后台任务和数据库容量。
+
+## 故障排查
+
+### 常见问题
+
+**首次启动时间较长**
+- 原因：PostgreSQL 初始化 Job 和 Formbricks 迁移 initContainer 需要先完成，Web UI 才会完全就绪。
+- 解决方法：等待迁移 initContainer 完成，并确认 StatefulSet Pod 日志显示服务已开始监听。如果启动反复失败，请在 Canvas 中查看 PostgreSQL、迁移 initContainer 和 Formbricks 日志。
+
+**邮件验证或密码重置没有发送邮件**
+- 原因：默认未包含 SMTP 设置，并且邮件验证/密码重置处于关闭状态。
+- 解决方法：先添加 Formbricks SMTP 环境变量，再启用这些功能。在此之前，请通过内置注册流程初始化实例，并妥善保存第一个账号的凭据。
+
+**上传文件或 SAML 连接文件需要持久化**
+- 原因：这些文件存储在挂载的持久卷中。
+- 解决方法：保留 StatefulSet 生成的 PVC。除非你明确要删除已存储文件，否则不要删除这些 PVC。
+
+### 获取帮助
+
+- [Formbricks 文档](https://formbricks.com/docs)
+- [Formbricks GitHub Issues](https://github.com/formbricks/formbricks/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Formbricks 自托管](https://formbricks.com/docs/self-hosting)
+- [Formbricks 开发者文档](https://formbricks.com/docs/developer-docs)
+- [Sealos 文档](https://sealos.io/docs)
+
+## 许可证
+
+此 Sealos 模板按仓库许可证提供。Formbricks 本身使用 [AGPL-3.0 许可证](https://github.com/formbricks/formbricks/blob/main/LICENSE)。

--- a/template/formbricks/index.yaml
+++ b/template/formbricks/index.yaml
@@ -17,7 +17,7 @@ spec:
   locale: en
   i18n:
     zh:
-      description: 'Formbricks 是一个免费的开源问卷调研平台，旨在帮助你轻松获取用户反馈，深入了解他们的体验。'
+      description: 'Formbricks 是一个免费的开源问卷调研平台，可在产品旅程中的关键节点收集应用内、网页、链接与邮件问卷反馈。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/formbricks/README_zh.md'
   categories:
     - tool
@@ -28,6 +28,15 @@ spec:
     app_name:
       type: string
       value: formbricks-${{ random(8) }}
+    nextauth_secret:
+      type: string
+      value: ${{ random(32) }}
+    encryption_key:
+      type: string
+      value: ${{ random(32) }}
+    cron_secret:
+      type: string
+      value: ${{ random(32) }}
   inputs:
     PRIVACY_URL:
       description: 'URL for your privacy policy page'
@@ -45,24 +54,23 @@ spec:
       default: 'https://www.formbricks.com/imprint'
       required: false
 ---
-# PostgreSQL Database Resources
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ${{ defaults.app_name }}-pg
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ${{ defaults.app_name }}-pg
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 rules:
   - apiGroups:
       - '*'
@@ -76,9 +84,9 @@ kind: RoleBinding
 metadata:
   name: ${{ defaults.app_name }}-pg
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -86,18 +94,17 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-pg
-
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
   name: ${{ defaults.app_name }}-pg
+  labels:
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    kb.io/database: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 spec:
   affinity:
     nodeLabels: {}
@@ -105,10 +112,12 @@ spec:
     tenancy: SharedNode
     topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
     - componentDefRef: postgresql
-      monitor: true
+      disableExporter: true
+      enabledLogs:
+        - running
       name: postgresql
       replicas: 1
       resources:
@@ -131,26 +140,36 @@ spec:
                 storage: 1Gi
             storageClassName: openebs-backup
   terminationPolicy: Delete
-
 ---
-# PostgreSQL Init Job
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${{ defaults.app_name }}-pg-init
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   completions: 1
   template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: pgsql-init
-          image: postgres:14-alpine
+        - name: pg-init
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           env:
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
             - name: PG_HOST
               valueFrom:
                 secretKeyRef:
@@ -166,36 +185,65 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: username
-            - name: DATABASE_URL
-              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PG_DATABASE
+              value: formbricks
+            - name: SAML_DATABASE
+              value: formbricks-saml
           command:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE EXTENSION IF NOT EXISTS vector; CREATE DATABASE formbricks;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
+              set -eu
+              export PGPASSWORD="$PG_PASSWORD"
+              for i in $(seq 1 90); do
+                if pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                if [ "$i" -eq 90 ]; then
+                  echo "PostgreSQL is not ready" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='formbricks'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"formbricks\""
+              fi
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='formbricks-saml'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"formbricks-saml\""
+              fi
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+      restartPolicy: OnFailure
+  backoffLimit: 10
   ttlSecondsAfterFinished: 300
-
 ---
-# Redis Database Resources
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ${{ defaults.app_name }}-redis
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
     app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ${{ defaults.app_name }}-redis
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
     app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
 rules:
   - apiGroups:
       - '*'
@@ -209,9 +257,9 @@ kind: RoleBinding
 metadata:
   name: ${{ defaults.app_name }}-redis
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
     app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/managed-by: kbcli
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -219,20 +267,17 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-redis
-
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
   name: ${{ defaults.app_name }}-redis
   labels:
-    clusterdefinition.kubeblocks.io/name: redis
-    kb.io/database: redis-7.2.7
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/version: 7.2.7
+    clusterdefinition.kubeblocks.io/name: redis
     helm.sh/chart: redis-cluster-0.9.0
+    kb.io/database: redis-7.2.7
     sealos-db-provider-cr: ${{ defaults.app_name }}-redis
 spec:
   clusterDefinitionRef: redis
@@ -240,11 +285,6 @@ spec:
     podAntiAffinity: Preferred
     topologyKeys:
       - kubernetes.io/hostname
-  tolerations:
-    - key: kb-data
-      operator: Equal
-      value: "true"
-      effect: NoSchedule
   componentSpecs:
     - name: redis
       componentDef: redis-7
@@ -252,6 +292,7 @@ spec:
         - running
       env:
         - name: CUSTOM_SENTINEL_MASTER_NAME
+          value: mymaster
       serviceVersion: 7.2.7
       serviceAccountName: ${{ defaults.app_name }}-redis
       replicas: 1
@@ -270,17 +311,20 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-    - componentDef: redis-sentinel-7
-      name: redis-sentinel
+    - name: redis-sentinel
+      componentDef: redis-sentinel-7
+      enabledLogs:
+        - running
+      serviceVersion: 7.2.7
+      serviceAccountName: ${{ defaults.app_name }}-redis
       replicas: 1
       resources:
         limits:
-          cpu: 100m
-          memory: 100Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
-      serviceVersion: 7.2.7
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -291,147 +335,23 @@ spec:
                 storage: 1Gi
   terminationPolicy: Delete
   topology: replication
-
 ---
-# Application Secret
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-type: Opaque
-stringData:
-  NEXTAUTH_SECRET: ${{ random(32) }}
-  ENCRYPTION_KEY: ${{ random(32) }}
-  CRON_SECRET: ${{ random(32) }}
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-init
-spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: ${{ defaults.app_name }}-init
-          image: ghcr.io/formbricks/formbricks:3.17.0
-          imagePullPolicy: IfNotPresent
-          env:
-            # Database configuration
-            - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: POSTGRES_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: POSTGRES_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: username
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks
-            
-            # Redis configuration
-            - name: REDIS_HOST
-              value: ${{ defaults.app_name }}-redis-redis-redis
-            - name: REDIS_PORT
-              value: '6379'
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-redis-redis-account-default
-                  key: password
-            - name: REDIS_URL
-              value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
-            
-            # Application secrets
-            - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: NEXTAUTH_SECRET
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: ENCRYPTION_KEY
-            - name: CRON_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: CRON_SECRET
-            
-            # Application URLs
-            - name: WEBAPP_URL
-              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-            - name: NEXTAUTH_URL
-              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-            - name: PRIVACY_URL
-              value: ${{ inputs.PRIVACY_URL }}
-            - name: TERMS_URL
-              value: ${{ inputs.TERMS_URL }}
-            - name: IMPRINT_URL
-              value: ${{ inputs.IMPRINT_URL }}
-            
-            # Other settings
-            - name: DOCKER_CRON_ENABLED
-              value: "0"
-            - name: EMAIL_VERIFICATION_DISABLED
-              value: "1"
-            - name: PASSWORD_RESET_DISABLED
-              value: "1"
-            - name: SIGNUP_DISABLED
-              value: "0"
-            - name: INVITE_DISABLED
-              value: "0"
-            - name: TELEMETRY_DISABLED
-              value: "1"
-          
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2048Mi
-            requests:
-              cpu: 200m
-              memory: 204Mi
-          command:
-            - /bin/sh
-            - -c
-            - |
-              sed -i "$(($(wc -l < /home/nextjs/start.sh)-2)),\$d" /home/nextjs/start.sh
-              /home/nextjs/start.sh
-      restartPolicy: OnFailure
-  backoffLimit: 10
-  ttlSecondsAfterFinished: 300
----
-# Application Deployment
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/formbricks/formbricks:3.17.0
+    originImageName: ghcr.io/formbricks/formbricks:4.9.7
+    docker-to-sealos.resource-override-source: 'Official Formbricks 4.9.7 Docker startup runs database migrations before serving; Sealos testing moves that migration to an initContainer with a 500m CPU / 512Mi memory limit, then sets SKIP_STARTUP_MIGRATION=true so the web container runs with lower steady-state resources: https://raw.githubusercontent.com/formbricks/formbricks/4.9.7/apps/web/scripts/docker/next-start.sh'
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
+  serviceName: ${{ defaults.app_name }}
   selector:
     matchLabels:
       app: ${{ defaults.app_name }}
@@ -439,18 +359,37 @@ spec:
     metadata:
       labels:
         app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: ghcr.io/formbricks/formbricks:3.17.0
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: ${{ defaults.app_name }}-migration
+          image: ghcr.io/formbricks/formbricks:4.9.7
           imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 3000
-              name: http
-              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              set -eu
+              for i in $(seq 1 90); do
+                if node packages/database/dist/scripts/apply-migrations.js; then
+                  exit 0
+                fi
+                echo "Database migration attempt $i failed; retrying in 5 seconds..." >&2
+                sleep 5
+              done
+              echo "Database migration failed after 90 attempts" >&2
+              exit 1
           env:
-            # Database configuration
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:
@@ -472,11 +411,60 @@ spec:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
             - name: DATABASE_URL
-              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks
-            
-            # Redis configuration
+              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks?schema=public
+            - name: MIGRATE_DATABASE_URL
+              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks?schema=public
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 51Mi
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: ghcr.io/formbricks/formbricks:4.9.7
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 3000
+              name: http
+              protocol: TCP
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: DATABASE_URL
+              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks?schema=public
+            - name: MIGRATE_DATABASE_URL
+              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks?schema=public
+            - name: SKIP_STARTUP_MIGRATION
+              value: 'true'
+            - name: SAML_DATABASE_URL
+              value: postgresql://$(POSTGRES_USERNAME):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/formbricks-saml?sslmode=disable
             - name: REDIS_HOST
-              value: ${{ defaults.app_name }}-redis-redis-redis
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local
             - name: REDIS_PORT
               value: '6379'
             - name: REDIS_PASSWORD
@@ -486,25 +474,12 @@ spec:
                   key: password
             - name: REDIS_URL
               value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
-            
-            # Application secrets
             - name: NEXTAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: NEXTAUTH_SECRET
+              value: ${{ defaults.nextauth_secret }}
             - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: ENCRYPTION_KEY
+              value: ${{ defaults.encryption_key }}
             - name: CRON_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: CRON_SECRET
-            
-            # Application URLs
+              value: ${{ defaults.cron_secret }}
             - name: WEBAPP_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
             - name: NEXTAUTH_URL
@@ -515,56 +490,84 @@ spec:
               value: ${{ inputs.TERMS_URL }}
             - name: IMPRINT_URL
               value: ${{ inputs.IMPRINT_URL }}
-            
-            # Other settings
             - name: DOCKER_CRON_ENABLED
-              value: "0"
+              value: '0'
             - name: EMAIL_VERIFICATION_DISABLED
-              value: "1"
+              value: '1'
             - name: PASSWORD_RESET_DISABLED
-              value: "1"
+              value: '1'
             - name: SIGNUP_DISABLED
-              value: "0"
+              value: '0'
             - name: INVITE_DISABLED
-              value: "0"
+              value: '0'
             - name: TELEMETRY_DISABLED
-              value: "1"
-          
+              value: '1'
           resources:
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 300m
+              memory: 256Mi
             requests:
-              cpu: 50m
-              memory: 51Mi
-          
-          livenessProbe:
-            failureThreshold: 15
-            httpGet:
-              path: /health
+              cpu: 30m
+              memory: 26Mi
+          volumeMounts:
+            - name: vn-homevn-nextjsvn-appsvn-webvn-uploads
+              mountPath: /home/nextjs/apps/web/uploads
+            - name: vn-homevn-nextjsvn-appsvn-webvn-saml-connection
+              mountPath: /home/nextjs/apps/web/saml-connection
+          startupProbe:
+            tcpSocket:
               port: 3000
-            initialDelaySeconds: 30
+            failureThreshold: 30
             periodSeconds: 10
-            successThreshold: 1
             timeoutSeconds: 5
-          
           readinessProbe:
-            failureThreshold: 5
             httpGet:
               path: /health
               port: 3000
             initialDelaySeconds: 10
+            failureThreshold: 5
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 5
-
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            failureThreshold: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: vn-homevn-nextjsvn-appsvn-webvn-uploads
+        annotations:
+          path: /home/nextjs/apps/web/uploads
+          value: '1'
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: vn-homevn-nextjsvn-appsvn-webvn-saml-connection
+        annotations:
+          path: /home/nextjs/apps/web/saml-connection
+          value: '1'
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ---
-# Service
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
@@ -575,33 +578,32 @@ spec:
       protocol: TCP
       port: 3000
       targetPort: 3000
-
 ---
-# Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 32m
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 64k;
-      large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
         add_header Cache-Control "public";
       }
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 64k;
+      large_client_header_buffers 4 128k;
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   rules:
     - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
@@ -618,14 +620,13 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
-# App CR
 apiVersion: app.sealos.io/v1
 kind: App
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   data:


### PR DESCRIPTION
## Summary

**Formbricks template**
- Update the Sealos Formbricks template to `ghcr.io/formbricks/formbricks:4.9.7`.
- Move Formbricks database migrations into a dedicated StatefulSet `initContainer`, then set `SKIP_STARTUP_MIGRATION=true` for the web container.
- Align dependencies to PostgreSQL 16 and Redis 7.
- Tune steady-state web resources to the tested passing profile: `300m` CPU / `256Mi` memory.
- Generate required Formbricks secrets from Sealos defaults.

**Documentation**
- Rewrite English and Chinese README content for the current template behavior.
- Clarify that there is no default username or password. The first account is created through Sign up/Create account after deployment.
- Document operational notes, troubleshooting, and upgrade behavior.

## Test Coverage

Template-only Kubernetes manifest and README change. No application code paths were added.

## Pre-Landing Review

No issues found in the template diff. Sensitive values are generated defaults or Kubernetes Secret references; no hardcoded real credentials were introduced.

## Design Review

No frontend source files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

Intent: update and stabilize the Formbricks Sealos template for Formbricks 4.9.7.

Delivered: template image/runtime updates, migration initContainer, resource tuning, and login docs.

## Plan Completion

No plan file detected.

## Verification Results

- `path_converter.py --self-test`: passed
- `check_consistency.py --artifacts template/formbricks/index.yaml`: passed, 35 rules
- `quality_gate.py` with `DOCKER_TO_SEALOS_ARTIFACTS=template/formbricks/index.yaml`: passed
- `git diff --check -- template/formbricks/...`: passed
- Fresh Sealos/Kubernetes deployment was tested during implementation: StatefulSet reached Ready, `/health` returned 200, signup/login routes returned 200 before final resource retune, and final 256Mi web memory profile remained stable after 60 seconds.
- Cleanup was verified: no `formbricks-test-*` Kubernetes resources remained.

## Test plan

- [x] Template validators pass for `template/formbricks/index.yaml`
- [x] Docker-to-Sealos quality gate passes for the Formbricks artifact
- [x] Whitespace validation passes
- [x] Deployment behavior verified in a temporary Sealos namespace during implementation

🤖 Generated with [OpenAI Codex](https://openai.com/codex)
