### PR TITLE
feat(insforge): update template to v2.1.8

### DIFF
--- a/template/insforge/README.md
+++ b/template/insforge/README.md
@@ -1,29 +1,30 @@
 # Deploy and Host InsForge on Sealos
 
-InsForge is an agent-native backend platform for building full-stack applications with database, authentication, storage, and function runtime capabilities. This template deploys InsForge as a multi-service stack with PostgreSQL, PostgREST, and Deno runtime on Sealos Cloud.
+InsForge is an agent-native backend platform for building full-stack applications with database, authentication, storage, REST API, and function runtime capabilities. This Sealos template deploys InsForge `v2.1.8` with PostgreSQL, PostgREST, and Deno Runtime as a ready-to-use backend stack.
 
 ## About Hosting InsForge
 
-InsForge on Sealos runs as a coordinated backend platform where the main InsForge service provides API, dashboard, and auth endpoints, while PostgREST exposes PostgreSQL as a REST layer and Deno runtime executes function workloads. The template also provisions PostgreSQL with required extensions and roles, so the core backend features work out of the box.
+InsForge on Sealos runs as a coordinated backend platform. The main InsForge service provides the dashboard, backend API, and authentication routes; PostgREST exposes PostgreSQL through a REST layer; Deno Runtime executes function workloads; and KubeBlocks PostgreSQL stores application data with persistent storage.
 
-The deployment includes persistent storage for application data, logs, and runtime cache, plus automatic HTTPS ingress and domain management. Sealos manages networking, certificates, and Kubernetes resources so you can focus on application logic instead of infrastructure.
+The template provisions the required database roles and extensions, prepares the PostgreSQL HTTP extension package, removes incompatible default monitoring extensions before InsForge migrations run, and exposes the dashboard through HTTPS Ingress. Sealos manages Kubernetes resources, networking, certificates, and persistent volumes so you can focus on application logic instead of infrastructure.
 
 ## Common Use Cases
 
-- **Agent-Native SaaS Backends**: Build and operate backend services that AI coding agents can provision and manage.
-- **Supabase-Style App Foundations**: Launch projects that need database, auth, and REST APIs with minimal setup.
-- **Internal Tools and Automation**: Create internal apps with secure authentication and server-side logic.
-- **Rapid MVP Development**: Prototype full-stack products quickly with a ready backend stack.
-- **AI Workflow Platforms**: Combine API access and function runtime for AI-assisted product workflows.
+- **Agent-native SaaS backends**: Build backend services that AI coding agents can provision and operate.
+- **Supabase-style app foundations**: Launch applications that need database, auth, storage, and REST APIs.
+- **Internal tools and automation**: Deploy authenticated tools with server-side logic and durable data.
+- **Rapid MVP development**: Start full-stack prototypes with a complete backend in minutes.
+- **AI workflow platforms**: Combine API access, database state, and function runtime for AI-assisted products.
 
 ## Dependencies for InsForge Hosting
 
-The Sealos template includes all required dependencies: InsForge core service, PostgreSQL, PostgREST, Deno runtime, ingress, and persistent volumes.
+The Sealos template includes the required runtime components: InsForge Core, PostgreSQL, PostgREST, Deno Runtime, initialization jobs, ingress, services, and persistent volumes.
 
 ### Deployment Dependencies
 
 - [InsForge Official Website](https://insforge.dev) - Product overview and updates
 - [InsForge GitHub Repository](https://github.com/insforge/insforge) - Source code and release details
+- [InsForge v2.1.8 Release](https://github.com/InsForge/InsForge/releases/tag/v2.1.8) - Version used by this template
 - [InsForge GitHub Issues](https://github.com/insforge/insforge/issues) - Issue tracking and community support
 - [Sealos Cloud](https://sealos.io) - Deployment platform
 
@@ -33,24 +34,33 @@ The Sealos template includes all required dependencies: InsForge core service, P
 
 This template deploys the following services:
 
-- **InsForge Core (StatefulSet)**: Main service on ports `7130` (API), `7131` (dashboard), and `7132` (auth).
-- **PostgreSQL Cluster (KubeBlocks)**: PostgreSQL `16.4.0` with persistent data storage.
-- **PostgreSQL Extension Init Job**: Installs and enables `pg_cron`, `http`, and `pgcrypto`, and ensures required roles exist.
+- **InsForge Core (StatefulSet)**: Main service on ports `7130` (API/dashboard), `7131`, and `7132`, using `ghcr.io/insforge/insforge-oss:v2.1.8`.
+- **PostgreSQL Cluster (KubeBlocks)**: PostgreSQL `16.4.0` with a `1Gi` persistent data volume.
+- **PostgreSQL Extension Init Job**: Installs the HTTP extension package, enables `pg_cron`, `http`, and `pgcrypto`, creates required roles, and removes incompatible `pg_auth_mon`, `pg_stat_kcache`, and `pg_stat_statements` extensions before migrations.
 - **PostgreSQL Extension Ensure CronJob**: Re-checks extension availability every 5 minutes for operational resilience.
 - **PostgREST (Deployment)**: REST gateway on port `3000` with JWT integration.
-- **Deno Runtime (StatefulSet)**: Function runtime on port `7133` for backend execution tasks.
+- **Deno Runtime (StatefulSet)**: Function runtime on port `7133`, using `ghcr.io/insforge/deno-runtime:2.0.6`.
 - **Ingress + Service Resources**: Public HTTPS endpoint with automatic TLS and internal service discovery.
 
 **Configuration:**
 
 - **Required input**: `admin_password`
 - **Optional inputs**: `admin_email`, `openrouter_api_key`, and OAuth credentials for Google, GitHub, Discord, Microsoft, LinkedIn, X, and Apple
-- **Security defaults**: Randomized `JWT_SECRET` and `ENCRYPTION_KEY` are generated automatically
+- **Security defaults**: `JWT_SECRET` and `ENCRYPTION_KEY` are generated automatically by the template
 - **Storage defaults**:
-  - InsForge storage: `/insforge-storage` (103Mi)
-  - InsForge logs: `/insforge-logs` (103Mi)
-  - Deno runtime cache: `/deno-dir` (103Mi)
+  - InsForge storage: `/insforge-storage` (`103Mi`)
+  - InsForge logs: `/insforge-logs` (`103Mi`)
+  - Deno runtime cache: `/deno-dir` (`103Mi`)
   - PostgreSQL data volume: `1Gi`
+
+**Tested minimum resources:**
+
+The template was deployed and verified with the following minimum resource settings:
+
+- InsForge Core: `20m` CPU / `25Mi` memory requests, `200m` CPU / `256Mi` memory limits
+- PostgREST: `20m` CPU / `25Mi` memory requests, `200m` CPU / `256Mi` memory limits
+- Deno Runtime: `20m` CPU / `25Mi` memory requests, `200m` CPU / `256Mi` memory limits
+- PostgreSQL: `50m` CPU / `51Mi` memory requests, `500m` CPU / `512Mi` memory limits, `1Gi` storage
 
 **License Information:**
 
@@ -60,13 +70,12 @@ InsForge is open-source software. Refer to the upstream repository for the lates
 
 Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies development, deployment, and operations. By deploying InsForge on Sealos, you get:
 
-- **One-Click Deployment**: Launch a multi-service backend stack without manual YAML orchestration.
-- **Built-In Kubernetes Reliability**: Use Kubernetes scheduling, service discovery, and restart behavior by default.
-- **Easy Configuration**: Manage environment variables and resource settings through Sealos forms and dialogs.
-- **Persistent Storage Included**: Keep database and service data durable across restarts.
-- **Automatic HTTPS Access**: Receive a public URL with SSL certificate provisioning.
-- **Pay-as-You-Go Efficiency**: Allocate only the resources you need and scale when demand grows.
-- **AI-Assisted Operations**: Use Canvas and AI dialog workflows for post-deployment changes.
+- **One-click deployment**: Launch a multi-service backend stack without manual YAML orchestration.
+- **Built-in Kubernetes reliability**: Use scheduling, service discovery, persistent storage, and restart behavior by default.
+- **Easy configuration**: Manage environment variables and resource settings through Sealos forms and dialogs.
+- **Automatic HTTPS access**: Receive a public URL with SSL certificate provisioning.
+- **Pay-as-you-go efficiency**: Start with small resources and scale when demand grows.
+- **AI-assisted operations**: Use Canvas and AI dialog workflows for post-deployment changes.
 
 Deploy InsForge on Sealos and focus on shipping product features instead of managing infrastructure.
 
@@ -74,52 +83,66 @@ Deploy InsForge on Sealos and focus on shipping product features instead of mana
 
 1. Open the [InsForge template](https://sealos.io/products/app-store/insforge) and click **Deploy Now**.
 2. Configure parameters in the popup dialog:
-   - **admin_password** (required): Administrator password
-   - **admin_email** (optional): Administrator email
-   - **openrouter_api_key** (optional): OpenRouter integration key
-   - **OAuth client settings** (optional): Google, GitHub, Discord, Microsoft, LinkedIn, X, Apple
-3. Wait for deployment to complete (typically 2-3 minutes). After deployment, you will be redirected to the Canvas. For later changes, describe requirements in the dialog for AI-assisted updates, or click resource cards to adjust settings.
-4. Access your application using the generated public URL:
-   - **InsForge Web/API Endpoint**: Main entrypoint served through HTTPS ingress
+   - **admin_password** (required): Administrator password. Use a strong value; do not keep the example password in production.
+   - **admin_email** (optional): Administrator email. The default is `admin@example.com`.
+   - **openrouter_api_key** (optional): OpenRouter integration key.
+   - **OAuth client settings** (optional): Google, GitHub, Discord, Microsoft, LinkedIn, X, and Apple provider credentials.
+3. Wait for deployment to complete. The stack is normally ready in about 2-3 minutes after PostgreSQL initialization and migrations finish.
+4. Access the generated public URL. The root path redirects to `/dashboard/login`, where you can sign in to the InsForge dashboard.
+
+## Login and Registration
+
+After deployment, open the generated public URL and go to `/dashboard/login`.
+
+- **Admin dashboard login**: Use the `admin_email` and `admin_password` values from the deployment dialog.
+- **API admin login endpoint**: `POST /api/auth/admin/sessions` with JSON body `{ "email": "<admin_email>", "password": "<admin_password>" }`.
+- **End-user registration**: The public auth API accepts `POST /api/auth/users` with an email and password when signup is enabled. The default auth config has `disableSignup: false`; you can adjust auth settings in the dashboard under Authentication.
+- **End-user login**: Use `POST /api/auth/sessions` with the registered email and password, or configure OAuth providers in the dashboard/deployment inputs.
+
+For production, replace the default admin email, choose a strong admin password, and configure OAuth or SMTP settings before inviting users.
 
 ## Configuration
 
 After deployment, you can configure InsForge through:
 
-- **AI Dialog**: Describe desired changes and let AI apply updates
-- **Resource Cards**: Edit StatefulSet/Deployment resources and environment variables
-- **Admin Credentials**: Update admin email/password and OAuth settings through deployment config
-- **Service Connectivity**: Keep internal service endpoints (`postgrest`, `deno`, `postgres`) managed by cluster DNS
+- **Dashboard**: Manage Authentication settings, users, providers, and project configuration after admin login.
+- **AI Dialog**: Describe desired changes and let Sealos apply updates.
+- **Resource Cards**: Edit StatefulSet/Deployment resources and environment variables.
+- **Service Connectivity**: Internal service endpoints for PostgREST, Deno Runtime, and PostgreSQL are managed by cluster DNS.
 
 ## Scaling
 
 To scale your InsForge deployment:
 
 1. Open the Canvas for your InsForge deployment.
-2. Select the relevant resource card (`insforge`, `insforge-postgrest`, or `insforge-deno`).
-3. Adjust CPU/Memory resources as needed.
+2. Select the relevant resource card (`insforge`, `insforge-postgrest`, `insforge-deno`, or PostgreSQL).
+3. Adjust CPU, memory, and storage resources as needed.
 4. Apply changes in the dialog.
 
-For higher throughput scenarios, prioritize vertical scaling of PostgreSQL and InsForge core resources before introducing topology changes.
+For higher throughput scenarios, prioritize vertical scaling of PostgreSQL and InsForge Core resources before introducing topology changes.
 
 ## Troubleshooting
 
 ### Common Issues
 
 **Issue: Initial startup takes longer than expected**
-- Cause: PostgreSQL extensions and role initialization jobs are still running.
-- Solution: Wait for init jobs to complete, then recheck pod readiness.
+- Cause: PostgreSQL startup, extension initialization, and InsForge migrations are still running.
+- Solution: Wait for the init job to complete, then recheck pod readiness.
 
-**Issue: Authentication or JWT-related API errors**
-- Cause: Misconfigured `JWT_SECRET` or mismatched auth settings.
-- Solution: Verify deployment environment variables and reapply correct values.
+**Issue: Dashboard login fails**
+- Cause: Incorrect `admin_email` or `admin_password`.
+- Solution: Confirm the values used in the deployment dialog and update the deployment secret/config if needed.
+
+**Issue: End-user signup or login fails**
+- Cause: Signup may be disabled, password policy may reject the value, or OAuth/SMTP settings may be incomplete.
+- Solution: Log in as admin, open Authentication settings, and verify signup, password, OAuth, and email configuration.
 
 **Issue: OAuth login not working**
 - Cause: Missing or invalid OAuth client ID/secret configuration.
-- Solution: Reconfigure provider credentials in deployment settings and restart affected pods.
+- Solution: Reconfigure provider credentials and restart affected pods if required.
 
 **Issue: Runtime function failures**
-- Cause: Deno runtime service not ready or internal connectivity issue.
+- Cause: Deno Runtime service is not ready or internal connectivity is unavailable.
 - Solution: Check `insforge-deno` pod status and verify internal service DNS resolution.
 
 ### Getting Help

--- a/template/insforge/README.md
+++ b/template/insforge/README.md
@@ -36,7 +36,7 @@ This template deploys the following services:
 
 - **InsForge Core (StatefulSet)**: Main service on ports `7130` (API/dashboard), `7131`, and `7132`, using `ghcr.io/insforge/insforge-oss:v2.1.8`.
 - **PostgreSQL Cluster (KubeBlocks)**: PostgreSQL `16.4.0` with a `1Gi` persistent data volume.
-- **PostgreSQL Extension Init Job**: Installs the HTTP extension package, enables `pg_cron`, `http`, and `pgcrypto`, creates required roles, and removes incompatible `pg_auth_mon`, `pg_stat_kcache`, and `pg_stat_statements` extensions before migrations.
+- **PostgreSQL Extension Init Job**: Installs the HTTP extension package, prepares compatibility log files for the default `postgres_log` foreign tables, enables `pg_cron`, `http`, and `pgcrypto`, creates required roles, and removes incompatible `pg_auth_mon`, `pg_stat_kcache`, and `pg_stat_statements` extensions before migrations.
 - **PostgreSQL Extension Ensure CronJob**: Re-checks extension availability every 5 minutes for operational resilience.
 - **PostgREST (Deployment)**: REST gateway on port `3000` with JWT integration.
 - **Deno Runtime (StatefulSet)**: Function runtime on port `7133`, using `ghcr.io/insforge/deno-runtime:2.0.6`.
@@ -98,6 +98,7 @@ After deployment, open the generated public URL and go to `/dashboard/login`.
 - **API admin login endpoint**: `POST /api/auth/admin/sessions` with JSON body `{ "email": "<admin_email>", "password": "<admin_password>" }`.
 - **End-user registration**: The public auth API accepts `POST /api/auth/users` with an email and password when signup is enabled. The default auth config has `disableSignup: false`; you can adjust auth settings in the dashboard under Authentication.
 - **End-user login**: Use `POST /api/auth/sessions` with the registered email and password, or configure OAuth providers in the dashboard/deployment inputs.
+- **Compute services**: The dashboard may show compute-service setup warnings unless you configure a supported compute provider such as Fly.io with `FLY_API_TOKEN` and `FLY_ORG`. This does not affect database, auth, storage, or dashboard access.
 
 For production, replace the default admin email, choose a strong admin password, and configure OAuth or SMTP settings before inviting users.
 
@@ -140,6 +141,10 @@ For higher throughput scenarios, prioritize vertical scaling of PostgreSQL and I
 **Issue: OAuth login not working**
 - Cause: Missing or invalid OAuth client ID/secret configuration.
 - Solution: Reconfigure provider credentials and restart affected pods if required.
+
+**Issue: Compute services show “not configured”**
+- Cause: Self-hosted compute requires external provider credentials such as `FLY_API_TOKEN` and `FLY_ORG`.
+- Solution: Configure a supported compute provider before using compute-service deployment features. Other core features can continue running without compute.
 
 **Issue: Runtime function failures**
 - Cause: Deno Runtime service is not ready or internal connectivity is unavailable.

--- a/template/insforge/README_zh.md
+++ b/template/insforge/README_zh.md
@@ -36,7 +36,7 @@ InsForge 是一个面向 AI 代理（Agent）的后端平台，提供数据库�
 
 - **InsForge Core（StatefulSet）**：主服务，开放 `7130`（API/Dashboard）、`7131` 与 `7132`，镜像为 `ghcr.io/insforge/insforge-oss:v2.1.8`。
 - **PostgreSQL Cluster（KubeBlocks）**：PostgreSQL `16.4.0`，使用 `1Gi` 持久化数据卷。
-- **PostgreSQL 扩展初始化 Job**：安装 HTTP 扩展包，启用 `pg_cron`、`http`、`pgcrypto`，创建所需角色，并在迁移前移除不兼容的 `pg_auth_mon`、`pg_stat_kcache`、`pg_stat_statements` 扩展。
+- **PostgreSQL 扩展初始化 Job**：安装 HTTP 扩展包，为默认 `postgres_log` foreign table 准备兼容日志文件，启用 `pg_cron`、`http`、`pgcrypto`，创建所需角色，并在迁移前移除不兼容的 `pg_auth_mon`、`pg_stat_kcache`、`pg_stat_statements` 扩展。
 - **PostgreSQL 扩展巡检 CronJob**：每 5 分钟复查扩展可用性，提升运行稳定性。
 - **PostgREST（Deployment）**：`3000` 端口 REST 网关，集成 JWT 配置。
 - **Deno Runtime（StatefulSet）**：`7133` 端口函数运行时，镜像为 `ghcr.io/insforge/deno-runtime:2.0.6`。
@@ -98,6 +98,7 @@ Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发
 - **管理员 API 登录接口**：`POST /api/auth/admin/sessions`，JSON 请求体为 `{ "email": "<admin_email>", "password": "<admin_password>" }`。
 - **终端用户注册**：当注册未被禁用时，公开认证 API 支持 `POST /api/auth/users`，提交邮箱和密码即可注册。默认认证配置中 `disableSignup: false`；你也可以在 Dashboard 的 Authentication 页面调整注册策略。
 - **终端用户登录**：使用 `POST /api/auth/sessions` 提交已注册用户的邮箱和密码，或在 Dashboard/部署参数中配置 OAuth Provider 后使用第三方登录。
+- **Compute services**：如果未配置 Fly.io 等计算服务提供商，Dashboard 可能显示 compute-service 未配置提示。该提示不影响数据库、认证、存储与 Dashboard 访问。
 
 生产环境建议先替换默认管理员邮箱，设置强密码，并在邀请用户前配置 OAuth 或 SMTP。
 
@@ -140,6 +141,10 @@ Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发
 **问题：OAuth 登录失败**
 - 原因：OAuth client ID/secret 缺失或填写错误。
 - 解决方案：重新配置 Provider 凭据，必要时重启相关 Pod。
+
+**问题：Compute services 显示未配置**
+- 原因：自托管 compute 需要配置外部提供商凭据，例如 `FLY_API_TOKEN` 和 `FLY_ORG`。
+- 解决方案：使用 compute-service 部署能力前先配置支持的计算服务提供商；未配置时，其它核心功能仍可正常使用。
 
 **问题：函数运行失败**
 - 原因：Deno Runtime 服务未就绪，或内部连通性异常。

--- a/template/insforge/README_zh.md
+++ b/template/insforge/README_zh.md
@@ -1,31 +1,32 @@
 # 在 Sealos 上部署并托管 InsForge
 
-InsForge 是一个面向 AI 代理（Agent）的后端平台，提供数据库、认证、存储与函数运行时能力，用于快速构建全栈应用。该模板会在 Sealos Cloud 上部署由 PostgreSQL、PostgREST 和 Deno Runtime 组成的 InsForge 多服务栈。
+InsForge 是一个面向 AI 代理（Agent）的后端平台，提供数据库、认证、存储、REST API 与函数运行时能力，用于快速构建全栈应用。该 Sealos 模板会部署 InsForge `v2.1.8`，并配套 PostgreSQL、PostgREST 与 Deno Runtime，形成可直接使用的后端栈。
 
 ## 关于在 Sealos 托管 InsForge
 
-在 Sealos 上，InsForge 以协同架构运行：主服务提供 API、控制台与认证端点；PostgREST 将 PostgreSQL 暴露为 REST 接口；Deno Runtime 负责函数执行任务。模板还会自动准备 PostgreSQL 所需扩展和角色，确保核心后端能力开箱即用。
+在 Sealos 上，InsForge 以多服务协同架构运行：主服务提供 Dashboard、后端 API 与认证路由；PostgREST 将 PostgreSQL 暴露为 REST 接口；Deno Runtime 负责函数执行；KubeBlocks PostgreSQL 负责持久化数据存储。
 
-部署同时包含应用数据、日志和运行时缓存的持久化存储，并自动配置 HTTPS Ingress 与公网域名。Sealos 负责网络、证书和 Kubernetes 资源编排，你可以把重点放在业务功能本身。
+模板会自动创建所需数据库角色和扩展，准备 PostgreSQL HTTP 扩展包，并在 InsForge 迁移执行前移除与迁移不兼容的默认监控扩展，然后通过 HTTPS Ingress 暴露控制台。Sealos 负责 Kubernetes 资源、网络、证书与持久卷管理，你可以专注于业务逻辑。
 
 ## 常见使用场景
 
-- **Agent 原生 SaaS 后端**：构建可由 AI 编码代理创建和维护的后端服务。
-- **Supabase 风格基础设施**：低成本启动带数据库、认证和 REST API 的应用底座。
-- **内部工具与自动化系统**：快速搭建具备安全认证与服务端逻辑的内部系统。
-- **MVP 快速验证**：借助完整后端栈，在更短时间内完成产品原型。
-- **AI 工作流平台**：将 API 能力与函数运行时结合，支撑 AI 辅助业务流程。
+- **Agent 原生 SaaS 后端**：构建可由 AI 编码代理创建和运维的后端服务。
+- **Supabase 风格应用底座**：快速启动需要数据库、认证、存储与 REST API 的应用。
+- **内部工具与自动化系统**：部署具备认证、服务端逻辑和持久数据的内部应用。
+- **MVP 快速验证**：用完整后端栈更快完成全栈原型。
+- **AI 工作流平台**：结合 API、数据库状态和函数运行时，支撑 AI 辅助产品。
 
 ## InsForge 托管依赖
 
-该 Sealos 模板已包含 InsForge 运行所需核心依赖：InsForge 主服务、PostgreSQL、PostgREST、Deno Runtime、Ingress 与持久卷。
+该 Sealos 模板已包含运行所需组件：InsForge Core、PostgreSQL、PostgREST、Deno Runtime、初始化任务、Ingress、Service 与持久卷。
 
 ### 部署依赖
 
 - [InsForge 官方网站](https://insforge.dev) - 产品介绍与更新信息
 - [InsForge GitHub 仓库](https://github.com/insforge/insforge) - 源码与版本发布
+- [InsForge v2.1.8 Release](https://github.com/InsForge/InsForge/releases/tag/v2.1.8) - 当前模板使用版本
 - [InsForge GitHub Issues](https://github.com/insforge/insforge/issues) - 问题追踪与社区支持
-- [Sealos Cloud](https://sealos.run) - 部署平台
+- [Sealos Cloud](https://sealos.io) - 部署平台
 
 ### 实现细节
 
@@ -33,24 +34,33 @@ InsForge 是一个面向 AI 代理（Agent）的后端平台，提供数据库�
 
 该模板会部署以下服务：
 
-- **InsForge Core（StatefulSet）**：主服务，开放 `7130`（API）、`7131`（dashboard）、`7132`（auth）。
-- **PostgreSQL Cluster（KubeBlocks）**：PostgreSQL `16.4.0`，提供持久化数据存储。
-- **PostgreSQL 扩展初始化 Job**：安装并启用 `pg_cron`、`http`、`pgcrypto`，并确保所需角色存在。
+- **InsForge Core（StatefulSet）**：主服务，开放 `7130`（API/Dashboard）、`7131` 与 `7132`，镜像为 `ghcr.io/insforge/insforge-oss:v2.1.8`。
+- **PostgreSQL Cluster（KubeBlocks）**：PostgreSQL `16.4.0`，使用 `1Gi` 持久化数据卷。
+- **PostgreSQL 扩展初始化 Job**：安装 HTTP 扩展包，启用 `pg_cron`、`http`、`pgcrypto`，创建所需角色，并在迁移前移除不兼容的 `pg_auth_mon`、`pg_stat_kcache`、`pg_stat_statements` 扩展。
 - **PostgreSQL 扩展巡检 CronJob**：每 5 分钟复查扩展可用性，提升运行稳定性。
 - **PostgREST（Deployment）**：`3000` 端口 REST 网关，集成 JWT 配置。
-- **Deno Runtime（StatefulSet）**：`7133` 端口函数运行时，执行后端任务。
+- **Deno Runtime（StatefulSet）**：`7133` 端口函数运行时，镜像为 `ghcr.io/insforge/deno-runtime:2.0.6`。
 - **Ingress + Service 资源**：提供公网 HTTPS 入口与集群内服务发现。
 
 **配置说明：**
 
 - **必填参数**：`admin_password`
 - **可选参数**：`admin_email`、`openrouter_api_key`，以及 Google、GitHub、Discord、Microsoft、LinkedIn、X、Apple 的 OAuth 凭据
-- **安全默认值**：`JWT_SECRET` 与 `ENCRYPTION_KEY` 自动随机生成
+- **安全默认值**：`JWT_SECRET` 与 `ENCRYPTION_KEY` 由模板自动随机生成
 - **默认存储配置**：
-  - InsForge 数据目录：`/insforge-storage`（103Mi）
-  - InsForge 日志目录：`/insforge-logs`（103Mi）
-  - Deno 运行时缓存：`/deno-dir`（103Mi）
+  - InsForge 数据目录：`/insforge-storage`（`103Mi`）
+  - InsForge 日志目录：`/insforge-logs`（`103Mi`）
+  - Deno 运行时缓存：`/deno-dir`（`103Mi`）
   - PostgreSQL 数据卷：`1Gi`
+
+**已验证的最小资源：**
+
+该模板已在以下资源配置下完成部署和访问验证：
+
+- InsForge Core：请求 `20m` CPU / `25Mi` 内存，限制 `200m` CPU / `256Mi` 内存
+- PostgREST：请求 `20m` CPU / `25Mi` 内存，限制 `200m` CPU / `256Mi` 内存
+- Deno Runtime：请求 `20m` CPU / `25Mi` 内存，限制 `200m` CPU / `256Mi` 内存
+- PostgreSQL：请求 `50m` CPU / `51Mi` 内存，限制 `500m` CPU / `512Mi` 内存，存储 `1Gi`
 
 **许可证信息：**
 
@@ -58,14 +68,13 @@ InsForge 为开源软件，具体许可证条款请以上游仓库最新说明�
 
 ## 为什么在 Sealos 上部署 InsForge？
 
-Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发、部署与运维全流程。将 InsForge 部署到 Sealos，你可以获得：
+Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发、部署与运维流程。将 InsForge 部署到 Sealos，你可以获得：
 
 - **一键部署**：无需手写复杂 YAML，即可拉起完整多服务后端栈。
-- **Kubernetes 级可靠性**：默认具备调度、服务发现和自动恢复能力。
+- **Kubernetes 级可靠性**：默认具备调度、服务发现、持久化存储和自动恢复能力。
 - **配置简单直观**：通过 Sealos 表单与对话框管理环境变量和资源规格。
-- **持久化存储内置**：数据库和应用数据可跨重启稳定保留。
 - **自动 HTTPS 公网访问**：自动分配公网地址并签发 SSL 证书。
-- **按量计费更高效**：按需分配资源，业务增长时再扩容。
+- **按量计费更高效**：以较小资源启动，业务增长后再扩容。
 - **AI 辅助运维**：可通过 Canvas 与 AI 对话完成部署后变更。
 
 将 InsForge 部署到 Sealos 后，你可以把精力集中在产品交付，而不是基础设施维护。
@@ -74,30 +83,40 @@ Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发
 
 1. 打开 [InsForge 模板页面](https://sealos.io/products/app-store/insforge)，点击 **Deploy Now**。
 2. 在弹窗中配置参数：
-   - **admin_password**（必填）：管理员密码
-   - **admin_email**（可选）：管理员邮箱
-   - **openrouter_api_key**（可选）：OpenRouter 集成密钥
-   - **OAuth client settings**（可选）：Google、GitHub、Discord、Microsoft、LinkedIn、X、Apple
-3. 等待部署完成（通常 2-3 分钟）。完成后会自动跳转到 Canvas。后续如需调整，可在对话框描述需求让 AI 应用变更，或点击资源卡片手动修改。
-4. 通过生成的公网地址访问应用：
-   - **InsForge Web/API Endpoint**：经 HTTPS Ingress 暴露的主入口
+   - **admin_password**（必填）：管理员密码。生产环境请使用强密码，不要保留示例密码。
+   - **admin_email**（可选）：管理员邮箱，默认值为 `admin@example.com`。
+   - **openrouter_api_key**（可选）：OpenRouter 集成密钥。
+   - **OAuth client settings**（可选）：Google、GitHub、Discord、Microsoft、LinkedIn、X、Apple 的 OAuth 凭据。
+3. 等待部署完成。PostgreSQL 初始化和迁移完成后，通常约 2-3 分钟可就绪。
+4. 通过生成的公网地址访问应用。根路径会跳转到 `/dashboard/login`，可在此登录 InsForge Dashboard。
+
+## 登录与注册
+
+部署完成后，打开生成的公网地址并进入 `/dashboard/login`。
+
+- **管理员控制台登录**：使用部署弹窗中的 `admin_email` 和 `admin_password`。
+- **管理员 API 登录接口**：`POST /api/auth/admin/sessions`，JSON 请求体为 `{ "email": "<admin_email>", "password": "<admin_password>" }`。
+- **终端用户注册**：当注册未被禁用时，公开认证 API 支持 `POST /api/auth/users`，提交邮箱和密码即可注册。默认认证配置中 `disableSignup: false`；你也可以在 Dashboard 的 Authentication 页面调整注册策略。
+- **终端用户登录**：使用 `POST /api/auth/sessions` 提交已注册用户的邮箱和密码，或在 Dashboard/部署参数中配置 OAuth Provider 后使用第三方登录。
+
+生产环境建议先替换默认管理员邮箱，设置强密码，并在邀请用户前配置 OAuth 或 SMTP。
 
 ## 配置
 
 部署完成后，可通过以下方式配置 InsForge：
 
-- **AI Dialog**：用自然语言描述你要调整的内容，由 AI 自动应用。
+- **Dashboard**：管理员登录后管理 Authentication 设置、用户、Provider 和项目配置。
+- **AI Dialog**：用自然语言描述调整内容，由 Sealos 应用变更。
 - **Resource Cards**：在 StatefulSet/Deployment 资源卡片中修改环境变量和资源规格。
-- **管理员凭据**：在部署配置中更新管理员邮箱/密码与 OAuth 参数。
-- **服务连通性**：`postgrest`、`deno`、`postgres` 通过集群 DNS 自动管理内部通信。
+- **服务连通性**：PostgREST、Deno Runtime 与 PostgreSQL 的内部访问由集群 DNS 自动管理。
 
 ## 扩缩容
 
 如需扩展 InsForge 部署能力：
 
 1. 在 Canvas 中打开 InsForge 部署。
-2. 选择目标资源卡片（`insforge`、`insforge-postgrest` 或 `insforge-deno`）。
-3. 按需调整 CPU/内存配置。
+2. 选择目标资源卡片（`insforge`、`insforge-postgrest`、`insforge-deno` 或 PostgreSQL）。
+3. 按需调整 CPU、内存和存储配置。
 4. 在弹窗中应用变更。
 
 在高吞吐场景下，建议先对 PostgreSQL 与 InsForge Core 做纵向扩容，再评估更复杂的拓扑调整。
@@ -107,16 +126,20 @@ Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发
 ### 常见问题
 
 **问题：首次启动时间明显偏长**
-- 原因：PostgreSQL 扩展与角色初始化任务仍在执行。
-- 解决方案：等待初始化任务完成后，再检查相关 Pod 就绪状态。
+- 原因：PostgreSQL 启动、扩展初始化和 InsForge 数据库迁移仍在执行。
+- 解决方案：等待初始化 Job 完成后，再检查相关 Pod 就绪状态。
 
-**问题：认证或 JWT 相关 API 报错**
-- 原因：`JWT_SECRET` 配置错误，或认证配置不一致。
-- 解决方案：核对部署环境变量并重新应用正确值。
+**问题：Dashboard 登录失败**
+- 原因：`admin_email` 或 `admin_password` 填写错误。
+- 解决方案：确认部署弹窗中使用的值，必要时更新部署配置。
+
+**问题：终端用户注册或登录失败**
+- 原因：注册可能被禁用、密码不符合策略，或 OAuth/SMTP 配置未完成。
+- 解决方案：以管理员身份登录，进入 Authentication 设置检查注册、密码、OAuth 与邮件配置。
 
 **问题：OAuth 登录失败**
 - 原因：OAuth client ID/secret 缺失或填写错误。
-- 解决方案：在部署参数中重新配置凭据，并重启受影响 Pod。
+- 解决方案：重新配置 Provider 凭据，必要时重启相关 Pod。
 
 **问题：函数运行失败**
 - 原因：Deno Runtime 服务未就绪，或内部连通性异常。
@@ -132,7 +155,7 @@ Sealos 是构建于 Kubernetes 之上的 AI 辅助云操作系统，覆盖开发
 ## 更多资源
 
 - [InsForge 源码仓库](https://github.com/insforge/insforge)
-- [Sealos 文档](https://sealos.run/docs)
+- [Sealos 文档](https://sealos.io/docs)
 - [Sealos 应用商店](https://sealos.io/products/app-store)
 
 ## 许可证

--- a/template/insforge/index.yaml
+++ b/template/insforge/index.yaml
@@ -169,6 +169,7 @@ metadata:
     kb.io/database: postgresql-16.4.0
     clusterdefinition.kubeblocks.io/name: postgresql
     clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 spec:
   affinity:
     podAntiAffinity: Preferred
@@ -279,11 +280,11 @@ spec:
               set -eu
 
               kubectl wait --for=condition=Ready pod \
-                -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,app.kubernetes.io/component=postgresql" \
+                -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,apps.kubeblocks.io/component-name=postgresql" \
                 --timeout=600s
 
               PG_POD="$(kubectl get pod \
-                -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,app.kubernetes.io/component=postgresql" \
+                -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,apps.kubeblocks.io/component-name=postgresql" \
                 -o jsonpath='{.items[0].metadata.name}')"
 
               kubectl exec -i "${PG_POD}" -c postgresql -- bash -s <<'EOS'
@@ -295,6 +296,9 @@ spec:
               ls /usr/share/postgresql/16/extension/http.control /usr/lib/postgresql/16/lib/http.so >/dev/null
 
               psql -v ON_ERROR_STOP=1 -d postgres <<'SQL'
+              DROP EXTENSION IF EXISTS pg_auth_mon CASCADE;
+              DROP EXTENSION IF EXISTS pg_stat_kcache CASCADE;
+              DROP EXTENSION IF EXISTS pg_stat_statements CASCADE;
               CREATE EXTENSION IF NOT EXISTS pg_cron;
               CREATE EXTENSION IF NOT EXISTS http;
               CREATE EXTENSION IF NOT EXISTS pgcrypto;
@@ -358,11 +362,11 @@ spec:
                   set -eu
 
                   kubectl wait --for=condition=Ready pod \
-                    -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,app.kubernetes.io/component=postgresql" \
+                    -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,apps.kubeblocks.io/component-name=postgresql" \
                     --timeout=300s
 
                   PG_POD="$(kubectl get pod \
-                    -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,app.kubernetes.io/component=postgresql" \
+                    -l "app.kubernetes.io/instance=${{ defaults.app_name }}-pg,apps.kubeblocks.io/component-name=postgresql" \
                     -o jsonpath='{.items[0].metadata.name}')"
 
                   kubectl exec -i "${PG_POD}" -c postgresql -- bash -s <<'EOS'
@@ -374,6 +378,9 @@ spec:
                   fi
 
                   psql -v ON_ERROR_STOP=1 -d postgres <<'SQL'
+                  DROP EXTENSION IF EXISTS pg_auth_mon CASCADE;
+                  DROP EXTENSION IF EXISTS pg_stat_kcache CASCADE;
+                  DROP EXTENSION IF EXISTS pg_stat_statements CASCADE;
                   CREATE EXTENSION IF NOT EXISTS pg_cron;
                   CREATE EXTENSION IF NOT EXISTS http;
                   CREATE EXTENSION IF NOT EXISTS pgcrypto;
@@ -398,12 +405,13 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/insforge/insforge-oss:v1.5.0
+    originImageName: ghcr.io/insforge/insforge-oss:v2.1.8
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -420,6 +428,13 @@ spec:
         - name: wait-db-prerequisites
           image: postgres:16-alpine
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
           env:
             - name: SEALOS_DATABASE_POSTGRES_HOST
               valueFrom:
@@ -470,7 +485,7 @@ spec:
               done
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/insforge/insforge-oss:v1.5.0
+          image: ghcr.io/insforge/insforge-oss:v2.1.8
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/template/insforge/index.yaml
+++ b/template/insforge/index.yaml
@@ -295,6 +295,12 @@ spec:
 
               ls /usr/share/postgresql/16/extension/http.control /usr/lib/postgresql/16/lib/http.so >/dev/null
 
+              mkdir -p /home/postgres/pgdata/pgroot/pg_log
+              for i in 0 1 2 3 4 5 6 7; do
+                touch "/home/postgres/pgdata/pgroot/pg_log/postgresql-${i}.csv"
+              done
+              chown -R postgres:postgres /home/postgres/pgdata/pgroot/pg_log
+
               psql -v ON_ERROR_STOP=1 -d postgres <<'SQL'
               DROP EXTENSION IF EXISTS pg_auth_mon CASCADE;
               DROP EXTENSION IF EXISTS pg_stat_kcache CASCADE;
@@ -376,6 +382,12 @@ spec:
                     apt-get update
                     DEBIAN_FRONTEND=noninteractive apt-get install -y --reinstall postgresql-16-http
                   fi
+
+                  mkdir -p /home/postgres/pgdata/pgroot/pg_log
+                  for i in 0 1 2 3 4 5 6 7; do
+                    touch "/home/postgres/pgdata/pgroot/pg_log/postgresql-${i}.csv"
+                  done
+                  chown -R postgres:postgres /home/postgres/pgdata/pgroot/pg_log
 
                   psql -v ON_ERROR_STOP=1 -d postgres <<'SQL'
                   DROP EXTENSION IF EXISTS pg_auth_mon CASCADE;


### PR DESCRIPTION
## Summary

- Update the InsForge template image to `ghcr.io/insforge/insforge-oss:v2.1.8`
- Fix PostgreSQL initialization for KubeBlocks by using the actual PostgreSQL pod selector and removing incompatible default monitoring extensions before InsForge migrations
- Document tested minimum resources, dashboard login, admin API login, public user registration, and user login flows in English and Chinese READMEs

## Validation

- Parsed `template/insforge/index.yaml` as 18 YAML documents
- Ran `docker-to-sealos` artifact consistency check: passed 35 rules
- Ran `docker-to-sealos` MUST coverage check: passed
- Deployed on Sealos USW test workspace and verified:
  - app pod, PostgREST, Deno Runtime, and PostgreSQL became ready
  - `/api/health` returned version `2.1.8`
  - `/dashboard/login` loaded
  - `POST /api/auth/admin/sessions` worked with configured admin credentials
  - `POST /api/auth/users` worked for public signup when signup is enabled
  - `POST /api/auth/sessions` worked for end-user login
- Removed all online test deployments, including Instance resources and remaining PVCs
