### PR TITLE
fix(influxdb): update Sealos template resources and docs

### DIFF
--- a/template/influxdb/README.md
+++ b/template/influxdb/README.md
@@ -1,27 +1,126 @@
-# influxdb
+# Deploy and Host InfluxDB on Sealos
 
-## Overview
+InfluxDB is an open source time series database for real-time analytics, metrics, events, and IoT data. This template deploys InfluxDB 2.9.1 with persistent storage, a compact default resource profile, and a public web UI on Sealos Cloud.
 
-Real-time insights from any time series data with a single, purpose-built database. Run at any scale in any environment in the cloud, on-premises, or at the edge.
+## About Hosting InfluxDB
 
-This Sealos template deploys **influxdb** as the `influxdb` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+InfluxDB stores timestamped measurements and provides a queryable platform for dashboards, alerting systems, observability pipelines, and sensor data. This Sealos template runs InfluxDB as a single StatefulSet with a persistent volume mounted at `/var/lib/influxdb2`, so databases, buckets, tokens, and metadata survive restarts.
 
-## Deploy on Sealos
+During first startup, the template initializes an admin user, organization, bucket, and API token from the deployment form. Sealos provisions HTTPS access through Ingress, keeps the workload on Kubernetes, and exposes the InfluxDB UI through an App entry in the Canvas.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Infrastructure Monitoring**: Store CPU, memory, disk, network, and service metrics for dashboards and alerts.
+- **IoT Telemetry**: Ingest high-volume sensor data from devices, gateways, and edge systems.
+- **Application Analytics**: Track events, counters, timings, and product usage trends over time.
+- **DevOps Observability**: Retain build, deployment, and runtime measurements for troubleshooting.
+- **Real-Time Experiments**: Query recent time series data for operational analysis and prototypes.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for InfluxDB Hosting
+
+The Sealos template includes the InfluxDB container image, persistent storage, a Kubernetes Service, HTTPS Ingress, and a Sealos App entry. No external database is required.
+
+### Deployment Dependencies
+
+- [InfluxDB Documentation](https://docs.influxdata.com/influxdb/v2/) - Official documentation for InfluxDB 2.x
+- [Docker Official Image](https://hub.docker.com/_/influxdb) - Supported InfluxDB container tags
+- [InfluxDB GitHub Repository](https://github.com/influxdata/influxdb) - Source code and releases
+- [Sealos](https://sealos.io) - Cloud platform used by this template
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **InfluxDB StatefulSet**: Runs `docker.io/library/influxdb:2.9.1` with `200m` CPU and `128Mi` memory limits, and stores data in `/var/lib/influxdb2`.
+- **Persistent Volume**: Provides 1 GiB of durable storage for time series data and metadata.
+- **Service**: Exposes the InfluxDB HTTP API and web UI on port `8086` inside the cluster.
+- **Ingress**: Provides HTTPS access at the generated Sealos domain.
+- **App Entry**: Adds a direct InfluxDB link in the Sealos Canvas.
+
+**Configuration:**
+
+The template uses InfluxDB's official first-run setup environment variables. Set the admin password and API token in the deployment form, then save them securely. The default organization is `sealos`, and the initial bucket is `primary`.
+
+**License Information:**
+
+InfluxDB is licensed under open source licenses published by InfluxData. This Sealos template is provided as a deployment wrapper for the official InfluxDB container image.
+
+## Why Deploy InfluxDB on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle, from deployment to ongoing operations. By deploying InfluxDB on Sealos, you get:
+
+- **One-Click Deployment**: Launch InfluxDB from the App Store without writing Kubernetes YAML.
+- **Persistent Storage Included**: Keep time series data and metadata across restarts.
+- **Instant Public Access**: Use an automatically provisioned HTTPS URL for the InfluxDB UI and API.
+- **Easy Customization**: Adjust credentials, resources, and storage through the deployment form and Canvas.
+- **Kubernetes Foundation**: Run on a cloud-native platform with service discovery, rollout management, and resource controls.
+- **Pay-As-You-Go Resources**: Start with a small footprint and scale resources when ingestion or query volume grows.
+
+## Deployment Guide
+
+1. Open the [InfluxDB template](https://sealos.io/products/app-store/influxdb) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - **Initial InfluxDB admin password**: Password for the `admin` web UI user.
+   - **Initial InfluxDB API token**: Token for CLI, API, and client integrations.
+3. Save the password and token securely before deploying. InfluxDB uses them during first initialization.
+4. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+5. Access InfluxDB from the provided App URL.
+6. Log in to the web UI with:
+   - **Username**: `admin`
+   - **Password**: the admin password you configured during deployment
+
+InfluxDB does not provide public self-registration in this template. The initial admin account is created automatically during first startup.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure InfluxDB through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **InfluxDB UI**: Create buckets, tokens, dashboards, and data sources from the web interface.
+- **InfluxDB API and CLI**: Use the API token configured during deployment for automation.
+- **Sealos AI Dialog**: Describe resource or configuration changes and let AI apply updates.
+- **Resource Cards**: Open the StatefulSet, Service, Ingress, or storage cards in Canvas to review or adjust settings.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+To scale resources for higher ingestion or query volume:
 
-- Not specified in the template metadata.
+1. Open the Canvas for your deployment.
+2. Click the InfluxDB StatefulSet resource card.
+3. Adjust CPU and memory resources according to your workload.
+4. Increase persistent storage if your retention policy requires more capacity.
+5. Apply the changes in the dialog and wait for the pod to become ready again.
+
+## Troubleshooting
+
+### Cannot log in
+
+- Cause: The password entered in the UI does not match the value configured during first deployment.
+- Solution: Use username `admin` and the initial admin password from the deployment form. If the value was lost, redeploy with a new password and token, or reset credentials manually inside InfluxDB.
+
+### Pod is not ready
+
+- Cause: The first initialization may still be running, or resource limits may be too small for the workload.
+- Solution: Wait a few minutes, then check the StatefulSet logs from the Canvas. Increase memory if the pod restarts under load.
+
+### API clients cannot authenticate
+
+- Cause: The client token does not match the initial API token or a token created in the UI.
+- Solution: Use the deployment token or create a new token from **Load Data → API Tokens** in the InfluxDB UI.
+
+### Getting Help
+
+- [InfluxDB Documentation](https://docs.influxdata.com/influxdb/v2/)
+- [InfluxDB Community](https://www.influxdata.com/community/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [InfluxDB Get Started](https://docs.influxdata.com/influxdb/v2/get-started/)
+- [InfluxDB API Documentation](https://docs.influxdata.com/influxdb/v2/api/)
+- [Line Protocol Reference](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/)
+
+## License
+
+This Sealos template is provided under the repository license. InfluxDB is licensed by InfluxData under the licenses published in the official project repository.

--- a/template/influxdb/README_zh.md
+++ b/template/influxdb/README_zh.md
@@ -1,27 +1,126 @@
-# influxdb
+# 在 Sealos 上部署和托管 InfluxDB
 
-## 应用概览
+InfluxDB 是一款开源时序数据库，适合处理实时分析、指标、事件和物联网数据。本模板会在 Sealos Cloud 上部署 InfluxDB 2.9.1，提供持久化存储、精简默认资源规格和公网 Web UI。
 
-influxdb 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+## InfluxDB 托管说明
 
-此 Sealos 模板会将 **influxdb** 部署为 `influxdb` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+InfluxDB 用于存储带时间戳的测量数据，适合接入仪表盘、告警系统、可观测性流水线和传感器数据。本 Sealos 模板会以单个 StatefulSet 运行 InfluxDB，并将持久化卷挂载到 `/var/lib/influxdb2`，确保数据库、bucket、token 和元数据在重启后仍然保留。
 
-## 在 Sealos 上部署
+首次启动时，模板会根据部署表单中的配置创建管理员用户、组织、bucket 和 API token。Sealos 会通过 Ingress 提供 HTTPS 访问，并在 Canvas 中创建应用入口，方便直接打开 InfluxDB UI。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **基础设施监控**：存储 CPU、内存、磁盘、网络和服务指标，用于仪表盘和告警。
+- **物联网遥测**：接收设备、网关和边缘系统产生的大量传感器数据。
+- **应用分析**：记录事件、计数器、耗时和产品使用趋势。
+- **DevOps 可观测性**：保留构建、部署和运行时指标，辅助排障。
+- **实时实验分析**：查询近期时序数据，支撑运营分析和原型验证。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## InfluxDB 托管依赖
 
-## 配置说明
+本 Sealos 模板已包含 InfluxDB 容器镜像、持久化存储、Kubernetes Service、HTTPS Ingress 和 Sealos App 入口。模板不需要外部数据库。
 
-部署时可以配置以下用户可见输入项：
+### 部署依赖
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- [InfluxDB 文档](https://docs.influxdata.com/influxdb/v2/) - InfluxDB 2.x 官方文档
+- [Docker 官方镜像](https://hub.docker.com/_/influxdb) - InfluxDB 官方容器标签
+- [InfluxDB GitHub 仓库](https://github.com/influxdata/influxdb) - 源码与版本发布
+- [Sealos](https://sealos.io) - 本模板使用的云平台
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 实现细节
 
-## 官方链接
+**架构组件：**
 
-- 模板元数据未提供。
+本模板会部署以下资源：
+
+- **InfluxDB StatefulSet**：运行 `docker.io/library/influxdb:2.9.1`，默认限制为 `200m` CPU 和 `128Mi` 内存，并将数据保存到 `/var/lib/influxdb2`。
+- **持久化卷**：提供 1 GiB 持久化存储，用于保存时序数据和元数据。
+- **Service**：在集群内通过 `8086` 端口暴露 InfluxDB HTTP API 和 Web UI。
+- **Ingress**：通过 Sealos 自动生成的域名提供 HTTPS 访问。
+- **App 入口**：在 Sealos Canvas 中创建 InfluxDB 快捷入口。
+
+**配置说明：**
+
+模板使用 InfluxDB 官方的一次性初始化环境变量。部署时请填写管理员密码和 API token，并妥善保存。默认组织为 `sealos`，初始 bucket 为 `primary`。
+
+**许可证信息：**
+
+InfluxDB 使用 InfluxData 在官方项目中发布的开源许可证。本 Sealos 模板只是官方 InfluxDB 容器镜像的部署封装。
+
+## 为什么在 Sealos 上部署 InfluxDB？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，覆盖从部署到日常运维的应用生命周期。在 Sealos 上部署 InfluxDB，可以获得：
+
+- **一键部署**：从应用商店启动 InfluxDB，无需手写 Kubernetes YAML。
+- **内置持久化存储**：重启后仍保留时序数据和元数据。
+- **即时公网访问**：自动生成 HTTPS URL，用于访问 InfluxDB UI 和 API。
+- **便捷配置调整**：通过部署表单和 Canvas 修改凭据、资源和存储配置。
+- **Kubernetes 底座**：获得服务发现、滚动更新和资源控制等云原生能力。
+- **按量使用资源**：先用较小规格启动，后续按写入和查询压力扩容。
+
+## 部署指南
+
+1. 打开 [InfluxDB 模板](https://sealos.io/products/app-store/influxdb)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - **Initial InfluxDB admin password**：`admin` Web UI 用户的登录密码。
+   - **Initial InfluxDB API token**：用于 CLI、API 和客户端集成的访问 token。
+3. 部署前请妥善保存密码和 token。InfluxDB 会在首次初始化时使用这些值。
+4. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas。后续如需调整，可在对话框中描述需求让 AI 修改，或点击相关资源卡片手动配置。
+5. 通过生成的 App URL 访问 InfluxDB。
+6. 使用以下信息登录 Web UI：
+   - **用户名**：`admin`
+   - **密码**：部署时配置的管理员密码
+
+本模板不会开放公开注册。初始管理员账号会在首次启动时自动创建。
+
+## 配置
+
+部署完成后，可以通过以下方式配置 InfluxDB：
+
+- **InfluxDB UI**：在 Web 界面中创建 bucket、token、仪表盘和数据源。
+- **InfluxDB API 和 CLI**：使用部署时配置的 API token 进行自动化操作。
+- **Sealos AI 对话框**：描述资源或配置变更，让 AI 辅助修改。
+- **资源卡片**：在 Canvas 中打开 StatefulSet、Service、Ingress 或存储卡片，查看并调整配置。
+
+## 扩容
+
+如果写入量或查询压力增加，可以按以下步骤调整资源：
+
+1. 打开当前部署的 Canvas。
+2. 点击 InfluxDB StatefulSet 资源卡片。
+3. 根据实际负载调整 CPU 和内存。
+4. 如果保留策略需要更大容量，可增加持久化存储。
+5. 在对话框中应用变更，并等待 Pod 重新进入 Ready 状态。
+
+## 故障排查
+
+### 无法登录
+
+- 原因：UI 中输入的密码与首次部署时配置的值不一致。
+- 解决方法：使用用户名 `admin` 和部署表单中的初始管理员密码登录。如果密码遗失，可以重新部署并设置新的密码和 token，或在 InfluxDB 内手动重置凭据。
+
+### Pod 未就绪
+
+- 原因：首次初始化仍在进行，或当前资源限制不足以支撑负载。
+- 解决方法：等待几分钟后，从 Canvas 查看 StatefulSet 日志。如果 Pod 在负载下重启，请提高内存配置。
+
+### API 客户端认证失败
+
+- 原因：客户端使用的 token 与部署时配置的初始 API token 或 UI 中创建的 token 不一致。
+- 解决方法：使用部署 token，或在 InfluxDB UI 的 **Load Data → API Tokens** 中创建新 token。
+
+### 获取帮助
+
+- [InfluxDB 文档](https://docs.influxdata.com/influxdb/v2/)
+- [InfluxDB 社区](https://www.influxdata.com/community/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [InfluxDB 入门指南](https://docs.influxdata.com/influxdb/v2/get-started/)
+- [InfluxDB API 文档](https://docs.influxdata.com/influxdb/v2/api/)
+- [Line Protocol 参考](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/)
+
+## 许可证
+
+本 Sealos 模板遵循模板仓库的许可证。InfluxDB 本身遵循官方项目仓库中由 InfluxData 发布的许可证。

--- a/template/influxdb/index.yaml
+++ b/template/influxdb/index.yaml
@@ -3,266 +3,182 @@ kind: Template
 metadata:
   name: influxdb
 spec:
-  title: 'influxdb'
-  url: 'https://www.influxdata.com/products/influxdb/'
-  author: 'Sealos'
-  description: 'Real-time insights from any time series data with a single, purpose-built database. Run at any scale in any environment in the cloud, on-premises, or at the edge.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/logo.svg'
+  title: InfluxDB
+  url: https://www.influxdata.com/products/influxdb/
+  gitRepo: https://github.com/influxdata/influxdb
+  author: Sealos
+  description: InfluxDB is an open source time series database built for real-time analytics, metrics, events, and IoT data.
+  readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/README.md
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/logo.svg
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/website-screenshot.webp'
+    - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/website-screenshot.webp
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: InfluxDB 是一款开源时序数据库，适用于实时分析、指标监控、事件数据和物联网数据存储。
+      readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/README_zh.md
   categories:
     - database
   defaults:
     app_host:
       type: string
-      value: ${{ random(8) }}
+      value: influxdb-${{ random(8) }}
     app_name:
       type: string
       value: influxdb-${{ random(8) }}
   inputs:
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/README_zh.md'
-#    adminUserPassword:
-#      description: 'admin user password'
-#      type: string
-#      default: 'adminUserPassw0rd'
-#      required: true
-#    adminUserToken:
-#      description: 'admin user token'
-#      type: string
-#      default: 'adminUserT0ken'
-#      required: true
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
-    app.kubernetes.io/name: ${{ defaults.app_name }}
-    app.kubernetes.io/version: 2.7.5
-type: Opaque
-data:
-  admin-user-password: cGFzc3cwcmQ=
-  admin-user-token: dDBrZW4=
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-spec:
-  ports:
-    - port: 8086
-      targetPort: 8086
-      name: http
-    - port: 8088
-      targetPort: 8088
-      name: rpc
-  selector:
-    app: ${{ defaults.app_name }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
-    app.kubernetes.io/name: ${{ defaults.app_name }}
-    app.kubernetes.io/version: 2.7.5
-    app.kubernetes.io/component: ${{ defaults.app_name }}
-automountServiceAccountToken: false
+    admin_password:
+      description: Initial InfluxDB admin password. Set and save this value for the web UI login.
+      type: string
+      default: ''
+      required: true
+    admin_token:
+      description: Initial InfluxDB API token. Set and save this value for CLI, API, and client access.
+      type: string
+      default: ''
+      required: true
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: nginx
+    originImageName: docker.io/library/influxdb:2.9.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
-    deploy.cloud.sealos.io/resize: 5Gi
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
+  minReadySeconds: 10
+  serviceName: ${{ defaults.app_name }}
   selector:
     matchLabels:
       app: ${{ defaults.app_name }}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 50%
-  minReadySeconds: 10
-  serviceName: ${{ defaults.app_name }}
   template:
     metadata:
       labels:
         app: ${{ defaults.app_name }}
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/instance: ${{ defaults.app_name }}
-                    app.kubernetes.io/name: ${{ defaults.app_name }}
-                    app.kubernetes.io/component: ${{ defaults.app_name }}
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-      securityContext:
-        fsGroup: 1001
-        fsGroupChangePolicy: Always
-        supplementalGroups: []
-        sysctls: []
-      serviceAccountName: ${{ defaults.app_name }}
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
-        - name: influxdb
-          image: docker.io/bitnamilegacy/influxdb:2.7.5-debian-12-r13
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 1001
-            runAsNonRoot: true
-            runAsUser: 1001
-            seLinuxOptions: {}
-            seccompProfile:
-              type: RuntimeDefault
+        - name: ${{ defaults.app_name }}
+          image: docker.io/library/influxdb:2.9.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              export DOCKER_INFLUXDB_INIT_USERNAME=admin
+              export DOCKER_INFLUXDB_INIT_PASSWORD="${INFLUXDB_INIT_CREDENTIAL}"
+              exec /entrypoint.sh influxd
           env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: INFLUXDB_HTTP_AUTH_ENABLED
-              value: "true"
-            - name: INFLUXDB_CREATE_USER_TOKEN
-              value: "no"
-            - name: INFLUXDB_ADMIN_USER
-              value: "admin"
-            - name: INFLUXDB_ADMIN_USER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: admin-user-password
-            - name: INFLUXDB_ADMIN_USER_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: admin-user-token
-            - name: INFLUXDB_ADMIN_BUCKET
-              value: "primary"
-            - name: INFLUXDB_ADMIN_ORG
-              value: "primary"
-          envFrom:
+            - name: DOCKER_INFLUXDB_INIT_MODE
+              value: setup
+            - name: INFLUXDB_INIT_CREDENTIAL
+              value: ${{ inputs.admin_password }}
+            - name: DOCKER_INFLUXDB_INIT_ORG
+              value: sealos
+            - name: DOCKER_INFLUXDB_INIT_BUCKET
+              value: primary
+            - name: DOCKER_INFLUXDB_INIT_ADMIN_TOKEN
+              value: ${{ inputs.admin_token }}
+            - name: INFLUXD_REPORTING_DISABLED
+              value: 'true'
           ports:
             - name: http
               containerPort: 8086
               protocol: TCP
-            - name: rpc
-              containerPort: 8088
-              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 60
+            periodSeconds: 5
+            timeoutSeconds: 3
           livenessProbe:
+            httpGet:
+              path: /health
+              port: http
             failureThreshold: 6
-            initialDelaySeconds: 180
-            periodSeconds: 45
-            successThreshold: 1
-            timeoutSeconds: 30
-            exec:
-              command:
-                - bash
-                - -c
-                - |
-                  . /opt/bitnami/scripts/libinfluxdb.sh
-                  influxdb_env
-                  export INFLUX_USERNAME="$INFLUXDB_ADMIN_USER"
-                  export INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"
-                  timeout 29s influx ping --host http://$POD_IP:8086
+            periodSeconds: 30
+            timeoutSeconds: 5
           readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
             failureThreshold: 6
-            initialDelaySeconds: 60
-            periodSeconds: 45
-            successThreshold: 1
-            timeoutSeconds: 30
-            exec:
-              command:
-                - bash
-                - -c
-                - |
-                  . /opt/bitnami/scripts/libinfluxdb.sh
-                  influxdb_env
-                  export INFLUX_USERNAME="$INFLUXDB_ADMIN_USER"
-                  export INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"
-                  timeout 29s influx ping --host http://$POD_IP:8086
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             limits:
-              cpu: 1000m
-              ephemeral-storage: 1024Mi
-              memory: 1024Mi
-            requests:
-              cpu: 100m
-              ephemeral-storage: 50Mi
+              cpu: 200m
               memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 12Mi
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/influxdb/etc
-              subPath: app-conf-dir
-            - name: vn-bitnamivn-influxdb
-              mountPath: /bitnami/influxdb
-      volumes:
-        - name: empty-dir
-          emptyDir: {}
+            - name: vn-varvn-libvn-influxdb2
+              mountPath: /var/lib/influxdb2
   volumeClaimTemplates:
     - metadata:
         annotations:
-          path: /bitnami/influxdb
-          value: '5'
-        name: vn-bitnamivn-influxdb
+          path: /var/lib/influxdb2
+          value: '1'
+        name: vn-varvn-libvn-influxdb2
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 5Gi
+            storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  ports:
+    - name: http
+      port: 8086
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: ${{ defaults.app_name }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: network-eadkuyljeayo
+  name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
-    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 64k;
+      large_client_header_buffers 4 128k;
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 64k;
-      large_client_header_buffers 4 128k;
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
+        expires 30d;
+        add_header Cache-Control "public";
+      }
 spec:
   rules:
     - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
@@ -279,3 +195,17 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
+---
+apiVersion: app.sealos.io/v1
+kind: App
+metadata:
+  name: ${{ defaults.app_name }}
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  data:
+    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+  displayType: normal
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/influxdb/logo.svg
+  name: InfluxDB
+  type: link


### PR DESCRIPTION
## Summary
- Update InfluxDB to the official Docker image `docker.io/library/influxdb:2.9.1`.
- Rework the Sealos template to remove hardcoded secrets, `emptyDir`, legacy Bitnami paths, and unused RPC exposure.
- Add required template metadata, App entry, first-run admin password/token inputs, probes, and tuned minimum resources.
- Rewrite English and Chinese READMEs with deployment, login, resource, and troubleshooting guidance.

## Test plan
- [x] `check_consistency.py ... --artifacts template/influxdb/index.yaml`
- [x] `DOCKER_TO_SEALOS_ARTIFACTS=... quality_gate.py`
- [x] Sealos Template API dry-run with admin password/token args
- [x] Live Sealos deployment smoke test: pod became Ready, `/health` returned InfluxDB v2.9.1, `/api/v2/setup` returned `allowed: false`
- [x] Cleanup verified for test Instance/App/Ingress/Service/StatefulSet/PVC
- [x] `git diff --check upstream/kb-0.9...HEAD`
