### PR TITLE
feat(immich): update template to v2.7.5

### DIFF
--- a/template/immich/README.md
+++ b/template/immich/README.md
@@ -1,30 +1,134 @@
-# Immich
+# Deploy and Host Immich on Sealos
 
-## Overview
+Immich is a self-hosted photo and video management platform for backing up, organizing, searching, and sharing personal media. This template deploys Immich with PostgreSQL, Redis, persistent media storage, and optional machine learning on Sealos Cloud.
 
-High performance self-hosted photo and video management solution. Store, organize, and share your memories with machine learning-powered features like face recognition and smart search.
+![Immich Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/immich/website-screenshot.webp)
 
-This Sealos template deploys **Immich** as the `immich` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Immich
 
-## Deploy on Sealos
+Immich runs as a web application that provides a browser UI, mobile app sync endpoints, background media processing, and smart library features. The Sealos template provisions the application server, PostgreSQL 16.4 with pgvector, Redis 7.2.7, persistent upload storage, and an optional machine learning service.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The application server stores photos and videos on a persistent volume mounted at `/usr/src/app/upload`. PostgreSQL stores metadata, users, albums, jobs, and vector indexes, while Redis coordinates background jobs and cache data. When machine learning is enabled, a separate Immich ML service provides face recognition, object detection, and smart search support.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **Personal Photo Backup**: Sync photos and videos from mobile devices to a private server.
+- **Family Media Library**: Organize shared albums, people, places, and timelines in one web UI.
+- **Private Smart Search**: Use local machine learning for face recognition and semantic media search.
+- **Self-Hosted Google Photos Alternative**: Keep media and metadata under your own Sealos-managed deployment.
+
+## Dependencies for Immich Hosting
+
+The Sealos template includes all required runtime dependencies for a single-node Immich deployment:
+
+- **Immich Server v2.7.5**: Web UI, API, background processing, and mobile sync endpoint.
+- **Immich Machine Learning v2.7.5**: Optional ML service for face recognition and smart search.
+- **PostgreSQL 16.4**: KubeBlocks-managed PostgreSQL with the pgvector extension enabled.
+- **Redis 7.2.7**: KubeBlocks-managed Redis for queue and cache coordination.
+- **Persistent Volumes**: Media upload storage, ML cache storage, PostgreSQL data, and Redis data.
+
+### Deployment Dependencies
+
+- [Immich Documentation](https://immich.app/docs/) - Official documentation
+- [Immich Post Installation Guide](https://immich.app/docs/install/post-install/) - First user and admin setup
+- [Immich GitHub Repository](https://github.com/immich-app/immich) - Source code and release notes
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Immich Server**: StatefulSet serving the web UI and API on port `2283`.
+- **Immich Machine Learning**: Optional StatefulSet serving ML requests on port `3003`.
+- **PostgreSQL**: KubeBlocks PostgreSQL 16.4 cluster with the `immich` database and vector extensions.
+- **Redis**: KubeBlocks Redis 7.2.7 cluster used by Immich job queues and cache.
+- **Ingress and App Link**: Sealos-managed HTTPS endpoint for browser and mobile app access.
+
+**Configuration:**
+
+- `enable_machine_learning` controls whether the Immich ML service is deployed.
+- The server uses `IMMICH_MACHINE_LEARNING_URL` to reach the ML service when ML is enabled.
+- PostgreSQL is initialized idempotently with the `immich` database and required extensions.
+- Uploaded media persists on `/usr/src/app/upload`; back up this volume together with PostgreSQL.
+
+**License Information:**
+
+Immich is distributed under the GNU Affero General Public License v3.0. This Sealos template follows the license of the templates repository.
+
+## Why Deploy Immich on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies deployment, networking, storage, and lifecycle management. By deploying Immich on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Immich, PostgreSQL, Redis, storage, and HTTPS routing from one template.
+- **Persistent Storage Included**: Keep media uploads, model cache, database data, and Redis data across restarts.
+- **Kubernetes Foundation**: Run Immich on managed Kubernetes without writing Kubernetes manifests by hand.
+- **Easy Customization**: Adjust resources, storage, environment variables, and scaling from Canvas resource cards or the AI dialog.
+- **Instant Public Access**: Get a Sealos-managed HTTPS URL after deployment completes.
+- **Pay-as-You-Go Resources**: Start with tested resource limits and scale as your media library grows.
+
+## Deployment Guide
+
+1. Open the [Immich template](https://sealos.io/products/app-store/immich) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - `enable_machine_learning`: keep `true` for face recognition and smart search, or set `false` for a lighter deployment.
+3. Wait for deployment to complete. The full stack usually needs several minutes because PostgreSQL, Redis, and the app server must initialize in order.
+4. Access your application via the provided URL:
+   - **Immich Web UI**: open the generated Sealos URL, for example `https://<your-app-host>.<your-sealos-domain>`.
+5. For later changes, open the deployment Canvas and describe your requirements in the AI dialog, or click the relevant resource cards to modify resources, storage, or environment variables.
+
+## First Login and Registration
+
+Immich does not ship with a default username or password. On a fresh deployment, open the web UI and complete the **Getting Started** flow; the first user you register becomes the administrator.
+
+After the admin account is created, sign in with that email and password. Additional users can be invited or created from the Immich administration settings according to your access policy.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Immich through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `enable_machine_learning` | Enable machine learning features (face recognition, object detection) | `false` | `true` |
+- **Immich Administration UI**: Manage users, libraries, jobs, storage template settings, and server preferences.
+- **Sealos AI Dialog**: Describe desired changes such as resource increases or environment-variable updates.
+- **Sealos Resource Cards**: Adjust StatefulSet resources, storage size, Ingress settings, or database resources.
+- **Mobile Apps**: Use the generated Sealos URL as the server endpoint in the official Immich mobile app.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+Start with the template defaults, then scale based on library size and feature usage:
 
-- Official website: https://immich.app/
-- Source repository: https://github.com/immich-app/immich
+1. Open the Canvas for your Immich deployment.
+2. Click the Immich server, ML service, PostgreSQL, or Redis resource card.
+3. Increase CPU, memory, storage, or replica settings as needed.
+4. Apply the changes and wait for the resources to roll out.
+
+Large libraries and ML-heavy workloads need more memory and storage. Always back up PostgreSQL and the upload volume before major upgrades or storage changes.
+
+## Troubleshooting
+
+### The web page is not ready immediately
+
+Immich depends on PostgreSQL and Redis. If the page is temporarily unavailable right after deployment, wait until the PostgreSQL, Redis, and Immich server pods are ready, then refresh the generated URL.
+
+### First login asks for account creation
+
+This is expected for a fresh Immich deployment. Register the first account in the Getting Started flow; that account becomes the administrator.
+
+### Uploads or machine learning jobs are slow
+
+Increase Immich server or ML service CPU and memory from the Sealos Canvas. Large video uploads, thumbnail generation, face recognition, and smart search indexing can be resource-intensive.
+
+### Getting Help
+
+- [Immich Documentation](https://immich.app/docs/)
+- [Immich GitHub Issues](https://github.com/immich-app/immich/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Immich Mobile App Documentation](https://immich.app/docs/features/mobile-app/)
+- [Immich Backup and Restore Guide](https://immich.app/docs/administration/backup-and-restore/)
+- [Immich Release Notes](https://github.com/immich-app/immich/releases)
+
+## License
+
+This Sealos template is provided under the templates repository license. Immich itself is licensed under the GNU Affero General Public License v3.0.

--- a/template/immich/README_zh.md
+++ b/template/immich/README_zh.md
@@ -1,30 +1,134 @@
-# Immich
+# 在 Sealos 上部署和托管 Immich
 
-## 应用概览
+Immich 是一款自托管照片和视频管理平台，可用于备份、整理、搜索和分享个人媒体。此模板会在 Sealos Cloud 上部署 Immich，并包含 PostgreSQL、Redis、持久化媒体存储和可选机器学习服务。
 
-高性能自托管照片和视频管理解决方案。通过人脸识别和智能搜索等机器学习功能，存储、整理和分享您的回忆。
+![Immich 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/immich/website-screenshot.webp)
 
-此 Sealos 模板会将 **Immich** 部署为 `immich` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于 Immich 托管
 
-## 在 Sealos 上部署
+Immich 提供浏览器界面、移动端同步接口、后台媒体处理和智能图库功能。Sealos 模板会自动创建应用服务、带 pgvector 的 PostgreSQL 16.4、Redis 7.2.7、持久化上传存储，以及可选的机器学习服务。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+应用服务会将照片和视频保存在挂载到 `/usr/src/app/upload` 的持久化卷中。PostgreSQL 保存元数据、用户、相册、任务和向量索引；Redis 负责后台任务队列和缓存。启用机器学习后，独立的 Immich ML 服务会提供人脸识别、目标检测和智能搜索能力。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **个人照片备份**：将手机照片和视频同步到自己的私有服务。
+- **家庭媒体库**：集中管理共享相册、人物、地点和时间线。
+- **私有智能搜索**：使用本地机器学习能力进行人脸识别和语义搜索。
+- **自托管 Google Photos 替代方案**：将媒体文件和元数据保留在自己的 Sealos 部署中。
 
-## 配置说明
+## Immich 托管依赖
 
-部署时可以配置以下用户可见输入项：
+此 Sealos 模板包含单节点 Immich 部署所需的运行依赖：
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `enable_machine_learning` | `enable_machine_learning` 部署参数。 | `否` | `true` |
+- **Immich Server v2.7.5**：Web 界面、API、后台处理和移动端同步入口。
+- **Immich Machine Learning v2.7.5**：可选机器学习服务，用于人脸识别和智能搜索。
+- **PostgreSQL 16.4**：由 KubeBlocks 管理，并启用 pgvector 扩展。
+- **Redis 7.2.7**：由 KubeBlocks 管理，用于任务队列和缓存协调。
+- **持久化卷**：媒体上传、机器学习缓存、PostgreSQL 数据和 Redis 数据都会持久化保存。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖
 
-## 官方链接
+- [Immich 文档](https://immich.app/docs/) - 官方文档
+- [Immich 安装后配置指南](https://immich.app/docs/install/post-install/) - 首个用户和管理员设置
+- [Immich GitHub 仓库](https://github.com/immich-app/immich) - 源码和发布记录
 
-- 官方网站: https://immich.app/
-- 源码仓库: https://github.com/immich-app/immich
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Immich Server**：StatefulSet，监听 `2283` 端口，提供 Web 界面和 API。
+- **Immich Machine Learning**：可选 StatefulSet，监听 `3003` 端口，处理机器学习请求。
+- **PostgreSQL**：KubeBlocks PostgreSQL 16.4 集群，包含 `immich` 数据库和向量扩展。
+- **Redis**：KubeBlocks Redis 7.2.7 集群，用于 Immich 任务队列和缓存。
+- **Ingress 和 App 入口**：由 Sealos 管理的 HTTPS 访问地址。
+
+**配置说明：**
+
+- `enable_machine_learning` 控制是否部署 Immich ML 服务。
+- 启用机器学习时，服务端通过 `IMMICH_MACHINE_LEARNING_URL` 访问 ML 服务。
+- PostgreSQL 初始化任务会幂等创建 `immich` 数据库和所需扩展。
+- 上传的媒体文件保存在 `/usr/src/app/upload`；备份时请同时备份此卷和 PostgreSQL。
+
+**许可证信息：**
+
+Immich 使用 GNU Affero General Public License v3.0 发布。此 Sealos 模板遵循模板仓库的许可证。
+
+## 为什么在 Sealos 上部署 Immich？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一管理部署、网络、存储和应用生命周期。在 Sealos 上部署 Immich 可以获得：
+
+- **一键部署**：通过一个模板部署 Immich、PostgreSQL、Redis、存储和 HTTPS 入口。
+- **内置持久化存储**：媒体上传、模型缓存、数据库和 Redis 数据可在重启后保留。
+- **Kubernetes 底座**：无需手写 Kubernetes YAML，也能运行在托管 Kubernetes 上。
+- **易于调整配置**：可通过 Canvas 资源卡片或 AI 对话调整资源、存储、环境变量和扩缩容设置。
+- **即时公网访问**：部署完成后获得 Sealos 管理的 HTTPS 地址。
+- **按量使用资源**：从测试过的资源配置开始，随着媒体库增长逐步扩容。
+
+## 部署指南
+
+1. 打开 [Immich 模板](https://sealos.io/products/app-store/immich)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - `enable_machine_learning`：保留 `true` 可启用人脸识别和智能搜索；设为 `false` 可获得更轻量的部署。
+3. 等待部署完成。由于 PostgreSQL、Redis 和应用服务需要依次初始化，完整启动通常需要数分钟。
+4. 通过生成的地址访问应用：
+   - **Immich Web 界面**：打开 Sealos 生成的 URL，例如 `https://<your-app-host>.<your-sealos-domain>`。
+5. 如需后续调整，请打开部署 Canvas，在 AI 对话中描述需求，或点击对应资源卡片修改资源、存储或环境变量。
+
+## 首次登录和注册
+
+Immich 不提供默认用户名或密码。全新部署后，打开 Web 界面并完成 **Getting Started** 流程；第一个注册的用户会成为管理员。
+
+管理员账号创建后，使用该邮箱和密码登录。后续可根据访问策略，在 Immich 管理设置中邀请或创建其他用户。
+
+## 配置
+
+部署完成后，可以通过以下方式配置 Immich：
+
+- **Immich 管理界面**：管理用户、图库、任务、存储模板设置和服务偏好。
+- **Sealos AI 对话**：描述需要的变更，例如增加资源或更新环境变量。
+- **Sealos 资源卡片**：调整 StatefulSet 资源、存储容量、Ingress 设置或数据库资源。
+- **移动端 App**：在官方 Immich 移动端中，将 Sealos 生成的 URL 填为服务器地址。
+
+## 扩缩容
+
+建议先使用模板默认配置，再根据媒体库规模和功能使用情况扩容：
+
+1. 打开 Immich 部署对应的 Canvas。
+2. 点击 Immich Server、ML 服务、PostgreSQL 或 Redis 资源卡片。
+3. 按需增加 CPU、内存、存储或副本配置。
+4. 应用变更并等待资源滚动更新完成。
+
+大型媒体库和高强度机器学习任务会需要更多内存和存储。进行大版本升级或存储变更前，请先备份 PostgreSQL 和上传卷。
+
+## 故障排查
+
+### Web 页面刚部署后暂时不可用
+
+Immich 依赖 PostgreSQL 和 Redis。若部署后页面暂时无法打开，请等待 PostgreSQL、Redis 和 Immich Server Pod 都进入就绪状态后再刷新生成的 URL。
+
+### 首次登录时要求创建账号
+
+这是全新 Immich 部署的正常行为。请在 Getting Started 流程中注册第一个账号，该账号会成为管理员。
+
+### 上传或机器学习任务较慢
+
+请在 Sealos Canvas 中增加 Immich Server 或 ML 服务的 CPU 和内存。大视频上传、缩略图生成、人脸识别和智能搜索索引都会消耗较多资源。
+
+### 获取帮助
+
+- [Immich 文档](https://immich.app/docs/)
+- [Immich GitHub Issues](https://github.com/immich-app/immich/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Immich 移动端文档](https://immich.app/docs/features/mobile-app/)
+- [Immich 备份与恢复指南](https://immich.app/docs/administration/backup-and-restore/)
+- [Immich 发布记录](https://github.com/immich-app/immich/releases)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库许可证。Immich 本身使用 GNU Affero General Public License v3.0。

--- a/template/immich/index.yaml
+++ b/template/immich/index.yaml
@@ -26,7 +26,7 @@ spec:
       value: immich-${{ random(8) }}
     app_host:
       type: string
-      value: ${{ random(8) }}
+      value: immich-${{ random(8) }}
   inputs:
     enable_machine_learning:
       description: 'Enable machine learning features (face recognition, object detection)'
@@ -130,13 +130,14 @@ spec:
     - componentDef: redis-sentinel-7
       name: redis-sentinel
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-redis
       resources:
         limits:
-          cpu: 100m
-          memory: 100Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: 50m
+          memory: 51Mi
       serviceVersion: 7.2.7
       volumeClaimTemplates:
         - name: data
@@ -200,30 +201,30 @@ metadata:
     - cluster.kubeblocks.io/finalizer
   labels:
     clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    kb.io/database: postgresql-16.4.0
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
   name: ${{ defaults.app_name }}-pg
 spec:
   affinity:
-    nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
     - componentDefRef: postgresql
-      monitor: true
+      disableExporter: true
+      enabledLogs:
+        - running
       name: postgresql
       replicas: 1
       resources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: '1'
+          memory: 1024Mi
         requests:
-          cpu: 50m
-          memory: 51Mi
+          cpu: 100m
+          memory: 102Mi
       serviceAccountName: ${{ defaults.app_name }}-pg
       switchPolicy:
         type: Noop
@@ -234,10 +235,9 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
+                storage: 2Gi
 
   terminationPolicy: Delete
-  tolerations: []
 
 ---
 apiVersion: batch/v1
@@ -252,22 +252,62 @@ spec:
     spec:
       containers:
         - name: pgsql-init
-          image: postgres:14-alpine
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_DATABASE
+              value: immich
           command:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE immich;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
+              set -eu
+              export PGPASSWORD="${PG_PASSWORD}"
+              for i in $(seq 1 60); do
+                if pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                sleep 2
+              done
+              pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres >/dev/null 2>&1
+              if ! psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
+                psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/postgres" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"${PG_DATABASE}\";"
+              fi
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "unaccent";'
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "cube";'
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "earthdistance";'
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "pg_trgm";'
+              psql "postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS "vector" CASCADE;'
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      restartPolicy: OnFailure
+  backoffLimit: 3
   ttlSecondsAfterFinished: 300
 
 ---
@@ -276,7 +316,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/immich-app/immich-server:v1.136.0
+    originImageName: ghcr.io/immich-app/immich-server:v2.7.5
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '3'
   labels:
@@ -295,14 +335,62 @@ spec:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PGDATABASE
+              value: immich
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              for i in $(seq 1 120); do
+                if psql -h "${PGHOST}" -p "${PGPORT}" -U "${PGUSER}" -d "${PGDATABASE}" -tAc 'SELECT 1' >/dev/null 2>&1; then
+                  exit 0
+                fi
+                sleep 2
+              done
+              psql -h "${PGHOST}" -p "${PGPORT}" -U "${PGUSER}" -d "${PGDATABASE}" -tAc 'SELECT 1' >/dev/null
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/immich-app/immich-server:v1.136.0
+          image: ghcr.io/immich-app/immich-server:v2.7.5
           imagePullPolicy: IfNotPresent
           env:
             # Redis Configuration
             - name: REDIS_HOSTNAME
-              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local
             - name: REDIS_PORT
               value: '6379'
             - name: REDIS_PASSWORD
@@ -333,10 +421,14 @@ spec:
                   key: password
             - name: DB_DATABASE_NAME
               value: immich
+            - name: DB_VECTOR_EXTENSION
+              value: pgvector
+            - name: IMMICH_MEDIA_LOCATION
+              value: /usr/src/app/upload
             # Machine Learning Configuration
             ${{ if(inputs.enable_machine_learning === 'true') }}
-            - name: MACHINE_LEARNING_URL
-              value: http://${{ defaults.app_name }}-ml:3003
+            - name: IMMICH_MACHINE_LEARNING_URL
+              value: http://${{ defaults.app_name }}-ml.${{ SEALOS_NAMESPACE }}.svc.cluster.local:3003
             ${{ endif() }}
           ports:
             - containerPort: 2283
@@ -394,6 +486,7 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
@@ -410,7 +503,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}-ml
   annotations:
-    originImageName: ghcr.io/immich-app/immich-machine-learning:v1.136.0
+    originImageName: ghcr.io/immich-app/immich-machine-learning:v2.7.5
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '2'
   labels:
@@ -429,17 +522,25 @@ spec:
         app: ${{ defaults.app_name }}-ml
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-ml
-          image: ghcr.io/immich-app/immich-machine-learning:v1.136.0
+          image: ghcr.io/immich-app/immich-machine-learning:v2.7.5
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
               value: production
-            - name: SERVER_PORT
+            - name: IMMICH_PORT
               value: '3003'
             - name: MACHINE_LEARNING_CACHE_FOLDER
               value: /cache
+            - name: TRANSFORMERS_CACHE
+              value: /cache
+            - name: HF_XET_CACHE
+              value: /cache/huggingface-xet
+            - name: MPLCONFIGDIR
+              value: /cache/matplotlib-config
           ports:
             - containerPort: 3003
               name: http
@@ -453,6 +554,30 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -472,6 +597,7 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}-ml
   labels:
+    app: ${{ defaults.app_name }}-ml
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-ml
 spec:
   ports:
@@ -488,17 +614,18 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 500m
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 64k;
       large_client_header_buffers 4 128k;
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 500m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '300'


### PR DESCRIPTION
## Summary
- update Immich server and machine-learning images to v2.7.5
- upgrade PostgreSQL to 16.4.0, add robust init/wait logic, and tune resources from Sealos deployment tests
- refresh English and Chinese README docs with deployment, registration, and scaling guidance

## Validation
- docker-to-sealos dry-run succeeded
- Sealos deployment smoke test passed: /api/server/ping and /api/server/version
- cleaned all online test resources, including Instance resources
- git diff --check passed

Note: PostgreSQL resources intentionally exceed the default docker-to-sealos database rule because Immich official requirements state PostgreSQL needs at least 2GB RAM when Docker resource limits are used, and live Sealos testing showed the default 512Mi/1Gi database configuration OOMs or exhausts database storage during initialization.