### PR TITLE
fix(docuseal): update Sealos template and docs

### DIFF
--- a/template/docuseal/README.md
+++ b/template/docuseal/README.md
@@ -1,28 +1,140 @@
-# DocuSeal
+# Deploy and Host DocuSeal on Sealos
 
-## Overview
+DocuSeal is an open source platform for building, filling, and signing PDF forms online. This template deploys DocuSeal with PostgreSQL, persistent file storage, and a public HTTPS endpoint on Sealos Cloud.
 
-Open source document signing solution. Create, fill, and sign digital documents with legally binding eSignatures.
+![DocuSeal Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/website-screenshot.webp)
 
-This Sealos template deploys **DocuSeal** as the `docuseal` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting DocuSeal
 
-## Deploy on Sealos
+DocuSeal provides a self-hosted document workflow for uploading PDFs, adding fillable fields, collecting signatures, and managing completed submissions. It is useful when you need a controllable eSignature system that keeps data inside your own deployment.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+This Sealos template runs DocuSeal as a single web service and provisions a Kubeblocks PostgreSQL database for application data. Uploaded documents and generated files are stored on a persistent volume mounted at `/data/docuseal`, so files survive restarts and rolling updates.
 
-## Access
+Sealos also configures the public HTTPS route, service discovery, persistent storage, and resource limits automatically. The template sets DocuSeal's public `APP_URL` to the generated Sealos domain so setup pages, email links, webhook URLs, and Open Graph metadata use the correct external URL.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Internal document approvals**: Prepare PDF forms and collect signatures from employees, contractors, or partners.
+- **Customer agreements**: Send service agreements, onboarding documents, and consent forms for online signing.
+- **Operations paperwork**: Digitize repeatable forms such as handover documents, checklists, and acknowledgements.
+- **API-driven signing flows**: Use DocuSeal's API and webhooks to integrate document signing into existing products.
+- **Self-hosted eSignature workflows**: Keep signing data and files in your own Sealos workspace instead of relying only on a hosted SaaS account.
+
+## Dependencies for DocuSeal Hosting
+
+The Sealos template includes the required runtime components: the DocuSeal container image, a PostgreSQL `postgresql-16.4.0` database, a database initialization job for the `docuseal` database, persistent application storage, a Kubernetes Service, an Ingress, and a Sealos App entry.
+
+### Deployment Dependencies
+
+- [DocuSeal Website](https://www.docuseal.com/) - Product overview and hosted cloud option
+- [DocuSeal GitHub Repository](https://github.com/docusealco/docuseal) - Source code, Docker image, and release notes
+- [DocuSeal Documentation](https://www.docuseal.com/docs) - Product and integration documentation
+- [DocuSeal API Reference](https://www.docuseal.com/docs/api) - API endpoints for automation and integrations
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **DocuSeal Web Service**: Runs `docuseal/docuseal:3.0.1` on port `3000` and serves the web UI, API, embedded signing pages, and background jobs.
+- **PostgreSQL**: Kubeblocks-managed PostgreSQL `postgresql-16.4.0` stores users, accounts, templates, submissions, and application metadata.
+- **PostgreSQL Init Job**: Creates the `docuseal` database idempotently after PostgreSQL is ready.
+- **Persistent Storage**: A `1Gi` volume mounted at `/data/docuseal` stores DocuSeal runtime files and uploaded attachments.
+- **Ingress and App Entry**: Sealos exposes the web service through an HTTPS domain and creates a dashboard entry for direct access.
+
+**Configuration:**
+
+The template automatically configures:
+
+- `APP_URL` as `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`.
+- `HOST` as the generated Sealos hostname.
+- `FORCE_SSL=true` so DocuSeal treats the public route as HTTPS.
+- `SECRET_KEY_BASE` as a generated secret value.
+- `DATABASE_URL` from the Kubeblocks PostgreSQL connection Secret.
+
+No required user inputs are needed during deployment. Optional SMTP, object storage, SSO, or license-related settings can be configured after deployment from the DocuSeal UI or by editing the workload environment variables in the Sealos Canvas.
+
+**License Information:**
+
+DocuSeal is distributed under the AGPLv3 License with additional terms from DocuSeal LLC. This Sealos template is provided as deployment configuration for DocuSeal and does not change the upstream application license.
+
+## Why Deploy DocuSeal on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. By deploying DocuSeal on Sealos, you get:
+
+- **One-Click Deployment**: Deploy DocuSeal, PostgreSQL, storage, networking, and the dashboard entry from one template.
+- **Zero Kubernetes Expertise Required**: Use Kubernetes-backed reliability without writing manifests manually.
+- **Persistent Storage Included**: Keep uploaded documents, generated files, and database data across restarts.
+- **Instant Public Access**: Each deployment receives an HTTPS URL suitable for setup, signing pages, and API callbacks.
+- **Easy Customization**: Adjust environment variables, resources, and storage through the Sealos Canvas and AI dialog.
+- **Pay-As-You-Go Resources**: Start from a compact resource profile and scale only when your signing workload grows.
+
+Deploy DocuSeal on Sealos and focus on document workflows instead of managing infrastructure.
+
+## Deployment Guide
+
+1. Open the [DocuSeal template](https://sealos.io/products/app-store/docuseal) and click **Deploy Now**.
+2. Keep the default parameters unless you need a custom generated name or host.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Open the generated DocuSeal URL from the App entry.
+5. Complete the first-run setup form:
+   - Enter the first administrator's first name and last name.
+   - Enter the administrator email address.
+   - Enter your company or workspace name.
+   - Set the administrator password.
+   - Keep the App URL field as the generated Sealos HTTPS URL unless you have configured a custom domain.
+   - Select the preferred interface language and submit the form.
+6. After setup, use the same email and password on the sign-in page for future logins.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure DocuSeal through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **Initial Setup Page**: Creates the first administrator account and stores the public App URL.
+- **DocuSeal Account Settings**: Manage users, branding, signing preferences, webhooks, API tokens, and account-level options.
+- **Sealos AI Dialog**: Describe environment or resource changes and let AI apply updates.
+- **Resource Cards**: Click the StatefulSet, PostgreSQL, Ingress, or storage cards in Canvas to inspect and adjust settings.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+If you enable outbound email, configure SMTP-related environment variables before sending user invitations or signing emails. If you change the public domain later, update DocuSeal's App URL in account settings so generated signing links continue to use the right hostname.
 
-## Official Links
+## Scaling
 
-- Official website: https://www.docuseal.com/
-- Source repository: https://github.com/docusealco/docuseal
+To scale DocuSeal on Sealos:
+
+1. Open the Canvas for your DocuSeal deployment.
+2. Click the DocuSeal StatefulSet resource card.
+3. Increase CPU or memory when large PDFs, frequent uploads, or high signing traffic require more capacity.
+4. Apply the change and wait for the pod to become ready.
+
+The default template uses a compact resource profile suitable for evaluation and light usage. For heavier production workloads, increase the application resources and consider external object storage for large attachment volumes.
+
+## Troubleshooting
+
+### The app opens the setup page
+
+This is expected on a fresh deployment. Create the first administrator account on the setup page. After the first user exists, DocuSeal redirects unauthenticated visitors to the sign-in page.
+
+### Generated links use the wrong domain
+
+Open DocuSeal account settings and update the App URL to the current Sealos HTTPS URL or your custom domain. The template sets `APP_URL` automatically for new deployments, but manual domain changes should also be reflected inside DocuSeal.
+
+### Invitation or signing emails are not sent
+
+DocuSeal needs SMTP configuration for outbound email. Add the required SMTP environment variables in the StatefulSet resource card, restart the workload, and test email delivery from DocuSeal settings.
+
+### Getting Help
+
+- [DocuSeal Documentation](https://www.docuseal.com/docs)
+- [DocuSeal GitHub Issues](https://github.com/docusealco/docuseal/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [DocuSeal API Reference](https://www.docuseal.com/docs/api)
+- [DocuSeal Docker Image](https://hub.docker.com/r/docuseal/docuseal)
+- [DocuSeal GitHub Releases](https://github.com/docusealco/docuseal/releases)
+
+## License
+
+This Sealos template is provided under the repository's template license. DocuSeal itself is licensed under AGPLv3 with additional terms from DocuSeal LLC.

--- a/template/docuseal/README_zh.md
+++ b/template/docuseal/README_zh.md
@@ -1,28 +1,140 @@
-# DocuSeal
+# 在 Sealos 上部署和托管 DocuSeal
 
-## 应用概览
+DocuSeal 是一个开源平台，可在线创建、填写和签署 PDF 表单。此模板会在 Sealos Cloud 上部署 DocuSeal，并配套 PostgreSQL、持久化文件存储和公开 HTTPS 访问入口。
 
-开源文档签名解决方案。创建、填写和签署具有法律约束力的电子签名数字文档。
+![DocuSeal 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/website-screenshot.webp)
 
-此 Sealos 模板会将 **DocuSeal** 部署为 `docuseal` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于托管 DocuSeal
 
-## 在 Sealos 上部署
+DocuSeal 提供一套自托管文档流程，用于上传 PDF、添加可填写字段、收集签名并管理已完成的提交记录。对于希望把电子签名数据保留在自有部署环境中的团队，它很适合用于搭建可控的签署系统。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+此 Sealos 模板会将 DocuSeal 作为单个 Web 服务运行，并创建一个 Kubeblocks PostgreSQL 数据库存储应用数据。上传的文档和生成的文件会保存在挂载到 `/data/docuseal` 的持久化卷中，重启或滚动更新后仍会保留。
 
-## 访问方式
+Sealos 会自动配置公网 HTTPS 路由、服务发现、持久化存储和资源限制。模板还会把 DocuSeal 的公开 `APP_URL` 设置为生成的 Sealos 域名，因此初始化页面、邮件链接、Webhook URL 和 Open Graph 元数据都会使用正确的外部地址。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
 
-## 配置说明
+- **内部文件审批**：准备 PDF 表单，收集员工、外包人员或合作伙伴的签名。
+- **客户协议签署**：发送服务协议、入驻文件和授权表单，让客户在线签署。
+- **运营纸质流程数字化**：将交接单、检查清单、确认书等高频文件转成在线流程。
+- **API 驱动的签署流程**：使用 DocuSeal API 和 Webhook，把文件签署能力接入已有产品。
+- **自托管电子签名系统**：把签署数据和文件保存在自己的 Sealos 工作区，而不只依赖托管 SaaS 账号。
 
-部署时可以配置以下用户可见输入项：
+## DocuSeal 托管依赖
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+此 Sealos 模板包含运行所需的组件：DocuSeal 容器镜像、PostgreSQL `postgresql-16.4.0` 数据库、用于创建 `docuseal` 数据库的初始化 Job、应用持久化存储、Kubernetes Service、Ingress 和 Sealos App 入口。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖
 
-## 官方链接
+- [DocuSeal 官网](https://www.docuseal.com/) - 产品概览和官方云服务
+- [DocuSeal GitHub 仓库](https://github.com/docusealco/docuseal) - 源码、Docker 镜像和版本发布记录
+- [DocuSeal 文档](https://www.docuseal.com/docs) - 产品与集成文档
+- [DocuSeal API 参考](https://www.docuseal.com/docs/api) - 自动化和集成所需的 API 端点
 
-- 官方网站: https://www.docuseal.com/
-- 源码仓库: https://github.com/docusealco/docuseal
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **DocuSeal Web 服务**：运行 `docuseal/docuseal:3.0.1`，监听 `3000` 端口，提供 Web UI、API、嵌入式签署页面和后台任务。
+- **PostgreSQL**：由 Kubeblocks 管理的 PostgreSQL `postgresql-16.4.0`，用于存储用户、账号、模板、提交记录和应用元数据。
+- **PostgreSQL 初始化 Job**：在 PostgreSQL 就绪后，以幂等方式创建 `docuseal` 数据库。
+- **持久化存储**：挂载到 `/data/docuseal` 的 `1Gi` 卷，用于保存 DocuSeal 运行文件和上传附件。
+- **Ingress 与 App 入口**：Sealos 暴露 HTTPS 访问域名，并在仪表盘中创建应用入口。
+
+**配置：**
+
+模板会自动配置：
+
+- `APP_URL` 为 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。
+- `HOST` 为生成的 Sealos 主机名。
+- `FORCE_SSL=true`，让 DocuSeal 按 HTTPS 公网路由运行。
+- `SECRET_KEY_BASE` 为自动生成的密钥。
+- `DATABASE_URL` 来自 Kubeblocks PostgreSQL 连接 Secret。
+
+部署时不需要填写必填参数。SMTP、对象存储、SSO 或许可证相关设置可在部署后通过 DocuSeal UI 配置，也可以在 Sealos Canvas 中编辑工作负载环境变量。
+
+**许可证信息：**
+
+DocuSeal 使用 AGPLv3 License，并附带 DocuSeal LLC 的额外条款。此 Sealos 模板只是 DocuSeal 的部署配置，不改变上游应用许可证。
+
+## 为什么在 Sealos 上部署 DocuSeal？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，覆盖从云端开发到生产部署和运维管理的完整应用生命周期。在 Sealos 上部署 DocuSeal 可以获得：
+
+- **一键部署**：通过一个模板同时部署 DocuSeal、PostgreSQL、存储、网络和仪表盘入口。
+- **无需 Kubernetes 经验**：不用手写清单，也能获得 Kubernetes 的可靠性。
+- **内置持久化存储**：上传文档、生成文件和数据库数据会在重启后保留。
+- **即时公网访问**：每次部署都会获得 HTTPS URL，可用于初始化、签署页面和 API 回调。
+- **易于自定义**：可通过 Sealos Canvas 和 AI 对话调整环境变量、资源和存储。
+- **按量使用资源**：从紧凑资源配置起步，随着签署业务增长再扩容。
+
+在 Sealos 上部署 DocuSeal，可以把精力放在文档流程本身，而不是基础设施维护上。
+
+## 部署指南
+
+1. 打开 [DocuSeal 模板](https://sealos.run/products/app-store/docuseal)，点击 **Deploy Now**。
+2. 除非需要自定义生成名称或访问域名，否则保留默认参数即可。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会跳转到 Canvas。后续如需修改，可在 AI 对话框中描述需求，或点击对应资源卡片调整配置。
+4. 从 App 入口打开生成的 DocuSeal URL。
+5. 完成首次初始化表单：
+   - 输入首个管理员的名字和姓氏。
+   - 输入管理员邮箱地址。
+   - 输入公司或工作区名称。
+   - 设置管理员密码。
+   - App URL 字段保持生成的 Sealos HTTPS URL；除非你已经配置了自定义域名。
+   - 选择界面语言并提交表单。
+6. 初始化完成后，后续可在登录页使用同一个邮箱和密码登录。
+
+## 配置
+
+部署后，你可以通过以下方式配置 DocuSeal：
+
+- **初始化页面**：创建首个管理员账号，并保存公开 App URL。
+- **DocuSeal 账号设置**：管理用户、品牌、签署偏好、Webhook、API Token 和账号级选项。
+- **Sealos AI 对话**：描述环境变量或资源调整需求，让 AI 协助修改。
+- **资源卡片**：在 Canvas 中点击 StatefulSet、PostgreSQL、Ingress 或存储卡片，查看并调整配置。
+
+如果需要发送站内邀请或签署邮件，请先配置 SMTP 相关环境变量。若后续修改公网域名，也应在 DocuSeal 账号设置中同步更新 App URL，确保生成的签署链接继续使用正确主机名。
+
+## 扩展
+
+在 Sealos 上扩展 DocuSeal：
+
+1. 打开 DocuSeal 部署对应的 Canvas。
+2. 点击 DocuSeal StatefulSet 资源卡片。
+3. 当大 PDF、频繁上传或高签署流量需要更多容量时，提高 CPU 或内存资源。
+4. 应用变更并等待 Pod 重新就绪。
+
+默认模板使用适合评估和轻量使用的紧凑资源配置。若用于更重的生产工作负载，请提高应用资源，并考虑为大量附件启用外部对象存储。
+
+## 故障排查
+
+### 应用打开后进入初始化页面
+
+这是新部署的正常行为。请在初始化页面创建首个管理员账号。首个用户创建后，未登录访问会跳转到登录页。
+
+### 生成链接使用了错误域名
+
+进入 DocuSeal 账号设置，将 App URL 更新为当前 Sealos HTTPS URL 或你的自定义域名。模板会为新部署自动设置 `APP_URL`，但手动更换域名后，也需要在 DocuSeal 内同步更新。
+
+### 邀请邮件或签署邮件无法发送
+
+DocuSeal 需要 SMTP 配置才能发送外部邮件。请在 StatefulSet 资源卡片中添加所需 SMTP 环境变量，重启工作负载，然后在 DocuSeal 设置中测试邮件发送。
+
+### 获取帮助
+
+- [DocuSeal 文档](https://www.docuseal.com/docs)
+- [DocuSeal GitHub Issues](https://github.com/docusealco/docuseal/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [DocuSeal API 参考](https://www.docuseal.com/docs/api)
+- [DocuSeal Docker 镜像](https://hub.docker.com/r/docuseal/docuseal)
+- [DocuSeal GitHub Releases](https://github.com/docusealco/docuseal/releases)
+
+## 许可证
+
+此 Sealos 模板遵循仓库中的模板许可证。DocuSeal 本身使用 AGPLv3，并附带 DocuSeal LLC 的额外条款。

--- a/template/docuseal/index.yaml
+++ b/template/docuseal/index.yaml
@@ -1,312 +1,367 @@
 apiVersion: app.sealos.io/v1
 kind: Template
 metadata:
-  name: docuseal
+    name: docuseal
 spec:
-  title: 'DocuSeal'
-  url: 'https://www.docuseal.com/'
-  gitRepo: 'https://github.com/docusealco/docuseal'
-  author: 'Sealos'
-  description: 'Open source document signing solution. Create, fill, and sign digital documents with legally binding eSignatures.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/logo.svg'
-  screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/website-screenshot.webp'
-  templateType: inline
-  locale: en
-  i18n:
-    zh:
-      title: 'DocuSeal'
-      description: '开源文档签名解决方案。创建、填写和签署具有法律约束力的电子签名数字文档。'
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/README_zh.md'
-  categories:
-    - tool
-  defaults:
-    app_name:
-      type: string
-      value: docuseal-${{ random(8) }}
-    app_host:
-      type: string
-      value: docuseal-${{ random(8) }}
+    title: "DocuSeal"
+    url: "https://www.docuseal.com/"
+    gitRepo: "https://github.com/docusealco/docuseal"
+    author: "Sealos"
+    description: "Open source platform for creating, filling, and signing PDF forms with secure digital signatures."
+    readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/README.md"
+    icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/logo.svg"
+    screenshots:
+        - "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/website-screenshot.webp"
+    templateType: inline
+    locale: en
+    i18n:
+        zh:
+            description: "用于创建、填写和签署 PDF 表单的开源平台，支持安全的数字签名流程。"
+            readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/README_zh.md"
+    categories:
+        - tool
+    defaults:
+        app_name:
+            type: string
+            value: docuseal-${{ random(8) }}
+        app_host:
+            type: string
+            value: docuseal-${{ random(8) }}
+        secret_key_base:
+            type: string
+            value: ${{ random(128) }}
 ---
 # PostgreSQL ServiceAccount
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
+    name: ${{ defaults.app_name }}-pg
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
 
 ---
 # PostgreSQL Role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
+    name: ${{ defaults.app_name }}-pg
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
 rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
+    - apiGroups:
+          - "*"
+      resources:
+          - "*"
+      verbs:
+          - "*"
 
 ---
 # PostgreSQL RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-pg
-subjects:
-  - kind: ServiceAccount
     name: ${{ defaults.app_name }}-pg
+    labels:
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+        app.kubernetes.io/managed-by: kbcli
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: ${{ defaults.app_name }}-pg
+subjects:
+    - kind: ServiceAccount
+      name: ${{ defaults.app_name }}-pg
 
 ---
 # PostgreSQL Cluster
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
+    name: ${{ defaults.app_name }}-pg
+    labels:
+        kb.io/database: postgresql-16.4.0
+        clusterdefinition.kubeblocks.io/name: postgresql
+        clusterversion.kubeblocks.io/name: postgresql-16.4.0
+        sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
+    affinity:
+        podAntiAffinity: Preferred
+        tenancy: SharedNode
+    clusterDefinitionRef: postgresql
+    clusterVersionRef: postgresql-16.4.0
+    terminationPolicy: Delete
+    componentSpecs:
+        - name: postgresql
+          componentDefRef: postgresql
+          disableExporter: true
+          enabledLogs:
+              - running
+          replicas: 1
+          serviceAccountName: ${{ defaults.app_name }}-pg
+          switchPolicy:
+              type: Noop
+          resources:
+              limits:
+                  cpu: 500m
+                  memory: 512Mi
               requests:
-                storage: 1Gi
-            storageClassName: openebs-backup
-  terminationPolicy: Delete
-  tolerations: []
+                  cpu: 50m
+                  memory: 51Mi
+          volumeClaimTemplates:
+              - name: data
+                spec:
+                    accessModes:
+                        - ReadWriteOnce
+                    resources:
+                        requests:
+                            storage: 1Gi
+                    storageClassName: openebs-backup
 
 ---
 # PostgreSQL Init Job
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ${{ defaults.app_name }}-pg-init
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-init
+    name: ${{ defaults.app_name }}-pg-init
 spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: pgsql-init
-          image: postgres:14-alpine
-          env:
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE docuseal;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 300
+    template:
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: pgsql-init
+                  image: postgres:16-alpine
+                  imagePullPolicy: IfNotPresent
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 12Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi
+                  env:
+                      - name: PG_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: password
+                      - name: PG_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: endpoint
+                      - name: PG_DATABASE
+                        value: docuseal
+                  command:
+                      - /bin/sh
+                      - -c
+                      - |
+                          set -eu
+                          for i in $(seq 1 60); do
+                            if pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1; then
+                              break
+                            fi
+                            sleep 2
+                          done
+                          pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1
+                          if ! psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='docuseal'" | grep -q 1; then
+                            psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "docuseal";'
+                          fi
 
 ---
 # Main Application StatefulSet
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: ${{ defaults.app_name }}
-  annotations:
-    originImageName: docuseal/docuseal:latest
-    deploy.cloud.sealos.io/minReplicas: '1'
-    deploy.cloud.sealos.io/maxReplicas: '1'
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app: ${{ defaults.app_name }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 1
-  serviceName: ${{ defaults.app_name }}
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}
-  template:
-    metadata:
-      labels:
+    name: ${{ defaults.app_name }}
+    annotations:
+        originImageName: docuseal/docuseal:3.0.1
+        deploy.cloud.sealos.io/minReplicas: "1"
+        deploy.cloud.sealos.io/maxReplicas: "1"
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
         app: ${{ defaults.app_name }}
-    spec:
-      automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: docuseal/docuseal:latest
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: FORCE_SSL
-              value: 'true'
-            - name: PG_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: PG_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: PG_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: username
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/docuseal
-          ports:
-            - containerPort: 3000
-              name: http
-          volumeMounts:
-            - name: vn-datavn-docuseal
-              mountPath: /data/docuseal
-          resources:
-            requests:
-              cpu: 20m
-              memory: 25Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
-  volumeClaimTemplates:
-    - metadata:
-        annotations:
-          path: /data/docuseal
-          value: '1'
-        name: vn-datavn-docuseal
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+spec:
+    replicas: 1
+    revisionHistoryLimit: 1
+    serviceName: ${{ defaults.app_name }}
+    selector:
+        matchLabels:
+            app: ${{ defaults.app_name }}
+    template:
+        metadata:
+            labels:
+                app: ${{ defaults.app_name }}
+        spec:
+            automountServiceAccountToken: false
+            imagePullSecrets:
+                - name: ${{ defaults.app_name }}
+            containers:
+                - name: ${{ defaults.app_name }}
+                  image: docuseal/docuseal:3.0.1
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: FORCE_SSL
+                        value: "true"
+                      - name: APP_URL
+                        value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+                      - name: HOST
+                        value: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+                      - name: SECRET_KEY_BASE
+                        value: ${{ defaults.secret_key_base }}
+                      - name: PG_HOST
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: host
+                      - name: PG_PORT
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: port
+                      - name: PG_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: username
+                      - name: PG_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: ${{ defaults.app_name }}-pg-conn-credential
+                                key: password
+                      - name: DATABASE_URL
+                        value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/docuseal
+                  ports:
+                      - containerPort: 3000
+                        name: http
+                        protocol: TCP
+                  startupProbe:
+                      httpGet:
+                          path: /up
+                          port: http
+                          scheme: HTTP
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 36
+                  livenessProbe:
+                      httpGet:
+                          path: /up
+                          port: http
+                          scheme: HTTP
+                      periodSeconds: 20
+                      timeoutSeconds: 5
+                      failureThreshold: 6
+                  readinessProbe:
+                      httpGet:
+                          path: /up
+                          port: http
+                          scheme: HTTP
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 6
+                  volumeMounts:
+                      - name: vn-datavn-docuseal
+                        mountPath: /data/docuseal
+                  resources:
+                      requests:
+                          cpu: 20m
+                          memory: 25Mi
+                      limits:
+                          cpu: 200m
+                          memory: 256Mi
+    volumeClaimTemplates:
+        - metadata:
+              annotations:
+                  path: /data/docuseal
+                  value: "1"
+              name: vn-datavn-docuseal
+          spec:
+              accessModes:
+                  - ReadWriteOnce
+              resources:
+                  requests:
+                      storage: 1Gi
 
 ---
 # Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  ports:
-    - port: 3000
-      targetPort: 3000
-      name: http
-  selector:
-    app: ${{ defaults.app_name }}
+    ports:
+        - name: http
+          port: 3000
+          targetPort: http
+          protocol: TCP
+    selector:
+        app: ${{ defaults.app_name }}
 
 ---
 # Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 32m
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 64k;
-      large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
-    nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
-        expires 30d;
-        add_header Cache-Control "public";
-      }
+    name: ${{ defaults.app_name }}
+    labels:
+        app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
+    annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-body-size: 32m
+        nginx.ingress.kubernetes.io/server-snippet: |
+            client_header_buffer_size 64k;
+            large_client_header_buffers 4 128k;
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: HTTP
+        nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
+        nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+            if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
+              expires 30d;
+              add_header Cache-Control "public";
+            }
 spec:
-  rules:
-    - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      http:
-        paths:
-          - pathType: Prefix
-            path: /
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 3000
-  tls:
-    - hosts:
-        - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      secretName: ${{ SEALOS_CERT_SECRET_NAME }}
+    rules:
+        - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+          http:
+              paths:
+                  - pathType: Prefix
+                    path: /
+                    backend:
+                        service:
+                            name: ${{ defaults.app_name }}
+                            port:
+                                number: 3000
+    tls:
+        - hosts:
+              - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+          secretName: ${{ SEALOS_CERT_SECRET_NAME }}
 
 ---
 # App CR
 apiVersion: app.sealos.io/v1
 kind: App
 metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  data:
-    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-  displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/logo.svg"
-  name: DocuSeal
-  type: link
+    data:
+        url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+    displayType: normal
+    icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/docuseal/logo.svg"
+    name: DocuSeal
+    type: link


### PR DESCRIPTION
## Summary
- Update DocuSeal to 3.0.1 and move the template to the current Sealos PostgreSQL 16.4.0 pattern.
- Add public URL, health probes, generated secret, image pull secrets, and deployment-tested minimal app resources.
- Rewrite English and Chinese READMEs with deployment, first-run setup, login, and management guidance.

## Tests
- python /Users/longnv/.codex/worktrees/8757/templates/scripts/check_consistency.py --skill /Users/longnv/.codex/worktrees/8757/templates/SKILL.md --references /Users/longnv/.codex/worktrees/8757/templates/references --rules-file /Users/longnv/.codex/worktrees/8757/templates/references/rules-registry.yaml --artifacts /Users/longnv/.codex/worktrees/8757/templates/template/docuseal/index.yaml
- DOCKER_TO_SEALOS_ARTIFACTS=/Users/longnv/.codex/worktrees/8757/templates/template/docuseal/index.yaml python /Users/longnv/.codex/worktrees/8757/templates/scripts/quality_gate.py
- python - <<PY (yaml.safe_load_all for template/docuseal/index.yaml)
- git diff --check
- Deployed docuseal-hvbubmsr on Sealos, verified /up and /setup, tuned resources at 200m CPU / 256Mi memory, then cleaned all test resources.