### PR TITLE
feat(affine): update Sealos template to 0.26.6

### DIFF
--- a/template/affine/README.md
+++ b/template/affine/README.md
@@ -1,28 +1,154 @@
-# AFFiNE
+# Deploy and Host AFFiNE on Sealos
 
-## Overview
+AFFiNE is a local-first, privacy-focused workspace for notes, documents, whiteboards, and knowledge management. This template deploys AFFiNE 0.26.6 with PostgreSQL, Redis, persistent storage, HTTPS ingress, and first-run admin setup on Sealos Cloud.
 
-A privacy-focussed, local-first, open-source, and ready-to-use alternative for Notion & Miro.
+![AFFiNE Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/website-screenshot.webp)
 
-This Sealos template deploys **AFFiNE** as the `affine` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting AFFiNE
 
-## Deploy on Sealos
+AFFiNE runs in self-hosted all-in-one mode and serves the web UI, API, document collaboration, and background jobs from one application workload. The template also provisions managed PostgreSQL for workspace metadata and Redis for cache and job coordination, so the application can start without manual database wiring.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The deployment stores AFFiNE configuration and uploaded workspace files on persistent volumes mounted at `/root/.affine/config` and `/root/.affine/storage`. Sealos provides the public HTTPS endpoint, Kubernetes scheduling, resource controls, and Canvas-based operations for later updates.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **Personal knowledge base**: Keep notes, docs, and whiteboards in a self-hosted workspace.
+- **Team documentation**: Manage project plans, meeting notes, and shared knowledge with persistent storage.
+- **Whiteboard collaboration**: Use AFFiNE's canvas-style blocks for diagrams, brainstorming, and visual planning.
+- **Privacy-focused workspace**: Host your workspace data in your own Sealos deployment instead of using a hosted SaaS account.
+
+## Dependencies for AFFiNE Hosting
+
+The Sealos template includes all required runtime dependencies:
+
+- **AFFiNE application**: `ghcr.io/toeverything/affine:0.26.6`
+- **PostgreSQL**: Kubeblocks-managed `postgresql-16.4.0` cluster with a dedicated `affine` database
+- **Redis**: Kubeblocks-managed `redis-7.2.7` cluster for cache and background jobs
+- **Persistent volumes**: Separate PVCs for AFFiNE config and uploaded storage
+- **Ingress and App entry**: HTTPS public URL exposed through Sealos
+
+### Deployment Dependencies
+
+- [AFFiNE Official Website](https://affine.pro/) - Product overview and feature information
+- [AFFiNE Self-host Documentation](https://docs.affine.pro/docs/self-host-affine) - Official self-hosting guide
+- [AFFiNE GitHub Repository](https://github.com/toeverything/AFFiNE) - Source code, releases, and issue tracking
+- [Sealos Documentation](https://sealos.io/docs) - Platform guides and operational documentation
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **AFFiNE StatefulSet**: Runs the self-hosted all-in-one AFFiNE server on port `3010`.
+- **Migration Job**: Executes `node ./scripts/self-host-predeploy.js` before the application serves traffic.
+- **PostgreSQL Cluster**: Stores account, workspace, and application metadata in the `affine` database.
+- **Redis Cluster**: Provides cache and queue coordination for the AFFiNE server.
+- **Service + Ingress + App**: Routes the generated HTTPS domain to the AFFiNE service.
+- **Persistent Storage**: Keeps `/root/.affine/config` and `/root/.affine/storage` across restarts.
+
+**Configuration:**
+
+- `DATABASE_URL` is composed from the Kubeblocks PostgreSQL secret and points to the `affine` database.
+- `REDIS_SERVER_HOST`, `REDIS_SERVER_USER`, and `REDIS_SERVER_PASSWORD` are wired from the Redis service and secret.
+- `AFFINE_SERVER_EXTERNAL_URL` is set to the generated Sealos HTTPS URL so AFFiNE can build correct public links.
+- `AFFINE_INDEXER_ENABLED=false` follows the upstream single-node self-hosting setup and avoids requiring an external search indexer.
+
+**Resource Baseline:**
+
+The tested minimum baseline keeps the AFFiNE app at `500m` CPU and `512Mi` memory, PostgreSQL at `500m` CPU and `512Mi` memory, and Redis at `500m` CPU and `512Mi` memory for each Redis component. A 256Mi AFFiNE app limit booted but restarted once during startup, so the template uses 512Mi for a stable cold start.
+
+**License Information:**
+
+AFFiNE uses a mixed license model. The repository root declares MIT for most source code, while backend Enterprise Edition portions are governed by the AFFiNE EE license and Community Edition portions by MPL-2.0. Review the upstream license files before using the software in production.
+
+## Why Deploy AFFiNE on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies deployment, storage, networking, and application operations. By deploying AFFiNE on Sealos, you get:
+
+- **One-Click Deployment**: Launch AFFiNE with PostgreSQL, Redis, storage, and HTTPS routing from one template.
+- **Managed Kubernetes Runtime**: Run AFFiNE on Kubernetes without hand-writing manifests or operating cluster primitives directly.
+- **Persistent Data by Default**: Keep AFFiNE configuration and uploaded workspace data on PVC-backed storage.
+- **Easy Customization**: Adjust resources, environment variables, and storage from Canvas resource cards or the AI dialog.
+- **Instant Public Access**: Receive a generated HTTPS URL after deployment.
+- **Pay-as-you-go Resources**: Start from the tested baseline and scale CPU, memory, and storage only when your workload needs it.
+
+Deploy AFFiNE on Sealos to keep control of your workspace data while reducing infrastructure maintenance.
+
+## Deployment Guide
+
+1. Open the [AFFiNE template](https://sealos.io/products/app-store/affine) and click **Deploy Now**.
+2. Review the generated app name and domain in the popup dialog. The default configuration is enough for a working deployment.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Open the generated AFFiNE URL from the app card.
+5. On first access, AFFiNE redirects to `/admin/setup`. Create the first administrator account with your name, email, and password.
+6. After setup, choose **Open AFFiNE** or go back to the generated app URL. Use the administrator email and password you created to sign in later.
+
+## First Login and Registration
+
+AFFiNE self-hosted mode requires an initial administrator before the workspace is usable.
+
+1. Open your generated AFFiNE URL.
+2. If the instance is new, you will be redirected to `https://<your-affine-domain>/admin/setup`.
+3. Click **Continue** and create the first administrator account.
+4. Use the same email and password to sign in to AFFiNE and to access the admin area at `/admin`.
+
+Use a strong password. AFFiNE expects an 8-32 character password, and it is best to include at least two character types such as uppercase letters, lowercase letters, numbers, or symbols.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure AFFiNE through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AFFiNE Admin Panel**: Open `/admin` on your generated domain to manage self-hosted settings.
+- **Canvas AI Dialog**: Describe changes such as resource adjustments or environment updates and let AI apply them.
+- **Resource Cards**: Edit the AFFiNE StatefulSet, PostgreSQL cluster, Redis cluster, Service, Ingress, or PVC resources.
+- **AFFiNE UI**: Manage workspaces, members, and documents from the application itself.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+SMTP and OAuth providers are not preconfigured by this template. Configure them later in AFFiNE admin settings or by adding the required environment variables according to the official documentation.
 
-## Official Links
+## Scaling
 
-- Official website: https://affine.pro/
-- Source repository: https://github.com/toeverything/AFFiNE
+For most small AFFiNE workspaces, keep a single AFFiNE replica and scale vertically first:
+
+1. Open the deployment in Canvas.
+2. Select the AFFiNE StatefulSet resource card.
+3. Increase CPU or memory if imports, large workspaces, or concurrent users increase load.
+4. Scale PostgreSQL, Redis, and PVC capacity from their resource cards when data size grows.
+
+Keep the application at one replica unless you have reviewed AFFiNE self-hosting behavior for multi-replica deployments.
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue: The application redirects to `/admin/setup`**
+- Cause: The AFFiNE instance has not been initialized yet.
+- Solution: Create the first administrator account from the setup page, then return to the app URL.
+
+**Issue: The app page is not ready immediately after deployment**
+- Cause: PostgreSQL, Redis, the database initialization job, and the migration job are still starting.
+- Solution: Wait a few minutes and check that the AFFiNE StatefulSet, PostgreSQL cluster, Redis cluster, and migration job are healthy in Canvas.
+
+**Issue: Email invitations or password reset emails do not send**
+- Cause: SMTP is not configured by default.
+- Solution: Configure SMTP settings according to the AFFiNE self-host documentation before relying on email workflows.
+
+**Issue: The pod restarts during cold start**
+- Cause: The app memory limit is too low for AFFiNE startup and background services.
+- Solution: Keep the default 512Mi app memory limit or increase it from Canvas for larger workspaces.
+
+### Getting Help
+
+- [AFFiNE Self-host Documentation](https://docs.affine.pro/docs/self-host-affine)
+- [AFFiNE GitHub Issues](https://github.com/toeverything/AFFiNE/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [AFFiNE Documentation](https://docs.affine.pro/)
+- [AFFiNE Community](https://community.affine.pro/)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is provided under the repository license. AFFiNE itself uses the upstream mixed license model described in its repository license files.

--- a/template/affine/README_zh.md
+++ b/template/affine/README_zh.md
@@ -1,28 +1,154 @@
-# AFFiNE
+# 在 Sealos 上部署和托管 AFFiNE
 
-## 应用概览
+AFFiNE 是一个本地优先、隐私优先的工作区，可用于笔记、文档、白板和知识管理。此模板会在 Sealos Cloud 上部署 AFFiNE 0.26.6，并自动配置 PostgreSQL、Redis、持久化存储、HTTPS Ingress 和首次管理员初始化流程。
 
-AFFiNE 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+![AFFiNE 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/website-screenshot.webp)
 
-此 Sealos 模板会将 **AFFiNE** 部署为 `affine` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于 AFFiNE 托管
 
-## 在 Sealos 上部署
+AFFiNE 以 self-hosted all-in-one 模式运行，一个应用工作负载同时提供 Web UI、API、文档协作和后台任务。模板会同时创建托管 PostgreSQL 与 Redis，分别用于工作区元数据、缓存和任务协调，无需手动配置数据库连接。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+部署会将 AFFiNE 配置和上传文件保存到持久卷，挂载路径分别为 `/root/.affine/config` 和 `/root/.affine/storage`。Sealos 负责公网 HTTPS 入口、Kubernetes 调度、资源限制和后续 Canvas 运维。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **个人知识库**：自托管笔记、文档和白板工作区。
+- **团队文档协作**：管理项目计划、会议记录和共享知识。
+- **白板与视觉化整理**：使用 AFFiNE 的画布式块结构进行图示、头脑风暴和视觉规划。
+- **隐私优先工作区**：在自己的 Sealos 部署中保存工作区数据，而不是完全依赖 SaaS 账号。
 
-## 配置说明
+## AFFiNE 托管依赖
 
-部署时可以配置以下用户可见输入项：
+此 Sealos 模板包含运行 AFFiNE 所需的依赖：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- **AFFiNE 应用**：`ghcr.io/toeverything/affine:0.26.6`
+- **PostgreSQL**：Kubeblocks 托管的 `postgresql-16.4.0` 集群，并创建专用 `affine` 数据库
+- **Redis**：Kubeblocks 托管的 `redis-7.2.7` 集群，用于缓存和后台任务
+- **持久化卷**：分别保存 AFFiNE 配置和上传文件
+- **Ingress 与 App 入口**：通过 Sealos 暴露 HTTPS 公网访问地址
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖链接
 
-## 官方链接
+- [AFFiNE 官方网站](https://affine.pro/) - 产品介绍和功能信息
+- [AFFiNE 自托管文档](https://docs.affine.pro/docs/self-host-affine) - 官方自托管指南
+- [AFFiNE GitHub 仓库](https://github.com/toeverything/AFFiNE) - 源码、版本发布和问题追踪
+- [Sealos 文档](https://sealos.io/docs) - 平台使用和运维文档
 
-- 官方网站: https://affine.pro/
-- 源码仓库: https://github.com/toeverything/AFFiNE
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **AFFiNE StatefulSet**：运行 self-hosted all-in-one AFFiNE 服务，监听 `3010` 端口。
+- **迁移 Job**：在应用对外服务前执行 `node ./scripts/self-host-predeploy.js`。
+- **PostgreSQL 集群**：在 `affine` 数据库中保存账号、工作区和应用元数据。
+- **Redis 集群**：为 AFFiNE 服务提供缓存和队列协调。
+- **Service + Ingress + App**：将生成的 HTTPS 域名路由到 AFFiNE 服务。
+- **持久化存储**：保留 `/root/.affine/config` 和 `/root/.affine/storage` 数据，Pod 重启后不丢失。
+
+**配置说明：**
+
+- `DATABASE_URL` 由 Kubeblocks PostgreSQL Secret 拼装，并指向 `affine` 数据库。
+- `REDIS_SERVER_HOST`、`REDIS_SERVER_USER` 和 `REDIS_SERVER_PASSWORD` 来自 Redis 服务和 Secret。
+- `AFFINE_SERVER_EXTERNAL_URL` 设置为 Sealos 生成的 HTTPS 地址，用于生成正确的公网链接。
+- `AFFINE_INDEXER_ENABLED=false` 与上游单节点自托管配置保持一致，避免依赖外部搜索索引器。
+
+**资源基线：**
+
+经部署测试，AFFiNE 应用的稳定最小基线为 `500m` CPU 和 `512Mi` 内存；PostgreSQL 为 `500m` CPU 和 `512Mi` 内存；Redis 每个组件为 `500m` CPU 和 `512Mi` 内存。AFFiNE 应用在 256Mi 内存限制下可以启动但冷启动期间出现过一次重启，因此模板使用 512Mi 作为稳定基线。
+
+**许可证信息：**
+
+AFFiNE 采用混合许可证模式。仓库根目录声明大部分源码使用 MIT；后端 Enterprise Edition 部分受 AFFiNE EE 许可证约束，Community Edition 部分使用 MPL-2.0。生产使用前请查看上游仓库中的许可证文件。
+
+## 为什么在 Sealos 上部署 AFFiNE？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一处理部署、存储、网络和应用运维。将 AFFiNE 部署到 Sealos 可以获得：
+
+- **一键部署**：通过一个模板同时启动 AFFiNE、PostgreSQL、Redis、存储和 HTTPS 路由。
+- **托管 Kubernetes 运行时**：无需手写清单或直接维护集群底层资源，也能获得 Kubernetes 的可靠性。
+- **默认持久化数据**：AFFiNE 配置和上传的工作区文件会写入 PVC。
+- **易于定制**：可在 Canvas 资源卡片或 AI 对话中调整资源、环境变量和存储。
+- **即时公网访问**：部署完成后自动获得 HTTPS 访问地址。
+- **按量使用资源**：从已测试的资源基线开始，只在业务需要时扩展 CPU、内存和存储。
+
+在 Sealos 上部署 AFFiNE，可以在掌控工作区数据的同时减少基础设施维护成本。
+
+## 部署指南
+
+1. 打开 [AFFiNE 模板](https://sealos.io/products/app-store/affine)，点击 **Deploy Now**。
+2. 在弹窗中检查生成的应用名称和域名。保留默认配置即可部署可用实例。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas；后续变更可在对话框中描述需求让 AI 应用，或点击相关资源卡片调整配置。
+4. 从应用卡片打开生成的 AFFiNE 访问地址。
+5. 首次访问时，AFFiNE 会跳转到 `/admin/setup`。填写姓名、邮箱和密码，创建第一个管理员账号。
+6. 初始化完成后，点击 **Open AFFiNE** 或返回应用访问地址。之后使用刚创建的管理员邮箱和密码登录。
+
+## 首次登录与注册
+
+AFFiNE 自托管模式必须先创建初始管理员，工作区才能正常使用。
+
+1. 打开系统生成的 AFFiNE 地址。
+2. 如果实例尚未初始化，会自动跳转到 `https://<your-affine-domain>/admin/setup`。
+3. 点击 **Continue**，创建第一个管理员账号。
+4. 后续使用同一个邮箱和密码登录 AFFiNE，也可以通过 `/admin` 进入管理后台。
+
+请使用强密码。AFFiNE 要求密码长度为 8-32 个字符，建议至少包含两类字符，例如大写字母、小写字母、数字或符号。
+
+## 配置
+
+部署完成后，可通过以下方式配置 AFFiNE：
+
+- **AFFiNE 管理后台**：在生成域名后追加 `/admin`，管理自托管设置。
+- **Canvas AI 对话**：描述资源调整或环境变量变更，由 AI 应用修改。
+- **资源卡片**：编辑 AFFiNE StatefulSet、PostgreSQL 集群、Redis 集群、Service、Ingress 或 PVC。
+- **AFFiNE 界面**：在应用内管理工作区、成员和文档。
+
+此模板默认不配置 SMTP 和 OAuth Provider。如需邮件邀请、密码重置或第三方登录，请按 AFFiNE 官方文档在管理后台或环境变量中补充配置。
+
+## 扩缩容
+
+大多数小型 AFFiNE 工作区建议保持单副本，并优先纵向扩容：
+
+1. 在 Canvas 打开该部署。
+2. 选择 AFFiNE StatefulSet 资源卡片。
+3. 如果导入、工作区规模或并发用户增加，可提升 CPU 或内存。
+4. 当数据规模增长时，通过 PostgreSQL、Redis 和 PVC 资源卡片扩展容量。
+
+除非已确认 AFFiNE 自托管多副本行为，否则建议保持应用单副本运行。
+
+## 故障排查
+
+### 常见问题
+
+**问题：应用跳转到 `/admin/setup`**
+- 原因：AFFiNE 实例尚未初始化。
+- 处理：在 setup 页面创建第一个管理员账号，然后返回应用地址。
+
+**问题：部署后页面没有立即就绪**
+- 原因：PostgreSQL、Redis、数据库初始化 Job 和迁移 Job 仍在启动。
+- 处理：等待几分钟，并在 Canvas 中确认 AFFiNE StatefulSet、PostgreSQL 集群、Redis 集群和迁移 Job 均为健康状态。
+
+**问题：邮件邀请或密码重置邮件无法发送**
+- 原因：模板默认未配置 SMTP。
+- 处理：在依赖邮件流程前，按照 AFFiNE 自托管文档配置 SMTP。
+
+**问题：冷启动时 Pod 重启**
+- 原因：AFFiNE 启动和后台服务所需内存高于当前限制。
+- 处理：保持默认 512Mi 应用内存限制；大型工作区可在 Canvas 中继续提高。
+
+### 获取帮助
+
+- [AFFiNE 自托管文档](https://docs.affine.pro/docs/self-host-affine)
+- [AFFiNE GitHub Issues](https://github.com/toeverything/AFFiNE/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [AFFiNE 文档](https://docs.affine.pro/)
+- [AFFiNE 社区](https://community.affine.pro/)
+- [Sealos 文档](https://sealos.io/docs)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库许可证。AFFiNE 本身使用其上游仓库许可证文件中描述的混合许可证模式。

--- a/template/affine/index.yaml
+++ b/template/affine/index.yaml
@@ -7,12 +7,17 @@ spec:
   url: "https://affine.pro/"
   gitRepo: "https://github.com/toeverything/AFFiNE"
   author: "Sealos"
-  description: "A privacy-focussed, local-first, open-source, and ready-to-use alternative for Notion & Miro."
+  description: "A privacy-focused, local-first, open-source workspace for notes, docs, whiteboards, and team knowledge management."
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/logo.png'
   screenshots:
     - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/website-screenshot.webp'
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: "AFFiNE 是一个隐私优先、本地优先的开源协作工作区，可用于笔记、文档、白板和团队知识管理。"
+      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/README_zh.md'
   categories:
     - tool
   defaults:
@@ -23,11 +28,7 @@ spec:
     app_name:
       type: string
       value: affine-${{ random(8) }}
-  inputs:
-
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/affine/README_zh.md'
+  inputs: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -39,71 +40,14 @@ metadata:
   name: ${{ defaults.app_name }}-redis
 
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: Cluster
-metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
-spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
+  name: ${{ defaults.app_name }}-redis
 rules:
   - apiGroups:
       - "*"
@@ -116,116 +60,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
+  name: ${{ defaults.app_name }}-redis
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ${{ defaults.app_name }}-pg
+  name: ${{ defaults.app_name }}-redis
 subjects:
   - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-migration
-spec:
-  backoffLimit: 3
-  template:
-    spec:
-      restartPolicy: Never
-      initContainers:
-        - name: wait-for-postgres
-          image: postgres:14-alpine
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: PG_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: PG_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: PG_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: username
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until pg_isready -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USERNAME}; do
-                echo "waiting for postgresql..."
-                sleep 2
-              done
-      containers:
-        - name: affine-migration
-          image: ghcr.io/toeverything/affine:0.25.7-beta.0
-          imagePullPolicy: IfNotPresent
-          command:
-            - /bin/sh
-            - -c
-            - node ./scripts/self-host-predeploy.js
-          env:
-            - name: AFFINE_CONFIG_PATH
-              value: /root/.affine/config
-            - name: REDIS_SERVER_HOST
-              value: ${{ defaults.app_name }}-redis-redis-redis
-            - name: REDIS_SERVER_USER
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-redis-redis-account-default
-                  key: username
-            - name: REDIS_SERVER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-redis-redis-account-default
-                  key: password
-            - name: PG_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: PG_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: PG_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: username
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/affine
-            - name: AFFINE_INDEXER_ENABLED
-              value: "false"
-          resources:
-            limits:
-              cpu: 500m
-              memory: 512Mi
-            requests:
-              cpu: 50m
-              memory: 51Mi
-  ttlSecondsAfterFinished: 300
+    name: ${{ defaults.app_name }}-redis
 
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
@@ -282,12 +127,13 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 100m
-          memory: 100Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: 50m
+          memory: 51Mi
       serviceVersion: 7.2.7
+      serviceAccountName: ${{ defaults.app_name }}-redis
       volumeClaimTemplates:
         - name: data
           spec:
@@ -300,14 +146,24 @@ spec:
   topology: replication
 
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+  name: ${{ defaults.app_name }}-pg
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
+  name: ${{ defaults.app_name }}-pg
 rules:
   - apiGroups:
       - "*"
@@ -320,48 +176,146 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
+  name: ${{ defaults.app_name }}-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ${{ defaults.app_name }}-redis
+  name: ${{ defaults.app_name }}-pg
 subjects:
   - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-redis
+    name: ${{ defaults.app_name }}-pg
 
 ---
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
 metadata:
-  name: ${{ defaults.app_name }}
-  annotations:
-    originImageName: ghcr.io/toeverything/affine:0.25.7-beta.0
-    deploy.cloud.sealos.io/minReplicas: "1"
-    deploy.cloud.sealos.io/maxReplicas: "1"
+  finalizers:
+    - cluster.kubeblocks.io/finalizer
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app: ${{ defaults.app_name }}
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+  annotations: {}
+  name: ${{ defaults.app_name }}-pg
 spec:
-  replicas: 1
-  revisionHistoryLimit: 1
-  minReadySeconds: 10
-  serviceName: ${{ defaults.app_name }}
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}
+  affinity:
+    nodeLabels: {}
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+    topologyKeys: []
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-16.4.0
+  componentSpecs:
+    - componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
+      name: postgresql
+      replicas: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 51Mi
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
+
+  terminationPolicy: Delete
+  tolerations: []
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-pg-init
+spec:
+  backoffLimit: 3
   template:
-    metadata:
-      labels:
-        app: ${{ defaults.app_name }}
     spec:
-      terminationGracePeriodSeconds: 10
-      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      containers:
+        - name: pgsql-init
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PG_DATABASE
+              value: affine
+            - name: PGPASSWORD
+              value: $(PG_PASSWORD)
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              for i in $(seq 1 120); do
+                if pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                echo "waiting for postgresql..."
+                sleep 2
+              done
+              pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres >/dev/null 2>&1
+              if ! psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
+                psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE affine;'
+              fi
+  ttlSecondsAfterFinished: 300
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-migration
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
       initContainers:
-        - name: ensure-affine-database
-          image: postgres:14-alpine
+        - name: wait-for-postgres
+          image: postgres:16-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -384,23 +338,36 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
           command:
             - /bin/sh
             - -c
             - |
-              echo "waiting for affine database..."
-              until psql -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USERNAME} -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='affine';" | grep -q 1; do
-                echo "affine database missing, rechecking in 2s"
+              until pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" >/dev/null 2>&1; do
+                echo "waiting for postgresql..."
                 sleep 2
               done
       containers:
-        - name: ${{ defaults.app_name }}
-          image: ghcr.io/toeverything/affine:0.25.7-beta.0
+        - name: affine-migration
+          image: ghcr.io/toeverything/affine:0.26.6
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - node ./scripts/self-host-predeploy.js
           env:
             - name: AFFINE_CONFIG_PATH
               value: /root/.affine/config
+            - name: AFFINE_SERVER_EXTERNAL_URL
+              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
             - name: REDIS_SERVER_HOST
-              value: ${{ defaults.app_name }}-redis-redis-redis
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local
             - name: REDIS_SERVER_USER
               valueFrom:
                 secretKeyRef:
@@ -411,22 +378,160 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-redis-redis-account-default
                   key: password
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
             - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432/affine
+              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/affine
+            - name: AFFINE_INDEXER_ENABLED
+              value: "false"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 51Mi
+  ttlSecondsAfterFinished: 300
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${{ defaults.app_name }}
+  annotations:
+    originImageName: ghcr.io/toeverything/affine:0.26.6
+    deploy.cloud.sealos.io/minReplicas: "1"
+    deploy.cloud.sealos.io/maxReplicas: "1"
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  minReadySeconds: 10
+  serviceName: ${{ defaults.app_name }}
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}
+    spec:
+      terminationGracePeriodSeconds: 10
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
+      initContainers:
+        - name: ensure-affine-database
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "waiting for affine database..."
+              until psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='affine';" | grep -q 1; do
+                echo "affine database missing, rechecking in 2s"
+                sleep 2
+              done
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: ghcr.io/toeverything/affine:0.26.6
+          env:
+            - name: AFFINE_CONFIG_PATH
+              value: /root/.affine/config
+            - name: AFFINE_SERVER_EXTERNAL_URL
+              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: REDIS_SERVER_HOST
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local
+            - name: REDIS_SERVER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-redis-redis-account-default
+                  key: username
+            - name: REDIS_SERVER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-redis-redis-account-default
+                  key: password
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: DATABASE_URL
+              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/affine
             - name: AFFINE_INDEXER_ENABLED
               value: "false"
           resources:
             requests:
               cpu: 50m
-              memory: 25Mi
+              memory: 51Mi
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 512Mi
           ports:
             - name: http
               protocol: TCP
@@ -437,16 +542,27 @@ spec:
               mountPath: /root/.affine/storage
             - name: vn-rootvn-vn-affinevn-config
               mountPath: /root/.affine/config
+          startupProbe:
+            httpGet:
+              path: /info
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /
+              path: /info
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /info
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -477,10 +593,14 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 3010
+    - name: http
+      port: 3010
+      targetPort: http
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
 ---


### PR DESCRIPTION
## Summary

- Update AFFiNE to `ghcr.io/toeverything/affine:0.26.6`
- Align the template with current docker-to-sealos requirements for PostgreSQL, Redis, App, Service, health checks, and i18n metadata
- Add PostgreSQL database initialization, migration gating, external URL wiring, and a tested 512Mi AFFiNE memory baseline
- Rewrite English and Chinese READMEs with deployment, first-admin setup, login, resources, and troubleshooting details

## Testing

- `python scripts/check_consistency.py --skill SKILL.md --references references --rules-file references/rules-registry.yaml --artifacts /Users/longnv/.codex/worktrees/ca90/templates/template/affine/index.yaml`
- `node scripts/deploy-template.mjs /Users/longnv/.codex/worktrees/ca90/templates/template/affine/index.yaml --dry-run`
- `DOCKER_TO_SEALOS_ARTIFACTS=/Users/longnv/.codex/worktrees/ca90/templates/template/affine/index.yaml python scripts/quality_gate.py`
- Deployed AFFiNE on Sealos, verified `/info` returns `AFFiNE 0.26.6 Server`, confirmed first access redirects to `/admin/setup`, and created the initial admin account successfully
- Cleaned up all AFFiNE test deployments, including Instance resources
