### PR TITLE
fix(nakama): update template to v3.39.0

### DIFF
--- a/template/nakama/README.md
+++ b/template/nakama/README.md
@@ -1,171 +1,166 @@
 # Deploy and Host Nakama Server on Sealos
 
-Nakama is an open-source game server for real-time multiplayer, social features, and live ops. This template deploys a production-ready Nakama server with PostgreSQL database on Sealos Cloud.
+Nakama is an open-source game server for realtime multiplayer, player accounts, social systems, and live operations. This template deploys Nakama v3.39.0 with a managed PostgreSQL database on Sealos Cloud.
+
+![Nakama Console Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/nakama/website-screenshot.webp)
 
 ## About Hosting Nakama
 
-Nakama is a distributed game server designed for modern multiplayer games and social applications. It provides real-time communication, user authentication, leaderboard management, achievement systems, and match-making capabilities out of the box. The Sealos template automatically provisions PostgreSQL for persistent data storage and configures Nakama with secure encryption keys for session management and runtime execution.
+Nakama runs as a single game-server node with built-in HTTP API, realtime socket support, gRPC endpoints, and an embedded admin console. It stores users, sessions, leaderboards, groups, storage objects, chat messages, and other game data in PostgreSQL.
 
-The deployment includes automatic SSL certificate provisioning, domain management, and integrated monitoring through the Sealos dashboard. All security credentials (session encryption keys, runtime keys, console signing keys) are automatically generated during deployment.
+The Sealos template provisions PostgreSQL 16.4.0, creates the `nakama` database, runs Nakama schema migrations, and starts the server after the database is ready. It also generates session, runtime, console, and socket keys for each deployment.
+
+Nakama Console is exposed as the primary web entry. The HTTP API is exposed on a separate URL for REST and WebSocket clients, while public gRPC ingress can be enabled when your client stack needs direct gRPC access.
 
 ## Common Use Cases
 
-- **Real-time Multiplayer Games**: Build synchronous multiplayer games with WebSocket-based real-time communication
-- **Social Features**: Implement chat, friend lists, groups, and social interactions
-- **Leaderboards and Rankings**: Create global or grouped leaderboards for competitive games
-- **User Authentication**: Handle player accounts, device authentication, and social login integration
-- **Live Game Operations**: Manage game configurations, tournaments, and events through the admin console
+- **Realtime Multiplayer Games**: Handle realtime sessions, matchmaking, authoritative matches, and game server logic.
+- **Player Identity and Accounts**: Use device, email, social, or custom authentication flows for players.
+- **Social Game Systems**: Add friends, groups, chat, parties, notifications, and user metadata.
+- **Leaderboards and Tournaments**: Build competitive rankings, seasonal challenges, and event-based scoring.
+- **Live Operations Dashboards**: Inspect players, storage, matches, runtime modules, and service metrics through Nakama Console.
 
 ## Dependencies for Nakama Hosting
 
-The Sealos template includes all required dependencies: Nakama server runtime and PostgreSQL database.
+The Sealos template includes all required runtime dependencies: Nakama Server and PostgreSQL. No separate console image is required because Nakama Console is embedded in the Nakama binary.
 
 ### Deployment Dependencies
 
-- [Official Nakama Documentation](https://heroiclabs.com/docs/nakama/) - Comprehensive documentation and guides
-- [Nakama GitHub Repository](https://github.com/heroiclabs/nakama) - Source code and community contributions
-- [Nakama Console Guide](https://heroiclabs.com/docs/nakama/getting-started/install/console/) - Admin console documentation
-- [Nakama Discord](https://discord.gg/8DkBAUCm4Y) - Community support and discussions
+- [Official Nakama Documentation](https://heroiclabs.com/docs/nakama/) - Product documentation and development guides
+- [Nakama GitHub Repository](https://github.com/heroiclabs/nakama) - Source code and release notes
+- [Nakama Docker Installation Guide](https://heroiclabs.com/docs/nakama/getting-started/install/docker/) - Official container deployment reference
+- [Nakama Client Libraries](https://heroiclabs.com/docs/nakama/client-libraries/) - SDKs for Unity, Unreal, Godot, JavaScript, and more
 
 ### Implementation Details
 
 **Architecture Components:**
 
-This template deploys two main services:
+This template deploys these services:
 
-- **Nakama Server**: The core game server handling real-time connections, authentication, and game logic
-- **PostgreSQL Database**: PostgreSQL 16.4.0 for persistent storage of user data, game state, and configurations
+- **Nakama Server**: StatefulSet running `heroiclabs/nakama:3.39.0` with persistent `/data` storage for runtime modules.
+- **PostgreSQL Database**: KubeBlocks PostgreSQL 16.4.0 cluster for persistent Nakama data.
+- **PostgreSQL Init Job**: Creates the `nakama` database idempotently before the server starts.
+- **Nakama Console Ingress**: Primary web entry that routes to Nakama Console on port `7351`.
+- **Nakama HTTP API Ingress**: Secondary endpoint for `/v2` REST API and `/ws` realtime WebSocket traffic on port `7350`.
+- **Optional gRPC Ingresses**: Public routes for Nakama gRPC (`7349`) and console gRPC (`7348`) when `enable_grpc` is enabled.
 
 **Configuration:**
 
-Nakama runs as a StatefulSet with three init containers that ensure proper initialization:
+Nakama starts only after PostgreSQL is reachable and the target database exists. A migration init container runs `nakama migrate up` before the main server starts, then health probes use `nakama healthcheck` for startup, readiness, and liveness checks.
 
-1. **init-modules-dir**: Creates the necessary directory structure for Lua/Go runtime modules
-2. **wait-for-postgres**: Waits for PostgreSQL to be ready and verifies the database exists
-3. **migrate**: Runs database migrations to set up the required schema
+The primary resource profile is tuned to the smallest validated Sealos tier for this template: `100m` CPU and `128Mi` memory for the Nakama container. PostgreSQL uses the standard database profile: `500m` CPU and `512Mi` memory.
 
-The server is configured with multiple ports:
-- **7350**: HTTP API for REST requests
-- **7349**: gRPC server for high-performance client connections
-- **7348**: Admin console gRPC interface
-- **7351**: Metrics endpoint for monitoring
+**Login and Access:**
 
-**Optional gRPC Exposure:**
+Nakama Console requires the console credentials configured during deployment:
 
-By default, gRPC ports (7348/7349) are only accessible within the cluster. You can enable public gRPC access by setting `enable_grpc` to `true` during deployment, which will create public Ingress routes for both gRPC and console gRPC endpoints.
+- **Username**: value of `console_username` (default `admin`)
+- **Password**: value of `console_password`
 
-**Security:**
-
-All sensitive credentials are automatically generated:
-- Session encryption keys for secure user sessions
-- Runtime HTTP key for server-side code execution
-- Console signing key and MFA encryption key for admin authentication
-- Server key for socket connections
-
-You can override the default admin console username and set your own password during deployment.
+Player accounts are not created from the console login screen. Game clients create or authenticate player accounts through Nakama APIs such as device authentication at `/v2/account/authenticate/device?create=true`, using the configured socket/server key as Basic Auth username.
 
 **License Information:**
 
-Nakama is licensed under Apache-2.0. See the [Nakama GitHub repository](https://github.com/heroiclabs/nakama) for details.
+Nakama is licensed under Apache-2.0. This Sealos template is also provided under Apache-2.0.
 
 ## Why Deploy Nakama on Sealos?
 
-Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. It is perfect for building and scaling modern multiplayer games and real-time applications. By deploying Nakama on Sealos, you get:
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle from deployment to operations. By deploying Nakama on Sealos, you get:
 
-- **One-Click Deployment**: Deploy complex game server infrastructure with a single click. No YAML configuration, no database setup - just point, click, and deploy.
-- **Auto-Scaling Built-In**: Your game server automatically scales based on player demand. Handle traffic spikes from game launches or events without manual intervention.
-- **Easy Customization**: Configure environment variables, resource limits, and credentials with intuitive forms. Customize your Nakama setup without touching configuration files.
-- **Zero Kubernetes Expertise Required**: Get all the benefits of Kubernetes - high availability, service discovery, and container orchestration - without becoming a Kubernetes expert.
-- **Persistent Storage Included**: Built-in PostgreSQL with persistent storage ensures your player data, game state, and configurations are safe across deployments.
-- **Instant Public Access**: Each deployment gets automatic public URLs with SSL certificates for HTTP and optional gRPC endpoints. Connect your game clients immediately.
-- **Automated Backups**: Automatic database backups ensure your game data and player progress are always safe.
-
-Deploy Nakama on Sealos and focus on building great games instead of managing infrastructure.
+- **One-Click Deployment**: Deploy Nakama and PostgreSQL from the App Store without writing Kubernetes YAML.
+- **Managed Public URLs**: Get HTTPS URLs for the console and API automatically.
+- **Persistent Data**: Store player, leaderboard, group, and storage data in managed PostgreSQL.
+- **Easy Customization**: Adjust credentials, resource limits, and optional gRPC exposure from the deployment form or Canvas.
+- **Kubernetes Foundation**: Run on a Kubernetes-based platform without managing cluster primitives directly.
+- **Pay-As-You-Go Resources**: Start from a small validated footprint and scale resources as player traffic grows.
 
 ## Deployment Guide
 
-1. Visit [Nakama Template Page](https://sealos.io/products/app-store/nakama)
-2. Click the "Deploy Now" button
-3. Configure the parameters in the popup dialog:
-   - **Console Username**: Admin username for Nakama Console (default: admin)
-   - **Console Password**: Set a secure password for initial console login
-   - **Enable gRPC**: Check this to expose gRPC ports publicly (optional)
-4. Wait for deployment to complete (typically 2-3 minutes)
-5. Access your Nakama server via the provided URLs:
-   - **Nakama Console**: Use your configured username and password
-   - **HTTP API**: For REST client connections
-   - **gRPC**: If enabled, for high-performance client connections
+1. Open the [Nakama Server template](https://sealos.io/products/app-store/nakama) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - **Console Username**: Admin username for Nakama Console. The default is `admin`.
+   - **Console Password**: Password for the console user. Set a strong value and save it securely.
+   - **Enable gRPC**: Optional. Enable only if your clients need public gRPC endpoints.
+3. Wait for deployment to complete. It typically takes 2-3 minutes because PostgreSQL must initialize before Nakama starts.
+4. Open the primary application URL to access **Nakama Console**.
+5. Log in with the configured Console Username and Console Password.
+6. Use the API URL for game clients:
+   - **HTTP API**: `https://<api-url>/v2/...`
+   - **WebSocket**: `wss://<api-url>/ws`
+   - **gRPC**: Use the generated gRPC URLs only when `enable_grpc` is enabled.
 
 ## Configuration
 
-After deployment, you can manage Nakama through:
+After deployment, manage Nakama through:
 
-- **Nakama Console**: Access at the console URL provided in your deployment dashboard
-- **Environment Variables**: Modify server settings in the App Launchpad by editing the deployment
-- **Runtime Modules**: Upload custom Lua or Go modules to extend Nakama functionality
+- **Nakama Console**: Inspect users, groups, storage, matches, leaderboards, notifications, API Explorer, and runtime modules.
+- **Canvas AI Dialog**: Describe configuration changes and let Sealos apply updates.
+- **Resource Cards**: Adjust StatefulSet resources, Ingress routes, and PostgreSQL settings from the Canvas.
+- **Runtime Modules**: Mount or upload Lua, JavaScript, or Go runtime modules under `/data/modules` as needed.
 
-### Accessing the Console
+### Console Login
 
-1. Navigate to your deployed application in Sealos
-2. Click on the provided URL to access the Nakama Console
-3. Log in with your configured username and password
-4. Use the console to manage users, view leaderboards, and configure game settings
+The console does not provide public self-registration. Use the console credentials configured during deployment. If you lose the password, update `console_password` in the Nakama StatefulSet arguments or redeploy with a new password.
 
-### gRPC Configuration
+### Client Authentication
 
-If you enabled gRPC during deployment, you'll receive separate URLs for:
-- **Nakama gRPC**: For client connections (port 7349)
-- **Console gRPC**: For admin console communication (port 7348)
+Nakama supports player registration through API flows such as device authentication, email authentication, and social provider authentication. For a basic device-auth smoke test, game clients call:
 
-Use these URLs in your game client configuration to connect to Nakama via gRPC for optimal performance.
+```bash
+curl -X POST "https://<api-url>/v2/account/authenticate/device?create=true" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(printf '<server-key>:' | base64)" \
+  -d '{"id":"unique-device-id","vars":{}}'
+```
+
+Replace `<server-key>` with the generated server key for your deployment. The template generates this value automatically as `server_key`; view it from the rendered deployment arguments or the Nakama StatefulSet `NAKAMA_SOCKET_SERVER_KEY` environment variable if you need to run manual API tests.
 
 ## Scaling
 
-To scale your Nakama deployment:
+Start with the default validated resource profile for development and small tests. To scale your Nakama deployment:
 
-1. Open App Launchpad in Sealos
-2. Select your Nakama deployment
-3. Adjust CPU/Memory resources based on your player count
-4. For horizontal scaling, you can run multiple Nakama instances behind a load balancer (advanced configuration)
+1. Open the Canvas for your deployment.
+2. Click the Nakama StatefulSet resource card.
+3. Increase CPU and memory to the next Sealos resource tier if player traffic, runtime modules, or match logic require more capacity.
+4. Click the PostgreSQL resource card if database load becomes the bottleneck.
+5. Apply the changes and verify readiness in Nakama Console.
 
-**Resource Guidelines:**
-- **Small games** (< 100 concurrent players): 100m CPU, 256Mi memory
-- **Medium games** (100-1000 concurrent players): 500m CPU, 512Mi memory
-- **Large games** (> 1000 concurrent players): 1000m CPU, 1Gi memory or more
+For production multiplayer games, benchmark with representative concurrent users, match logic, runtime modules, and API traffic before choosing final resource limits.
 
 ## Troubleshooting
 
 ### Common Issues
 
-**Issue: Database connection failed**
-- Cause: PostgreSQL is still initializing
-- Solution: Wait 2-3 minutes for the database to fully start. The init container will automatically wait for the database to be ready.
+**Nakama Console login fails**
+- Cause: Incorrect console username or password.
+- Solution: Use the credentials configured during deployment. The default username is `admin`, but the password is whatever you entered in the deployment form.
 
-**Issue: Cannot access Nakama Console**
-- Cause: Console URL not correctly configured or password incorrect
-- Solution: Verify your console username and password in the deployment configuration. Use the credentials you set during deployment.
+**API returns `Server key invalid`**
+- Cause: The client is using the wrong Basic Auth username.
+- Solution: Use the deployment's server key as the Basic Auth username and an empty password.
 
-**Issue: gRPC connection fails**
-- Cause: gRPC ports not enabled or firewall blocking connections
-- Solution: Ensure you enabled "Expose gRPC ports" during deployment if you need public gRPC access. Check your game client configuration for the correct endpoint URL.
+**Database initialization takes longer than expected**
+- Cause: PostgreSQL is still starting or creating the `nakama` database.
+- Solution: Wait a few minutes. The init containers are designed to wait for database readiness and run migrations automatically.
 
-**Issue: High memory usage**
-- Cause: Large number of concurrent players or runtime modules consuming resources
-- Solution: Increase memory limits in the App Launchpad or optimize your runtime modules
+**gRPC client cannot connect**
+- Cause: Public gRPC ingress was not enabled or the client is using the HTTP API URL.
+- Solution: Redeploy or update the template with `enable_grpc` enabled, then use the generated gRPC endpoint.
 
 ### Getting Help
 
 - [Nakama Documentation](https://heroiclabs.com/docs/nakama/)
 - [Nakama GitHub Issues](https://github.com/heroiclabs/nakama/issues)
+- [Heroic Labs Forum](https://forum.heroiclabs.com/)
 - [Sealos Documentation](https://sealos.io/docs/)
 - [Sealos Discord](https://discord.gg/wdUn538zVP)
 
 ## Additional Resources
 
-- [Nakama Developer Guide](https://heroiclabs.com/docs/nakama/getting-started/) - Quick start and development guides
-- [Nakama Client SDKs](https://heroiclabs.com/docs/nakama/client-libraries/) - Official SDKs for Unity, Godot, JavaScript, and more
-- [Nakama Runtime Code](https://heroiclabs.com/docs/nakama/getting-started/runtime/) - Custom server-side logic with Lua and Go
-- [Nakama Tutorials](https://heroiclabs.com/docs/nakama/category-tutorials/) - Step-by-step tutorials for common features
+- [Nakama Getting Started](https://heroiclabs.com/docs/nakama/getting-started/)
+- [Nakama Runtime Code](https://heroiclabs.com/docs/nakama/server-framework/runtime-code/)
+- [Nakama API Reference](https://heroiclabs.com/docs/nakama/api/)
+- [Nakama Console Guide](https://heroiclabs.com/docs/nakama/getting-started/install/console/)
 
 ## License
 

--- a/template/nakama/README_zh.md
+++ b/template/nakama/README_zh.md
@@ -1,172 +1,167 @@
-# Deploy and Host Nakama Server on Sealos
+# 在 Sealos 上部署和托管 Nakama Server
 
-Nakama is an open-source game server for real-time multiplayer, social features, and live ops. This template deploys a production-ready Nakama server with PostgreSQL database on Sealos Cloud.
+Nakama 是一个开源游戏服务器，面向实时多人游戏、玩家账号、社交系统和在线运营场景。此模板会在 Sealos Cloud 上部署 Nakama v3.39.0，并自动配置托管 PostgreSQL 数据库。
 
-## About Hosting Nakama
+![Nakama 控制台截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/nakama/website-screenshot.webp)
 
-Nakama is a distributed game server designed for modern multiplayer games and social applications. It provides real-time communication, user authentication, leaderboard management, achievement systems, and match-making capabilities out of the box. The Sealos template automatically provisions PostgreSQL for persistent data storage and configures Nakama with secure encryption keys for session management and runtime execution.
+## 关于托管 Nakama
 
-The deployment includes automatic SSL certificate provisioning, domain management, and integrated monitoring through the Sealos dashboard. All security credentials (session encryption keys, runtime keys, console signing keys) are automatically generated during deployment.
+Nakama 以单节点游戏服务器运行，内置 HTTP API、实时 WebSocket、gRPC 端点和管理控制台。用户、会话、排行榜、群组、存储对象、聊天消息等游戏数据会持久化到 PostgreSQL。
 
-## Common Use Cases
+Sealos 模板会自动创建 PostgreSQL 16.4.0、初始化 `nakama` 数据库、运行 Nakama 数据库迁移，并在数据库就绪后启动服务。每次部署都会生成会话、运行时、控制台和 socket 所需的密钥。
 
-- **Real-time Multiplayer Games**: Build synchronous multiplayer games with WebSocket-based real-time communication
-- **Social Features**: Implement chat, friend lists, groups, and social interactions
-- **Leaderboards and Rankings**: Create global or grouped leaderboards for competitive games
-- **User Authentication**: Handle player accounts, device authentication, and social login integration
-- **Live Game Operations**: Manage game configurations, tournaments, and events through the admin console
+Nakama Console 是主要的 Web 入口。HTTP API 会通过独立 URL 暴露给 REST 与 WebSocket 客户端；如果客户端需要直接访问 gRPC，也可以在部署时开启公开 gRPC 入口。
 
-## Dependencies for Nakama Hosting
+## 常见使用场景
 
-The Sealos template includes all required dependencies: Nakama server runtime and PostgreSQL database.
+- **实时多人游戏**：处理实时会话、匹配、权威比赛和游戏服务器逻辑。
+- **玩家身份与账号**：支持设备、邮箱、社交账号或自定义认证流程。
+- **游戏社交系统**：实现好友、群组、聊天、组队、通知和用户元数据。
+- **排行榜与锦标赛**：构建竞技排名、赛季挑战和活动积分系统。
+- **在线运营控制台**：通过 Nakama Console 查看玩家、存储、比赛、运行时模块和服务指标。
 
-### Deployment Dependencies
+## Nakama 托管依赖
 
-- [Official Nakama Documentation](https://heroiclabs.com/docs/nakama/) - Comprehensive documentation and guides
-- [Nakama GitHub Repository](https://github.com/heroiclabs/nakama) - Source code and community contributions
-- [Nakama Console Guide](https://heroiclabs.com/docs/nakama/getting-started/install/console/) - Admin console documentation
-- [Nakama Discord](https://discord.gg/8DkBAUCm4Y) - Community support and discussions
+此 Sealos 模板包含所有必需运行依赖：Nakama Server 和 PostgreSQL。Nakama Console 已内置在 Nakama 二进制文件中，不需要单独的控制台镜像。
 
-### Implementation Details
+### 部署依赖
 
-**Architecture Components:**
+- [Nakama 官方文档](https://heroiclabs.com/docs/nakama/) - 产品文档和开发指南
+- [Nakama GitHub 仓库](https://github.com/heroiclabs/nakama) - 源码和发布说明
+- [Nakama Docker 安装指南](https://heroiclabs.com/docs/nakama/getting-started/install/docker/) - 官方容器部署参考
+- [Nakama 客户端库](https://heroiclabs.com/docs/nakama/client-libraries/) - Unity、Unreal、Godot、JavaScript 等 SDK
 
-This template deploys two main services:
+### 实现细节
 
-- **Nakama Server**: The core game server handling real-time connections, authentication, and game logic
-- **PostgreSQL Database**: PostgreSQL 16.4.0 for persistent storage of user data, game state, and configurations
+**架构组件：**
 
-**Configuration:**
+此模板会部署以下服务：
 
-Nakama runs as a StatefulSet with three init containers that ensure proper initialization:
+- **Nakama Server**：运行 `heroiclabs/nakama:3.39.0` 的 StatefulSet，并为 `/data` 提供持久存储，用于运行时模块。
+- **PostgreSQL 数据库**：KubeBlocks PostgreSQL 16.4.0 集群，用于持久化 Nakama 数据。
+- **PostgreSQL 初始化 Job**：以幂等方式创建 `nakama` 数据库。
+- **Nakama Console Ingress**：主 Web 入口，路由到 Nakama Console 的 `7351` 端口。
+- **Nakama HTTP API Ingress**：面向 `/v2` REST API 和 `/ws` 实时 WebSocket 流量的独立端点，路由到 `7350` 端口。
+- **可选 gRPC Ingress**：开启 `enable_grpc` 后，公开 Nakama gRPC（`7349`）和控制台 gRPC（`7348`）。
 
-1. **init-modules-dir**: Creates the necessary directory structure for Lua/Go runtime modules
-2. **wait-for-postgres**: Waits for PostgreSQL to be ready and verifies the database exists
-3. **migrate**: Runs database migrations to set up the required schema
+**配置：**
 
-The server is configured with multiple ports:
-- **7350**: HTTP API for REST requests
-- **7349**: gRPC server for high-performance client connections
-- **7348**: Admin console gRPC interface
-- **7351**: Metrics endpoint for monitoring
+Nakama 只有在 PostgreSQL 可访问且目标数据库存在后才会启动。迁移 init container 会先执行 `nakama migrate up`，主容器启动后使用 `nakama healthcheck` 作为启动、就绪和存活探针。
 
-**Optional gRPC Exposure:**
+主服务资源已调试到此模板通过验证的最小 Sealos 档位：Nakama 容器使用 `100m` CPU 和 `128Mi` 内存。PostgreSQL 使用标准数据库档位：`500m` CPU 和 `512Mi` 内存。
 
-By default, gRPC ports (7348/7349) are only accessible within the cluster. You can enable public gRPC access by setting `enable_grpc` to `true` during deployment, which will create public Ingress routes for both gRPC and console gRPC endpoints.
+**登录和访问：**
 
-**Security:**
+Nakama Console 需要使用部署时配置的控制台凭据：
 
-All sensitive credentials are automatically generated:
-- Session encryption keys for secure user sessions
-- Runtime HTTP key for server-side code execution
-- Console signing key and MFA encryption key for admin authentication
-- Server key for socket connections
+- **用户名**：`console_username` 的值，默认是 `admin`
+- **密码**：`console_password` 的值
 
-You can override the default admin console username and set your own password during deployment.
+玩家账号不是从控制台登录页注册的。游戏客户端需要通过 Nakama API 创建或认证玩家账号，例如使用 `/v2/account/authenticate/device?create=true` 设备认证接口，并将配置的 socket/server key 作为 Basic Auth 用户名。
 
-**License Information:**
+**许可证信息：**
 
-Nakama is licensed under Apache-2.0. See the [Nakama GitHub repository](https://github.com/heroiclabs/nakama) for details.
+Nakama 使用 Apache-2.0 许可证。此 Sealos 模板同样使用 Apache-2.0 许可证。
 
-## Why Deploy Nakama on Sealos?
+## 为什么在 Sealos 上部署 Nakama？
 
-Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. It is perfect for building and scaling modern multiplayer games and real-time applications. By deploying Nakama on Sealos, you get:
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用从部署到运维的生命周期。在 Sealos 上部署 Nakama 可以获得：
 
-- **One-Click Deployment**: Deploy complex game server infrastructure with a single click. No YAML configuration, no database setup - just point, click, and deploy.
-- **Auto-Scaling Built-In**: Your game server automatically scales based on player demand. Handle traffic spikes from game launches or events without manual intervention.
-- **Easy Customization**: Configure environment variables, resource limits, and credentials with intuitive forms. Customize your Nakama setup without touching configuration files.
-- **Zero Kubernetes Expertise Required**: Get all the benefits of Kubernetes - high availability, service discovery, and container orchestration - without becoming a Kubernetes expert.
-- **Persistent Storage Included**: Built-in PostgreSQL with persistent storage ensures your player data, game state, and configurations are safe across deployments.
-- **Instant Public Access**: Each deployment gets automatic public URLs with SSL certificates for HTTP and optional gRPC endpoints. Connect your game clients immediately.
-- **Automated Backups**: Automatic database backups ensure your game data and player progress are always safe.
+- **一键部署**：无需编写 Kubernetes YAML，即可从应用商店部署 Nakama 和 PostgreSQL。
+- **托管公网 URL**：自动获得控制台和 API 的 HTTPS 地址。
+- **持久化数据**：玩家、排行榜、群组和存储数据会保存在托管 PostgreSQL 中。
+- **易于定制**：可以通过部署表单或 Canvas 调整凭据、资源限制和可选 gRPC 暴露。
+- **Kubernetes 底座**：获得 Kubernetes 能力，同时不需要直接管理集群资源。
+- **按量资源**：从经过验证的小资源档位开始，并随着玩家流量增长逐步扩容。
 
-Deploy Nakama on Sealos and focus on building great games instead of managing infrastructure.
+## 部署指南
 
-## Deployment Guide
+1. 打开 [Nakama Server 模板](https://sealos.io/products/app-store/nakama)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - **Console Username**：Nakama Console 管理员用户名，默认是 `admin`。
+   - **Console Password**：控制台用户密码。请设置强密码并妥善保存。
+   - **Enable gRPC**：可选。仅当客户端需要公开 gRPC 端点时开启。
+3. 等待部署完成。由于 PostgreSQL 需要先初始化，通常需要 2-3 分钟。
+4. 打开主应用 URL 访问 **Nakama Console**。
+5. 使用配置的 Console Username 和 Console Password 登录。
+6. 游戏客户端使用 API URL 连接：
+   - **HTTP API**：`https://<api-url>/v2/...`
+   - **WebSocket**：`wss://<api-url>/ws`
+   - **gRPC**：仅在开启 `enable_grpc` 时使用生成的 gRPC URL。
 
-1. Visit [Nakama Template Page](https://sealos.io/products/app-store/nakama)
-2. Click the "Deploy Now" button
-3. Configure the parameters in the popup dialog:
-   - **Console Username**: Admin username for Nakama Console (default: admin)
-   - **Console Password**: Set a secure password for initial console login
-   - **Enable gRPC**: Check this to expose gRPC ports publicly (optional)
-4. Wait for deployment to complete (typically 2-3 minutes)
-5. Access your Nakama server via the provided URLs:
-   - **Nakama Console**: Use your configured username and password
-   - **HTTP API**: For REST client connections
-   - **gRPC**: If enabled, for high-performance client connections
+## 配置
 
-## Configuration
+部署后，你可以通过以下方式管理 Nakama：
 
-After deployment, you can manage Nakama through:
+- **Nakama Console**：查看用户、群组、存储、比赛、排行榜、通知、API Explorer 和运行时模块。
+- **Canvas AI 对话框**：描述需要修改的配置，由 Sealos 帮助应用变更。
+- **资源卡片**：在 Canvas 中调整 StatefulSet 资源、Ingress 路由和 PostgreSQL 设置。
+- **运行时模块**：按需将 Lua、JavaScript 或 Go 运行时模块挂载或上传到 `/data/modules`。
 
-- **Nakama Console**: Access at the console URL provided in your deployment dashboard
-- **Environment Variables**: Modify server settings in the App Launchpad by editing the deployment
-- **Runtime Modules**: Upload custom Lua or Go modules to extend Nakama functionality
+### 控制台登录
 
-### Accessing the Console
+控制台不提供公开自助注册。请使用部署时配置的控制台凭据登录。如果忘记密码，可以更新 Nakama StatefulSet 参数中的 `console_password`，或使用新密码重新部署。
 
-1. Navigate to your deployed application in Sealos
-2. Click on the provided URL to access the Nakama Console
-3. Log in with your configured username and password
-4. Use the console to manage users, view leaderboards, and configure game settings
+### 客户端认证
 
-### gRPC Configuration
+Nakama 支持通过设备认证、邮箱认证和社交账号认证等 API 流程注册玩家。基础设备认证测试示例：
 
-If you enabled gRPC during deployment, you'll receive separate URLs for:
-- **Nakama gRPC**: For client connections (port 7349)
-- **Console gRPC**: For admin console communication (port 7348)
+```bash
+curl -X POST "https://<api-url>/v2/account/authenticate/device?create=true" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Basic $(printf '<server-key>:' | base64)" \
+  -d '{"id":"unique-device-id","vars":{}}'
+```
 
-Use these URLs in your game client configuration to connect to Nakama via gRPC for optimal performance.
+将 `<server-key>` 替换为当前部署生成的 server key。模板会自动生成 `server_key`；如果需要手动进行 API 测试，可以从渲染后的部署参数或 Nakama StatefulSet 的 `NAKAMA_SOCKET_SERVER_KEY` 环境变量中查看。
 
-## Scaling
+## 扩容
 
-To scale your Nakama deployment:
+开发和小规模测试可以从默认验证资源档位开始。扩容 Nakama 的步骤如下：
 
-1. Open App Launchpad in Sealos
-2. Select your Nakama deployment
-3. Adjust CPU/Memory resources based on your player count
-4. For horizontal scaling, you can run multiple Nakama instances behind a load balancer (advanced configuration)
+1. 打开当前部署的 Canvas。
+2. 点击 Nakama StatefulSet 资源卡片。
+3. 如果玩家流量、运行时模块或比赛逻辑需要更多资源，将 CPU 和内存提升到下一个 Sealos 资源档位。
+4. 如果瓶颈在数据库，点击 PostgreSQL 资源卡片调整数据库资源。
+5. 应用变更后，在 Nakama Console 中确认服务就绪。
 
-**Resource Guidelines:**
-- **Small games** (< 100 concurrent players): 100m CPU, 256Mi memory
-- **Medium games** (100-1000 concurrent players): 500m CPU, 512Mi memory
-- **Large games** (> 1000 concurrent players): 1000m CPU, 1Gi memory or more
+生产多人游戏上线前，请使用接近真实的并发用户、比赛逻辑、运行时模块和 API 流量进行压测，再决定最终资源限制。
 
-## Troubleshooting
+## 故障排查
 
-### Common Issues
+### 常见问题
 
-**Issue: Database connection failed**
-- Cause: PostgreSQL is still initializing
-- Solution: Wait 2-3 minutes for the database to fully start. The init container will automatically wait for the database to be ready.
+**Nakama Console 登录失败**
+- 原因：控制台用户名或密码不正确。
+- 解决：使用部署时配置的凭据。默认用户名是 `admin`，密码是你在部署表单中填写的值。
 
-**Issue: Cannot access Nakama Console**
-- Cause: Console URL not correctly configured or password incorrect
-- Solution: Verify your console username and password in the deployment configuration. Use the credentials you set during deployment.
+**API 返回 `Server key invalid`**
+- 原因：客户端使用了错误的 Basic Auth 用户名。
+- 解决：使用当前部署的 server key 作为 Basic Auth 用户名，密码留空。
 
-**Issue: gRPC connection fails**
-- Cause: gRPC ports not enabled or firewall blocking connections
-- Solution: Ensure you enabled "Expose gRPC ports" during deployment if you need public gRPC access. Check your game client configuration for the correct endpoint URL.
+**数据库初始化时间较长**
+- 原因：PostgreSQL 仍在启动或正在创建 `nakama` 数据库。
+- 解决：等待几分钟。init containers 会自动等待数据库就绪并执行迁移。
 
-**Issue: High memory usage**
-- Cause: Large number of concurrent players or runtime modules consuming resources
-- Solution: Increase memory limits in the App Launchpad or optimize your runtime modules
+**gRPC 客户端无法连接**
+- 原因：未开启公开 gRPC Ingress，或客户端使用了 HTTP API URL。
+- 解决：重新部署或更新模板并开启 `enable_grpc`，然后使用生成的 gRPC 端点。
 
-### Getting Help
+### 获取帮助
 
-- [Nakama Documentation](https://heroiclabs.com/docs/nakama/)
+- [Nakama 文档](https://heroiclabs.com/docs/nakama/)
 - [Nakama GitHub Issues](https://github.com/heroiclabs/nakama/issues)
-- [Sealos Documentation](https://sealos.io/docs/)
+- [Heroic Labs 论坛](https://forum.heroiclabs.com/)
+- [Sealos 文档](https://sealos.run/docs/)
 - [Sealos Discord](https://discord.gg/wdUn538zVP)
 
-## Additional Resources
+## 更多资源
 
-- [Nakama Developer Guide](https://heroiclabs.com/docs/nakama/getting-started/) - Quick start and development guides
-- [Nakama Client SDKs](https://heroiclabs.com/docs/nakama/client-libraries/) - Official SDKs for Unity, Godot, JavaScript, and more
-- [Nakama Runtime Code](https://heroiclabs.com/docs/nakama/getting-started/runtime/) - Custom server-side logic with Lua and Go
-- [Nakama Tutorials](https://heroiclabs.com/docs/nakama/category-tutorials/) - Step-by-step tutorials for common features
+- [Nakama 入门指南](https://heroiclabs.com/docs/nakama/getting-started/)
+- [Nakama 运行时代码](https://heroiclabs.com/docs/nakama/server-framework/runtime-code/)
+- [Nakama API 参考](https://heroiclabs.com/docs/nakama/api/)
+- [Nakama Console 指南](https://heroiclabs.com/docs/nakama/getting-started/install/console/)
 
-## License
+## 许可证
 
-This Sealos template is provided under Apache-2.0. Nakama itself is licensed under Apache-2.0.
+此 Sealos 模板使用 Apache-2.0 许可证。Nakama 本身使用 Apache-2.0 许可证。

--- a/template/nakama/index.yaml
+++ b/template/nakama/index.yaml
@@ -16,7 +16,6 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Nakama 游戏服务器'
       description: 'Nakama 是一个开源的游戏开发平台，能自动处理用户登录、实时聊天、排行榜、成就系统，还能智能匹配玩家。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/nakama/README_zh.md'
   categories:
@@ -88,6 +87,7 @@ metadata:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -98,6 +98,7 @@ metadata:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 rules:
   - apiGroups:
       - '*'
@@ -115,6 +116,7 @@ metadata:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -131,6 +133,7 @@ metadata:
     kb.io/database: postgresql-16.4.0
     clusterdefinition.kubeblocks.io/name: postgresql
     clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
   name: ${{ defaults.app_name }}-pg
   namespace: ns-admin
 spec:
@@ -181,7 +184,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: pgsql-init
-          image: postgres:14-alpine
+          image: postgres:16-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -216,8 +219,8 @@ spec:
               done
           resources:
             requests:
-              cpu: 20m
-              memory: 64Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
@@ -231,12 +234,13 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: heroiclabs/nakama:3.35.1
+    originImageName: heroiclabs/nakama:3.39.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -250,6 +254,8 @@ spec:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       initContainers:
         - name: init-modules-dir
           image: busybox:1.36
@@ -264,12 +270,12 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 12Mi
             limits:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 100m
+              memory: 128Mi
         - name: wait-for-postgres
-          image: postgres:14-alpine
+          image: postgres:16-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -312,13 +318,13 @@ spec:
               echo "database ${DB_NAME} exists"
           resources:
             requests:
-              cpu: 20m
-              memory: 64Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
         - name: migrate
-          image: heroiclabs/nakama:3.35.1
+          image: heroiclabs/nakama:3.39.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: vn-data
@@ -354,25 +360,25 @@ spec:
             - $(NAKAMA_DATABASE_ADDRESS)
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 20m
+              memory: 25Mi
             limits:
               cpu: 200m
               memory: 256Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: heroiclabs/nakama:3.35.1
+          image: heroiclabs/nakama:3.39.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: vn-data
               mountPath: /data
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 128Mi
           env:
             - name: PG_HOST
               valueFrom:
@@ -420,7 +426,7 @@ spec:
               containerPort: 7349
             - name: http
               containerPort: 7350
-            - name: metrics
+            - name: console
               containerPort: 7351
           args:
             - --name
@@ -447,6 +453,30 @@ spec:
             - $(NAKAMA_SOCKET_SERVER_KEY)
             - --runtime.path
             - /data/modules
+          startupProbe:
+            exec:
+              command:
+                - /nakama/nakama
+                - healthcheck
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command:
+                - /nakama/nakama
+                - healthcheck
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /nakama/nakama
+                - healthcheck
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -466,7 +496,9 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
   selector:
@@ -551,6 +583,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}-http
   labels:
+    app: ${{ defaults.app_name }}-http
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.http_host }}
   annotations:
@@ -576,7 +609,14 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /
+            path: /v2
+            backend:
+              service:
+                name: ${{ defaults.app_name }}
+                port:
+                  number: 7350
+          - pathType: Prefix
+            path: /ws
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -593,6 +633,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -636,6 +677,7 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    cloud.sealos.io/deploy-on-sealos: ${{ defaults.app_name }}
 spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}


### PR DESCRIPTION
## Summary
- update Nakama template image to `heroiclabs/nakama:3.39.0`
- tune Sealos resources to the verified minimum for Nakama runtime
- add health probes, imagePullSecrets, Sealos labels, and split Console/API ingress paths
- refresh English and Chinese README files with login and API authentication guidance

## Validation
- `git diff --check`
- docker-to-sealos consistency check passed for `template/nakama/index.yaml`
- docker-to-sealos unit and MUST coverage checks passed
- deployed the rendered template on Sealos usw-1 and verified Pod readiness
- verified Console login with configured credentials
- verified device authentication through the public `/v2` API endpoint
- patched runtime to `100m/128Mi` and re-verified Console and API health

## Cleanup
- removed all Sealos deployment test resources, including the Instance and database resources
