### PR TITLE
fix(n8n): update template runtime and queue mode

### DIFF
--- a/template/n8n/README.md
+++ b/template/n8n/README.md
@@ -1,392 +1,150 @@
 # Deploy and Host n8n on Sealos
 
-n8n is a powerful workflow automation platform that combines the flexibility of code with the speed of no-code, enabling technical teams to build complex automation workflows with ease. This template provides one-click deployment of a production-ready n8n instance with optional PostgreSQL database and Redis queue mode, allowing you to create sophisticated automation workflows and integrations on Sealos Cloud.
+n8n is a workflow automation platform for connecting APIs, apps, and data workflows with a visual editor. This template deploys n8n 2.22.4 on Sealos Cloud with persistent storage, optional PostgreSQL 16.4, and optional Redis-backed queue mode.
+
+![Application Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/n8n/website-screenshot.webp)
 
 ## About Hosting n8n
 
-n8n runs as a Node.js application that provides a visual workflow editor and execution engine for automating tasks across hundreds of different services and APIs. The platform supports both simple automations and complex multi-step workflows with conditional logic, loops, and data transformations.
+n8n runs as a Node.js web application that serves the workflow editor, API, webhook endpoints, and execution engine from one managed service. The default deployment uses SQLite on persistent storage for lightweight projects, tests, and personal automation.
 
-The Sealos template offers flexible deployment options: you can start with a lightweight SQLite-based setup for testing, upgrade to PostgreSQL for production workloads with better performance and data persistence, or enable queue mode with Redis for improved scalability and parallel execution. The deployment includes automatic initialization, persistent storage for workflow data, and secure public access with SSL certificates.
+For production workloads, enable PostgreSQL during deployment. Sealos provisions PostgreSQL automatically, initializes the `n8n` database, injects connection credentials through Kubernetes secrets, and keeps workflow data persistent across restarts. For parallel workflow execution, enable queue mode; it provisions Redis, PostgreSQL, n8n workers, and external task runners.
 
 ## Common Use Cases
 
-- **API Integration and Data Sync**: Connect different services and sync data between platforms automatically
-- **Business Process Automation**: Automate repetitive tasks like data entry, report generation, and notifications
-- **Data Processing Pipelines**: Build ETL workflows to extract, transform, and load data between systems
-- **Webhook Processing**: Receive and process webhooks from external services with custom logic
-- **Scheduled Tasks**: Run workflows on schedules using cron expressions for periodic automation
-- **Customer Communication**: Automate email campaigns, notifications, and customer support workflows
-- **DevOps Automation**: Integrate CI/CD pipelines, monitoring alerts, and deployment workflows
-- **Content Management**: Automate content publishing, social media posting, and content aggregation
+- **API Integration**: Connect SaaS tools, internal APIs, and databases without writing glue code.
+- **Webhook Automation**: Receive webhooks and trigger workflows for notifications, updates, or downstream processing.
+- **Scheduled Operations**: Run recurring jobs with cron-style triggers and timezone-aware scheduling.
+- **Data Pipelines**: Extract, transform, and route data between business systems.
+- **DevOps Workflows**: Automate deployment notifications, incident responses, and routine maintenance tasks.
 
 ## Dependencies for n8n Hosting
 
-The Sealos template includes all required components: n8n application server with optional PostgreSQL database and Redis for queue mode.
+The Sealos template includes the n8n application service, 1Gi persistent storage, optional PostgreSQL for production data storage, and optional Redis queue resources for worker-based execution.
 
 ### Deployment Dependencies
 
 - [n8n Documentation](https://docs.n8n.io/) - Official n8n documentation
-- [n8n Quickstart Guide](https://docs.n8n.io/try-it-out/) - Getting started with n8n
-- [n8n Workflow Examples](https://n8n.io/workflows) - Community workflow templates
-- [n8n Node Reference](https://docs.n8n.io/integrations/) - Available integrations and nodes
+- [n8n Hosting Guide](https://docs.n8n.io/hosting/) - Self-hosting and configuration guidance
+- [n8n Integrations](https://docs.n8n.io/integrations/) - Available nodes and integrations
 - [PostgreSQL Documentation](https://www.postgresql.org/docs/) - Database backend documentation
-- [Redis Documentation](https://redis.io/docs/) - Queue backend documentation
+- [Redis Documentation](https://redis.io/docs/latest/) - Queue backend documentation
 
 ## Implementation Details
 
 ### Architecture Components
 
-This template supports three deployment modes:
+This template deploys these resources:
 
-**1. Basic Mode (Default):**
-- **n8n Application**: Workflow automation server with SQLite database
-  - Version: n8n 2.1.4
-  - Web UI: Port 5678 (exposed via Ingress with SSL)
-  - Persistent storage: 1Gi for workflow data and SQLite database
-  - Suitable for: Testing, development, and light production workloads
+- **n8n StatefulSet**: Runs n8n 2.22.4 and stores `/home/node/.n8n` on persistent storage.
+- **Service and Ingress**: Exposes the n8n web UI, API, and webhook endpoints over HTTPS.
+- **PostgreSQL Cluster (optional)**: Provides production-grade workflow and execution data storage.
+- **PostgreSQL Init Job (optional)**: Creates the `n8n` database idempotently after PostgreSQL is ready.
+- **Redis Cluster (queue mode)**: Provides the Bull queue backend required by n8n queue execution.
+- **n8n Worker and Runners (queue mode)**: Runs workflow executions and isolated task runners separately from the editor process.
 
-**2. PostgreSQL Mode:**
-- **PostgreSQL Database**: Persistent data storage for workflows and executions
-  - Version: PostgreSQL 14.8.0
-  - Persistent storage: 1Gi
-  - Automatic database initialization with 'n8n' database
-  - Connection credentials managed via Kubernetes secrets
-- **n8n Application**: Connected to PostgreSQL for better performance
-  - Suitable for: Production workloads with high reliability requirements
+### Resource Allocation
 
-**3. Queue Mode (Requires PostgreSQL):**
-- **PostgreSQL Database**: Same as PostgreSQL mode
-- **Redis**: Message queue for workflow execution
-  - Version: Redis 7.0.6
-  - Persistent storage: 1Gi
-  - Includes Redis Sentinel for high availability
-- **n8n Main Process**: Workflow editor and API server
-- **n8n Worker**: Dedicated workflow execution worker
-  - Supports parallel execution of workflows
-  - Scalable for high-volume automation
-- **n8n Runners**: External task runners for isolated code execution
-  - Separate runners for main process and worker
-  - Enhanced security through isolated execution environment
-  - Suitable for: High-traffic production environments with many concurrent workflows
+| Component | CPU Request | CPU Limit | Memory Request | Memory Limit | Storage |
+|-----------|-------------|-----------|----------------|--------------|---------|
+| n8n | 50m | 500m | 102Mi | 1024Mi | 1Gi |
+| PostgreSQL (optional) | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| Redis (queue mode) | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| Redis Sentinel (queue mode) | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| n8n Worker (queue mode) | 20m | 200m | 51Mi | 512Mi | - |
+| n8n Runners (queue mode) | 20m | 200m | 25Mi | 256Mi | - |
 
-**Resource Allocation:**
+### Configuration
 
-| Component | CPU Request | CPU Limit | Memory Request | Memory Limit |
-|-----------|-------------|-----------|----------------|--------------|
-| n8n (Basic/PostgreSQL) | 50m | 500m | 51Mi | 512Mi |
-| n8n Worker (Queue Mode) | 20m | 200m | 51Mi | 512Mi |
-| n8n Runners (Queue Mode) | 20m | 200m | 25Mi | 256Mi |
-| PostgreSQL | 50m | 500m | 51Mi | 512Mi |
-| Redis | 50m | 500m | 51Mi | 512Mi |
-| Redis Sentinel | 100m | 100m | 100Mi | 100Mi |
+- **n8n version**: 2.22.4
+- **PostgreSQL version**: 16.4.0 when enabled
+- **Redis version**: 7.2.7 when queue mode is enabled
+- **Port**: 5678
+- **Timezone**: Configurable during deployment
+- **Encryption key**: Generated automatically per deployment
+- **Startup behavior**: n8n relies on Kubernetes restarts and health probes for PostgreSQL and Redis readiness; queue workers wait for the main n8n `/healthz` endpoint so database migrations finish in the editor process first
+- **Probe profile**: Extended startup and liveness timeouts avoid restarts during database migrations
+- **Public URL**: `https://<app-host>.<region-domain>/`
+- **Webhook URL**: Uses the public HTTPS URL generated by Sealos
 
-### Environment Configuration
+### License Information
 
-The template automatically configures n8n with the following settings:
-
-**Basic Configuration:**
-- Port: 5678
-- Webhook URL: Automatic (based on your deployment domain)
-- Timezone: Configurable (default: America/New_York)
-- Encryption Key: Automatically generated 32-character random string
-
-**Database Configuration (when PostgreSQL is enabled):**
-- Client: PostgreSQL
-- Connection: Automatic via Kubernetes secrets
-- Database name: `n8n`
-- SSL: Disabled (internal cluster communication)
-
-**Queue Configuration (when queue mode is enabled):**
-- Execution Mode: Queue
-- Redis Connection: Automatic via Kubernetes secrets
-- Worker Concurrency: 10 concurrent workflow executions
-- Health Checks: Enabled for both main process and workers
-
-**Public URLs:**
-- Web UI: `https://<app-host>.<domain>/`
-- Webhook Endpoint: `https://<app-host>.<domain>/webhook/`
-- Production Webhook: `https://<app-host>.<domain>/webhook-test/`
-
-### Deployment Process
-
-The deployment process varies by mode:
-
-**Basic Mode:**
-1. **Application Deployment**: n8n starts with SQLite database
-2. **Persistent Storage**: Workflow data stored in persistent volume
-
-**PostgreSQL Mode:**
-1. **Database Initialization Job**: Creates the `n8n` database in PostgreSQL
-2. **Application Deployment**: n8n connects to PostgreSQL and initializes schema
-
-**Queue Mode:**
-1. **Redis Deployment**: Redis cluster with Sentinel for high availability
-2. **PostgreSQL Deployment**: Database for persistent storage
-3. **Database Initialization Job**: Creates the `n8n` database
-4. **Main Process Deployment**: n8n web UI and API server
-5. **Runners Deployment**: External task runners for main process
-6. **Worker Deployment**: Dedicated workflow execution worker
-7. **Worker Runners Deployment**: External task runners for worker
-
-All deployments include automatic health checks and are ready to use immediately after completion.
+n8n is source-available under the [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md). This Sealos template is provided under the repository license for Sealos templates.
 
 ## Why Deploy n8n on Sealos?
 
-Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. By deploying n8n on Sealos, you get:
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, operations, and scaling. By deploying n8n on Sealos, you get:
 
-- **One-Click Deployment**: Deploy n8n with optional PostgreSQL and Redis in seconds. No complex configuration or Kubernetes expertise required.
-- **Flexible Architecture**: Choose between SQLite for simplicity, PostgreSQL for production reliability, or queue mode for high-scale automation.
-- **Pre-Configured Databases**: PostgreSQL and Redis are automatically provisioned, initialized, and connected with secure credentials.
-- **Persistent Storage**: Built-in persistent storage ensures your workflows, credentials, and execution history survive restarts and updates.
-- **Secure Public Access**: n8n gets automatic public URL with SSL certificate, allowing secure access to the web UI and webhook endpoints.
-- **Timezone Support**: Configure your instance timezone for accurate scheduled workflow execution.
-- **Easy Scaling**: Adjust resources through intuitive forms as your automation needs grow.
-- **Automatic Security**: Encryption keys and database credentials are generated automatically with cryptographically secure random values.
-- **Worker Scalability**: Queue mode enables horizontal scaling of workflow execution for high-volume automation.
-
-Deploy n8n on Sealos and focus on building powerful automation workflows instead of managing infrastructure.
+- **One-Click Deployment**: Open the template page, click **Deploy Now**, and launch n8n without writing Kubernetes YAML.
+- **Persistent Storage Included**: Workflow data and local configuration survive restarts and upgrades.
+- **Optional Managed PostgreSQL**: Enable PostgreSQL for production workloads without manually wiring credentials.
+- **Queue Mode Available**: Enable Redis, workers, and task runners for parallel workflow execution.
+- **Automatic HTTPS Access**: Sealos provides a public URL with SSL for the editor and webhook endpoints.
+- **Simple Operations**: Use the Canvas, AI dialog, and resource cards to adjust resources or inspect runtime status.
+- **Pay-as-You-Go Resources**: Start with the minimum tested resources and scale only when workflows need more capacity.
 
 ## Deployment Guide
 
-1. Visit [n8n Template Page](https://sealos.io/products/app-store/n8n)
-2. Click the "Deploy Now" button
-3. Configure your deployment options:
-   - **Use PostgreSQL**: Enable for production workloads (recommended for better performance and data persistence)
-   - **Timezone**: Select your timezone for accurate scheduled workflow execution
-   - **Use Queue Mode**: Enable for high-scale automation with parallel execution (requires PostgreSQL)
-4. Wait for deployment to complete (typically 1-2 minutes)
-5. Access n8n via the provided URL (shown in the canvas)
-6. Create your admin account on first access
+1. Open the [n8n template](https://sealos.io/products/app-store/n8n) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - **Use PostgreSQL**: Enable for production workloads or multi-user usage.
+   - **Timezone**: Select the timezone used by schedule and cron nodes.
+   - **Use Queue Mode**: Enable Redis-backed worker execution. Queue mode also enables PostgreSQL automatically in the template.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Access n8n from the URL shown in the Canvas.
+5. Create the first owner account when n8n opens.
+
+## Login and Registration
+
+n8n does not include a default username or password. On first access, the setup screen asks you to create the owner account with an email, name, and password.
+
+After the owner account is created, use the same email and password on the n8n sign-in page. To add teammates later, invite users from n8n user management settings after logging in as the owner.
 
 ## Configuration
 
-After deployment, you can customize your n8n instance:
+After deployment, configure n8n through:
 
-### Initial Setup
+- **n8n UI**: Create credentials, workflows, variables, and project settings.
+- **AI Dialog**: Describe resource or environment changes and let Sealos apply updates.
+- **Resource Cards**: Open the StatefulSet, Ingress, storage, or PostgreSQL cards in Canvas for direct changes.
+- **PostgreSQL Mode**: Enable PostgreSQL during deployment when you need a production database backend.
+- **Queue Mode**: Enable queue mode during deployment when you need worker-based parallel workflow execution with Redis.
 
-1. **Create Owner Account**: On first access, you'll be prompted to create an owner account with email and password
-2. **Explore Workflow Templates**: Browse the template library to get started quickly
-3. **Configure Credentials**: Add credentials for the services you want to integrate
-4. **Create Your First Workflow**: Use the visual editor to build your first automation
+## Scaling
 
-### Deployment Modes
+Start with the default resource profile. The n8n editor uses 1024Mi memory because initial PostgreSQL migrations and workflow indexing exceed the smaller 512Mi profile in queue-mode smoke tests. Increase CPU or memory from the n8n StatefulSet resource card if workflow executions are slow, if large data items are processed, or if the UI becomes unresponsive.
 
-**When to use each mode:**
-
-- **Basic Mode (SQLite)**:
-  - ✅ Testing and development
-  - ✅ Personal automation projects
-  - ✅ Low-volume workflows (< 100 executions/day)
-  - ❌ Not recommended for production with multiple users
-
-- **PostgreSQL Mode**:
-  - ✅ Production deployments
-  - ✅ Multi-user environments
-  - ✅ Medium-volume workflows (100-1000 executions/day)
-  - ✅ When you need reliable data persistence
-
-- **Queue Mode**:
-  - ✅ High-volume automation (> 1000 executions/day)
-  - ✅ Workflows that need parallel execution
-  - ✅ When you need to scale workflow execution independently
-  - ✅ Production environments with high reliability requirements
-
-### Resource Scaling
-
-Adjust resources in the canvas based on your needs:
-- **CPU/Memory (Main Process)**: Increase for better UI performance and handling more concurrent users
-- **CPU/Memory (Worker)**: Increase for faster workflow execution and more concurrent workflows
-- **Storage**: Expand for more workflow history and execution data
-
-### Timezone Configuration
-
-The timezone setting is critical for scheduled workflows:
-- Affects all Cron nodes and scheduled triggers
-- Can be changed after deployment by updating the deployment environment variables
-- Supported timezones include major cities across all continents
-
-### Service Endpoints
-
-| Service | Endpoint | Purpose |
-|---------|----------|---------|
-| Web UI | `https://<app-host>.<domain>` | Workflow editor and management interface |
-| Webhook | `https://<app-host>.<domain>/webhook/<workflow-id>` | Production webhook endpoints |
-| Test Webhook | `https://<app-host>.<domain>/webhook-test/<workflow-id>` | Test webhook endpoints |
-| PostgreSQL | `<app-name>-pg-postgresql.<namespace>.svc:5432` | Database (internal, if enabled) |
-| Redis | `<app-name>-redis-redis.<namespace>.svc:6379` | Queue (internal, if queue mode enabled) |
+For heavier production workloads, enable PostgreSQL and monitor database storage, CPU, and memory from the Canvas. Increase PostgreSQL resources when execution history or concurrent workflows grow. Enable queue mode when workflow execution should be separated from the editor process, then monitor the worker, runner, and Redis cards.
 
 ## Troubleshooting
 
-### Common Issues
+### First page asks for account setup
 
-**Issue 1: Cannot Create Owner Account**
-- Cause: First-time setup not completed
-- Solution: Access the web UI URL and follow the owner account creation wizard. This is required on first deployment.
+This is expected. Create the owner account on first access; there is no default admin credential.
 
-**Issue 2: Scheduled Workflows Running at Wrong Time**
-- Cause: Timezone configuration mismatch
-- Solution: Verify the timezone setting in the deployment configuration matches your expected timezone. Update the `GENERIC_TIMEZONE` and `TZ` environment variables if needed.
+### Scheduled workflows run in the wrong timezone
 
-**Issue 3: Workflows Failing with Database Errors (PostgreSQL Mode)**
-- Cause: Database not initialized or connection issues
-- Solution: Check that the PostgreSQL cluster is running in the canvas. Verify the init job completed successfully by examining its logs. The database connection is automatic via Kubernetes secrets.
+Confirm the deployment timezone input. Update `GENERIC_TIMEZONE` and `TZ` from the StatefulSet environment variables if you need to change it after deployment.
 
-**Issue 4: Worker Not Processing Workflows (Queue Mode)**
-- Cause: Redis connection issues or worker not running
-- Solution: Verify both Redis and the worker deployment are running in the canvas. Check worker logs for connection errors. Ensure PostgreSQL mode is enabled (queue mode requires it).
+### PostgreSQL deployment does not start
 
-**Issue 5: Webhook Endpoints Not Responding**
-- Cause: Workflow not activated or incorrect webhook URL
-- Solution: Ensure the workflow is activated (toggle in the workflow editor). Verify you're using the correct webhook URL format. Check Ingress configuration for routing issues.
+Check the PostgreSQL Cluster and `pg-init` Job in Canvas. The init Job waits for PostgreSQL readiness and creates the `n8n` database automatically. n8n also waits for the PostgreSQL service port before starting, so temporary startup waiting is expected while the database is created.
 
-**Issue 6: High Memory Usage**
-- Cause: Large workflow executions or many concurrent workflows
-- Solution: Increase memory allocation in the canvas. Consider enabling queue mode to offload execution to dedicated workers. Review workflow efficiency and optimize data processing.
+### Queue mode workers do not start
 
-**Issue 7: Credentials Not Persisting**
-- Cause: Storage not properly mounted or encryption key changed
-- Solution: Verify persistent storage is attached. Never change the `N8N_ENCRYPTION_KEY` after initial deployment as it will invalidate all stored credentials.
+Check the Redis Cluster, n8n Worker, and runner deployments in Canvas. Queue mode needs Redis, PostgreSQL, and the main n8n service to become ready before workers can process workflows. The worker init container waits for the main `/healthz` endpoint; temporary startup waiting is expected while services are created and migrations complete.
 
-### Getting Help
+### Webhooks use the wrong URL
 
-- [n8n Documentation](https://docs.n8n.io/)
-- [n8n Community Forum](https://community.n8n.io/)
-- [n8n Discord](https://discord.gg/n8n)
-- [Sealos Discord Community](https://discord.gg/wdUn538zVP)
+Confirm `WEBHOOK_URL`, `N8N_HOST`, `N8N_PROTOCOL`, and `N8N_EDITOR_BASE_URL` match the public URL shown in Canvas.
 
 ## Additional Resources
 
-- [n8n Workflow Examples](https://n8n.io/workflows) - Browse community-created workflow templates
-- [n8n Node Documentation](https://docs.n8n.io/integrations/) - Complete reference for all available nodes
-- [n8n Expression Reference](https://docs.n8n.io/code/expressions/) - Guide to using expressions in workflows
-- [n8n Best Practices](https://docs.n8n.io/workflows/best-practices/) - Tips for building efficient workflows
-- [PostgreSQL Best Practices](https://wiki.postgresql.org/wiki/Don%27t_Do_This) - Database optimization tips
-- [Redis Best Practices](https://redis.io/docs/management/optimization/) - Queue optimization guide
-
-## Development Workflow
-
-### Creating Workflows
-
-To create your first workflow:
-
-1. **Access the Editor**: Navigate to your n8n URL and log in
-2. **Create New Workflow**: Click "Add Workflow" in the top menu
-3. **Add Nodes**: Drag and drop nodes from the left panel
-4. **Configure Nodes**: Click on each node to configure its settings
-5. **Connect Nodes**: Draw connections between nodes to define the flow
-6. **Test Execution**: Use the "Execute Workflow" button to test
-7. **Activate**: Toggle the workflow to "Active" to enable automatic execution
-
-### Using Webhooks
-
-n8n provides two types of webhook endpoints:
-
-**Production Webhooks:**
-```
-https://<app-host>.<domain>/webhook/<workflow-id>
-```
-- Used when workflow is activated
-- Stable URL that doesn't change
-- Use for production integrations
-
-**Test Webhooks:**
-```
-https://<app-host>.<domain>/webhook-test/<workflow-id>
-```
-- Used during workflow development
-- Only works when workflow editor is open
-- Use for testing before activation
-
-### Managing Credentials
-
-1. Go to **Credentials** in the left menu
-2. Click **Add Credential**
-3. Select the service type (e.g., Gmail, Slack, GitHub)
-4. Enter the required authentication details
-5. Test the connection
-6. Save the credential
-7. Use the credential in your workflow nodes
-
-**Important**: Credentials are encrypted using the `N8N_ENCRYPTION_KEY`. Never change this key after initial deployment, or all credentials will become inaccessible.
-
-### Workflow Best Practices
-
-1. **Error Handling**: Always add error workflows to handle failures gracefully
-2. **Data Validation**: Validate input data before processing to prevent errors
-3. **Execution Limits**: Set reasonable limits on loop iterations and data processing
-4. **Logging**: Use the "Set" node to log important data points for debugging
-5. **Testing**: Thoroughly test workflows with various input scenarios before activation
-6. **Documentation**: Add notes to complex workflows explaining the logic
-7. **Modular Design**: Break complex automations into smaller, reusable workflows
-
-### Queue Mode Optimization
-
-When using queue mode, consider these optimization strategies:
-
-1. **Worker Scaling**: Increase worker replicas for higher throughput
-2. **Concurrency**: Adjust `N8N_CONCURRENCY` environment variable (default: 10)
-3. **Workflow Design**: Design workflows to be stateless for better parallel execution
-4. **Resource Allocation**: Monitor worker resource usage and adjust CPU/memory limits
-5. **Redis Tuning**: For very high volumes, consider increasing Redis resources
-
-### Monitoring and Maintenance
-
-**Execution History:**
-- View all workflow executions in the "Executions" tab
-- Filter by status (success, error, waiting)
-- Inspect execution data and error messages
-
-**Performance Monitoring:**
-- Monitor resource usage in the Sealos canvas
-- Check execution times in the workflow execution history
-- Review worker logs for queue mode deployments
-
-**Backup and Recovery:**
-- Workflow definitions are stored in the database
-- Regular database backups are recommended for production
-- Export important workflows as JSON for version control
-
-### Upgrading n8n
-
-To upgrade to a newer version of n8n:
-
-1. Update the image tag in the StatefulSet/Deployment
-2. Apply the changes through the Sealos canvas
-3. n8n will automatically run database migrations on startup
-4. Verify all workflows still function correctly after upgrade
-
-**Note**: Always review the [n8n release notes](https://docs.n8n.io/release-notes/) before upgrading, especially for major version changes.
-
-## Security Considerations
-
-### Credential Management
-
-- All credentials are encrypted at rest using the `N8N_ENCRYPTION_KEY`
-- Never share or expose the encryption key
-- Use environment-specific credentials for different deployments
-- Regularly rotate API keys and tokens used in credentials
-
-### Webhook Security
-
-- Use webhook authentication when possible (HTTP Basic Auth, Header Auth)
-- Validate webhook payloads to prevent injection attacks
-- Use HTTPS (automatically provided by Sealos)
-- Consider IP whitelisting for sensitive webhooks
-
-### Access Control
-
-- Use strong passwords for owner and user accounts
-- Limit user access based on roles (owner, member, viewer)
-- Regularly review user access and remove inactive accounts
-- Enable two-factor authentication if available in your n8n version
-
-### Network Security
-
-- All external communication uses HTTPS with SSL certificates
-- Internal service communication uses Kubernetes service networking
-- Database and Redis are not exposed externally
-- Webhook endpoints are the only public-facing entry points
+- [n8n Documentation](https://docs.n8n.io/)
+- [n8n Workflow Templates](https://n8n.io/workflows)
+- [n8n Community Forum](https://community.n8n.io/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
 
 ## License
 
-This Sealos template is provided under MIT License. n8n is provided under the [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md) - see the license for details regarding commercial use.
+This Sealos template is provided under the repository license for Sealos templates. n8n itself is distributed under the [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md).

--- a/template/n8n/README_zh.md
+++ b/template/n8n/README_zh.md
@@ -1,394 +1,150 @@
-# 在 Sealos 上部署 n8n 工作流自动化平台
+# 在 Sealos 上部署和托管 n8n
 
-n8n 是一款强大的工作流自动化平台，兼具代码的灵活性与低代码的便捷性，让技术团队轻松构建复杂的自动化流程。本模板支持一键部署生产级 n8n 实例，可选配 PostgreSQL 数据库和 Redis 队列模式，助你在 Sealos Cloud 上快速搭建强大的自动化工作流。
+n8n 是一个工作流自动化平台，可通过可视化编辑器连接 API、应用和数据流程。本模板在 Sealos Cloud 上部署 n8n 2.22.4，包含持久化存储，可选启用 PostgreSQL 16.4，并可选启用 Redis 队列模式。
 
-## 关于 n8n
+![应用截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/n8n/website-screenshot.webp)
 
-n8n 是一个基于 Node.js 的应用，提供可视化工作流编辑器和执行引擎，能够对接数百种服务和 API，实现任务自动化。无论是简单的自动化操作，还是包含条件逻辑、循环和数据转换的复杂多步骤工作流，n8n 都能胜任。
+## 关于 n8n 托管
 
-Sealos 模板提供灵活的部署选项：可以先用轻量级的 SQLite 方案进行测试，再升级到 PostgreSQL 以获得更好的性能和数据持久化，或启用 Redis 队列模式实现更高的可扩展性和并行执行能力。部署过程包含自动初始化、工作流数据持久存储，以及带 SSL 证书的安全公网访问。
+n8n 以 Node.js Web 应用运行，同一个服务提供工作流编辑器、API、Webhook 端点和执行引擎。默认部署使用持久化存储上的 SQLite，适合轻量项目、测试环境和个人自动化。
 
-## 典型应用场景
+生产工作负载建议在部署时启用 PostgreSQL。Sealos 会自动创建 PostgreSQL、初始化 `n8n` 数据库、通过 Kubernetes Secret 注入连接凭据，并确保工作流数据在重启后仍然保留。如需并行执行工作流，可启用队列模式；模板会创建 Redis、PostgreSQL、n8n Worker 和外部任务 Runner。
 
-- **API 集成与数据同步**：连接不同服务，自动同步平台间的数据
-- **业务流程自动化**：将数据录入、报表生成、通知发送等重复性工作交给机器
-- **数据处理管道**：构建 ETL 工作流，在系统间进行数据的提取、转换和加载
-- **Webhook 处理**：接收外部服务的 Webhook 请求，执行自定义逻辑
-- **定时任务**：通过 Cron 表达式按计划运行工作流
-- **客户沟通**：自动化邮件营销、通知推送和客服流程
-- **DevOps 自动化**：集成 CI/CD 流水线、监控告警和部署工作流
-- **内容管理**：自动化内容发布、社交媒体推送和内容聚合
+## 常见使用场景
 
-## 依赖组件
+- **API 集成**：连接 SaaS 工具、内部 API 和数据库，无需编写大量胶水代码。
+- **Webhook 自动化**：接收 Webhook 并触发通知、数据更新或后续处理。
+- **定时任务**：使用 cron 类触发器运行周期性任务，并支持时区配置。
+- **数据管道**：在业务系统之间抽取、转换和分发数据。
+- **DevOps 流程**：自动化部署通知、故障响应和日常维护任务。
 
-Sealos 模板已包含所有必需组件：n8n 应用服务器，以及可选的 PostgreSQL 数据库和 Redis 队列服务。
+## n8n 托管依赖
 
-### 相关文档
+Sealos 模板包含 n8n 应用服务、1Gi 持久化存储、可选的 PostgreSQL 生产数据库，以及可选的 Redis 队列资源。
 
-- [n8n 官方文档](https://docs.n8n.io/) - n8n 使用指南
-- [n8n 快速入门](https://docs.n8n.io/try-it-out/) - 新手上路
-- [n8n 工作流示例](https://n8n.io/workflows) - 社区工作流模板
-- [n8n 节点参考](https://docs.n8n.io/integrations/) - 可用集成和节点
+### 部署依赖
+
+- [n8n 文档](https://docs.n8n.io/) - n8n 官方文档
+- [n8n 托管指南](https://docs.n8n.io/hosting/) - 自托管和配置指南
+- [n8n 集成](https://docs.n8n.io/integrations/) - 可用节点和集成
 - [PostgreSQL 文档](https://www.postgresql.org/docs/) - 数据库后端文档
-- [Redis 文档](https://redis.io/docs/) - 队列后端文档
+- [Redis 文档](https://redis.io/docs/latest/) - 队列后端文档
 
-## 技术架构
+## 实现细节
 
 ### 架构组件
 
-本模板支持三种部署模式：
+本模板会部署以下资源：
 
-**1. 基础模式（默认）：**
-- **n8n 应用**：使用 SQLite 数据库的工作流自动化服务器
-  - 版本：n8n 2.1.4
-  - Web 界面：端口 5678（通过 Ingress 暴露，带 SSL）
-  - 持久存储：1Gi，用于工作流数据和 SQLite 数据库
-  - 适用场景：测试、开发和轻量级生产环境
+- **n8n StatefulSet**：运行 n8n 2.22.4，并将 `/home/node/.n8n` 存储在持久卷中。
+- **Service 和 Ingress**：通过 HTTPS 暴露 n8n Web 界面、API 和 Webhook 端点。
+- **PostgreSQL Cluster（可选）**：提供适合生产环境的工作流与执行数据存储。
+- **PostgreSQL 初始化 Job（可选）**：在 PostgreSQL 就绪后幂等创建 `n8n` 数据库。
+- **Redis Cluster（队列模式）**：提供 n8n 队列执行所需的 Bull 队列后端。
+- **n8n Worker 和 Runner（队列模式）**：将工作流执行和隔离任务执行器从编辑器进程中拆分出来。
 
-**2. PostgreSQL 模式：**
-- **PostgreSQL 数据库**：为工作流和执行记录提供持久化存储
-  - 版本：PostgreSQL 14.8.0
-  - 持久存储：1Gi
-  - 自动初始化 'n8n' 数据库
-  - 通过 Kubernetes Secrets 管理连接凭据
-- **n8n 应用**：连接 PostgreSQL，性能更佳
-  - 适用场景：对可靠性要求较高的生产环境
+### 资源配置
 
-**3. 队列模式（需启用 PostgreSQL）：**
-- **PostgreSQL 数据库**：与 PostgreSQL 模式相同
-- **Redis**：工作流执行的消息队列
-  - 版本：Redis 7.0.6
-  - 持久存储：1Gi
-  - 包含 Redis Sentinel 实现高可用
-- **n8n 主进程**：工作流编辑器和 API 服务器
-- **n8n Worker**：专用的工作流执行进程
-  - 支持工作流并行执行
-  - 可扩展以应对高并发场景
-- **n8n Runners**：外部任务执行器，用于隔离代码执行
-  - 主进程和 Worker 各有独立的 Runners
-  - 通过隔离执行环境增强安全性
-  - 适用场景：高流量生产环境，需处理大量并发工作流
+| 组件 | CPU 请求 | CPU 限制 | 内存请求 | 内存限制 | 存储 |
+|------|----------|----------|----------|----------|------|
+| n8n | 50m | 500m | 102Mi | 1024Mi | 1Gi |
+| PostgreSQL（可选） | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| Redis（队列模式） | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| Redis Sentinel（队列模式） | 50m | 500m | 51Mi | 512Mi | 1Gi |
+| n8n Worker（队列模式） | 20m | 200m | 51Mi | 512Mi | - |
+| n8n Runners（队列模式） | 20m | 200m | 25Mi | 256Mi | - |
 
-**资源配置：**
+### 配置
 
-| 组件 | CPU 请求 | CPU 限制 | 内存请求 | 内存限制 |
-|------|----------|----------|----------|----------|
-| n8n（基础/PostgreSQL 模式） | 50m | 500m | 51Mi | 512Mi |
-| n8n Worker（队列模式） | 20m | 200m | 51Mi | 512Mi |
-| n8n Runners（队列模式） | 20m | 200m | 25Mi | 256Mi |
-| PostgreSQL | 50m | 500m | 51Mi | 512Mi |
-| Redis | 50m | 500m | 51Mi | 512Mi |
-| Redis Sentinel | 100m | 100m | 100Mi | 100Mi |
+- **n8n 版本**：2.22.4
+- **PostgreSQL 版本**：启用时为 16.4.0
+- **Redis 版本**：启用队列模式时为 7.2.7
+- **端口**：5678
+- **时区**：部署时可配置
+- **加密密钥**：每次部署自动生成
+- **启动行为**：n8n 依赖 Kubernetes 自动重启和健康探针处理 PostgreSQL、Redis 就绪过程；队列 Worker 会等待主 n8n `/healthz` 端点就绪，确保数据库迁移先由编辑器进程完成
+- **探针配置**：已延长启动和存活探针超时，避免数据库迁移期间被误重启
+- **公网地址**：`https://<app-host>.<region-domain>/`
+- **Webhook 地址**：使用 Sealos 生成的 HTTPS 公网地址
 
-### 环境配置
+### 许可证信息
 
-模板会自动为 n8n 配置以下设置：
+n8n 采用 [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md)。本 Sealos 模板遵循 Sealos templates 仓库的许可证。
 
-**基础配置：**
-- 端口：5678
-- Webhook URL：自动配置（基于部署域名）
-- 时区：可配置（默认：America/New_York）
-- 加密密钥：自动生成 32 位随机字符串
+## 为什么在 Sealos 上部署 n8n？
 
-**数据库配置（启用 PostgreSQL 时）：**
-- 客户端：PostgreSQL
-- 连接：通过 Kubernetes Secrets 自动配置
-- 数据库名：`n8n`
-- SSL：禁用（集群内部通信）
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用部署、运维和扩缩容。在 Sealos 上部署 n8n，你可以获得：
 
-**队列配置（启用队列模式时）：**
-- 执行模式：队列
-- Redis 连接：通过 Kubernetes Secrets 自动配置
-- Worker 并发数：10 个并发工作流执行
-- 健康检查：主进程和 Worker 均已启用
-
-**公网访问地址：**
-- Web 界面：`https://<app-host>.<domain>/`
-- Webhook 端点：`https://<app-host>.<domain>/webhook/`
-- 生产 Webhook：`https://<app-host>.<domain>/webhook-test/`
-
-### 部署流程
-
-部署流程因模式而异：
-
-**基础模式：**
-1. **应用部署**：n8n 使用 SQLite 数据库启动
-2. **持久存储**：工作流数据存储在持久卷中
-
-**PostgreSQL 模式：**
-1. **数据库初始化任务**：在 PostgreSQL 中创建 `n8n` 数据库
-2. **应用部署**：n8n 连接 PostgreSQL 并初始化表结构
-
-**队列模式：**
-1. **Redis 部署**：部署带 Sentinel 的 Redis 集群实现高可用
-2. **PostgreSQL 部署**：部署持久化存储数据库
-3. **数据库初始化任务**：创建 `n8n` 数据库
-4. **主进程部署**：n8n Web 界面和 API 服务器
-5. **Runners 部署**：主进程的外部任务执行器
-6. **Worker 部署**：专用的工作流执行进程
-7. **Worker Runners 部署**：Worker 的外部任务执行器
-
-所有部署均包含自动健康检查，完成后即可立即使用。
-
-## 为什么选择在 Sealos 上部署 n8n？
-
-Sealos 是基于 Kubernetes 构建的 AI 云操作系统，从云端 IDE 开发到生产部署和运维，覆盖应用全生命周期。在 Sealos 上部署 n8n，你将获得：
-
-- **一键部署**：秒级部署 n8n 及可选的 PostgreSQL 和 Redis，无需复杂配置，无需 Kubernetes 专业知识
-- **灵活架构**：可选择 SQLite 追求简洁、PostgreSQL 确保生产可靠性，或队列模式应对高并发场景
-- **数据库开箱即用**：PostgreSQL 和 Redis 自动创建、初始化并配置安全凭据
-- **持久存储**：内置持久存储确保工作流、凭据和执行历史在重启和更新后依然保留
-- **安全公网访问**：自动分配带 SSL 证书的公网 URL，安全访问 Web 界面和 Webhook 端点
-- **时区支持**：可配置实例时区，确保定时工作流准确执行
-- **弹性扩展**：通过直观的表单界面，按需调整资源
-- **自动安全配置**：加密密钥和数据库凭据均使用密码学安全的随机值自动生成
-- **Worker 可扩展**：队列模式支持工作流执行的水平扩展，应对高并发自动化需求
-
-在 Sealos 上部署 n8n，让你专注于构建强大的自动化工作流，而非折腾基础设施。
+- **一键部署**：打开模板页并点击 **Deploy Now**，无需编写 Kubernetes YAML。
+- **内置持久化存储**：工作流数据和本地配置可在重启和升级后保留。
+- **可选托管 PostgreSQL**：生产工作负载可启用 PostgreSQL，无需手动配置凭据。
+- **可选队列模式**：可启用 Redis、Worker 和 Runner，实现工作流并行执行。
+- **自动 HTTPS 访问**：Sealos 为编辑器和 Webhook 端点提供带 SSL 的公网地址。
+- **简化运维**：通过 Canvas、AI 对话和资源卡片调整资源或查看运行状态。
+- **按量使用资源**：从已测试的最小资源开始，根据工作流压力再扩容。
 
 ## 部署指南
 
-1. 访问 [Sealos Cloud](https://os.sealos.io/?openapp=system-brain?trial=true)
-2. 点击「从模板创建」
-3. 在应用商店搜索「n8n」
-4. 配置部署选项：
-   - **使用 PostgreSQL**：生产环境建议启用（性能更好、数据持久化）
-   - **时区**：选择你的时区，确保定时工作流准确执行
-   - **使用队列模式**：需要高并发并行执行时启用（需先启用 PostgreSQL）
-5. 点击「部署」
-6. 等待部署完成（通常 1-2 分钟）
-7. 通过画布中显示的 URL 访问 n8n
-8. 首次访问时创建管理员账号
+1. 打开 [n8n 模板](https://sealos.io/products/app-store/n8n)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - **Use PostgreSQL**：生产工作负载或多用户场景建议启用。
+   - **Timezone**：选择定时和 Cron 节点使用的时区。
+   - **Use Queue Mode**：启用基于 Redis 的 Worker 执行模式。队列模式会在模板中自动启用 PostgreSQL。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会进入 Canvas。后续如需修改配置，可在 AI 对话中描述需求，或点击相关资源卡片直接调整。
+4. 通过 Canvas 中显示的 URL 访问 n8n。
+5. 首次打开 n8n 时创建第一个所有者账号。
 
-## 配置说明
+## 登录和注册
 
-部署完成后，你可以对 n8n 实例进行个性化配置：
+n8n 不提供默认用户名或密码。首次访问时，设置页面会要求你填写邮箱、姓名和密码来创建所有者账号。
 
-### 初始设置
+所有者账号创建完成后，请使用同一个邮箱和密码在 n8n 登录页登录。若后续需要添加团队成员，请以所有者身份登录后，在 n8n 用户管理设置中邀请其他用户。
 
-1. **创建管理员账号**：首次访问时，系统会提示你创建管理员账号（邮箱和密码）
-2. **浏览工作流模板**：在模板库中快速找到入门案例
-3. **配置凭据**：添加你要集成的服务的凭据
-4. **创建首个工作流**：使用可视化编辑器构建你的第一个自动化流程
+## 配置
 
-### 部署模式选择
+部署后可通过以下方式配置 n8n：
 
-**各模式适用场景：**
+- **n8n 界面**：创建凭据、工作流、变量和项目设置。
+- **AI 对话**：描述资源或环境变量修改需求，由 Sealos 应用更新。
+- **资源卡片**：在 Canvas 中打开 StatefulSet、Ingress、存储或 PostgreSQL 卡片进行调整。
+- **PostgreSQL 模式**：需要生产数据库后端时，在部署时启用 PostgreSQL。
+- **队列模式**：需要基于 Worker 的并行执行时，在部署时启用队列模式。
 
-- **基础模式（SQLite）**：
-  - ✅ 测试和开发
-  - ✅ 个人自动化项目
-  - ✅ 低频工作流（每天 < 100 次执行）
-  - ❌ 不建议用于多用户生产环境
+## 扩缩容
 
-- **PostgreSQL 模式**：
-  - ✅ 生产环境部署
-  - ✅ 多用户场景
-  - ✅ 中等频率工作流（每天 100-1000 次执行）
-  - ✅ 需要可靠数据持久化
+建议先使用默认资源配置。n8n 编辑器使用 1024Mi 内存，是因为队列模式冒烟测试中，初始 PostgreSQL 迁移和工作流索引会超过较小的 512Mi 配置。若工作流执行缓慢、处理大体积数据，或界面响应变慢，可从 n8n StatefulSet 资源卡片增加 CPU 或内存。
 
-- **队列模式**：
-  - ✅ 高频自动化（每天 > 1000 次执行）
-  - ✅ 需要并行执行的工作流
-  - ✅ 需要独立扩展工作流执行能力
-  - ✅ 高可靠性要求的生产环境
-
-### 资源调整
-
-在画布中根据需求调整资源：
-- **CPU/内存（主进程）**：增加以提升界面性能和并发用户处理能力
-- **CPU/内存（Worker）**：增加以加速工作流执行和提高并发处理能力
-- **存储**：扩展以保存更多工作流历史和执行数据
-
-### 时区配置
-
-时区设置对定时工作流至关重要：
-- 影响所有 Cron 节点和定时触发器
-- 部署后可通过更新 Deployment 环境变量修改
-- 支持全球主要城市时区
-
-### 服务端点
-
-| 服务 | 端点 | 用途 |
-|------|------|------|
-| Web 界面 | `https://<app-host>.<domain>` | 工作流编辑器和管理界面 |
-| Webhook | `https://<app-host>.<domain>/webhook/<workflow-id>` | 生产 Webhook 端点 |
-| 测试 Webhook | `https://<app-host>.<domain>/webhook-test/<workflow-id>` | 测试用 Webhook 端点 |
-| PostgreSQL | `<app-name>-pg-postgresql.<namespace>.svc:5432` | 数据库（内部访问，如已启用） |
-| Redis | `<app-name>-redis-redis.<namespace>.svc:6379` | 队列（内部访问，如已启用队列模式） |
+更重的生产工作负载建议启用 PostgreSQL，并在 Canvas 中监控数据库存储、CPU 和内存。当执行历史或并发工作流增加时，可提高 PostgreSQL 资源。若希望将工作流执行从编辑器进程拆分出来，请启用队列模式，并监控 Worker、Runner 和 Redis 资源卡片。
 
 ## 故障排查
 
-### 常见问题
+### 首次打开页面要求创建账号
 
-**问题 1：无法创建管理员账号**
-- 原因：首次设置未完成
-- 解决方案：访问 Web 界面 URL，按照管理员账号创建向导操作。首次部署必须完成此步骤。
+这是正常行为。首次访问时需要创建所有者账号；模板不内置默认管理员凭据。
 
-**问题 2：定时工作流执行时间不对**
-- 原因：时区配置不匹配
-- 解决方案：检查部署配置中的时区设置是否与预期一致。如需修改，更新 `GENERIC_TIMEZONE` 和 `TZ` 环境变量。
+### 定时工作流时区不正确
 
-**问题 3：工作流报数据库错误（PostgreSQL 模式）**
-- 原因：数据库未初始化或连接问题
-- 解决方案：在画布中确认 PostgreSQL 集群正在运行。检查初始化 Job 的日志确认是否成功完成。数据库连接通过 Kubernetes Secrets 自动配置。
+检查部署时的 timezone 参数。如需部署后修改，请更新 StatefulSet 环境变量中的 `GENERIC_TIMEZONE` 和 `TZ`。
 
-**问题 4：Worker 不处理工作流（队列模式）**
-- 原因：Redis 连接问题或 Worker 未运行
-- 解决方案：在画布中确认 Redis 和 Worker Deployment 都在运行。查看 Worker 日志排查连接错误。确保已启用 PostgreSQL 模式（队列模式依赖它）。
+### PostgreSQL 部署未正常启动
 
-**问题 5：Webhook 端点无响应**
-- 原因：工作流未激活或 Webhook URL 不正确
-- 解决方案：确保工作流已激活（工作流编辑器中的开关）。检查 Webhook URL 格式是否正确。排查 Ingress 配置的路由问题。
+在 Canvas 中检查 PostgreSQL Cluster 和 `pg-init` Job。初始化 Job 会等待 PostgreSQL 就绪，并自动创建 `n8n` 数据库。n8n 也会等待 PostgreSQL 服务端口可连接后再启动，因此数据库创建期间短暂等待属于正常现象。
 
-**问题 6：内存占用过高**
-- 原因：大型工作流执行或并发工作流过多
-- 解决方案：在画布中增加内存配额。考虑启用队列模式将执行任务分流到专用 Worker。优化工作流效率和数据处理逻辑。
+### 队列模式 Worker 未启动
 
-**问题 7：凭据未持久化**
-- 原因：存储未正确挂载或加密密钥已变更
-- 解决方案：确认持久存储已挂载。切记：初始部署后绝不能修改 `N8N_ENCRYPTION_KEY`，否则所有已存储的凭据都将失效。
+在 Canvas 中检查 Redis Cluster、n8n Worker 和 Runner 部署。队列模式需要 Redis、PostgreSQL 和主 n8n 服务就绪后，Worker 才能开始处理工作流；Worker initContainer 会等待主 `/healthz` 端点，相关服务创建和数据库迁移期间短暂等待属于正常现象。
 
-### 获取帮助
+### Webhook URL 不正确
 
-- [n8n 官方文档](https://docs.n8n.io/)
-- [n8n 社区论坛](https://community.n8n.io/)
-- [n8n Discord](https://discord.gg/n8n)
-- [Sealos Discord 社区](https://discord.gg/wdUn538zVP)
+确认 `WEBHOOK_URL`、`N8N_HOST`、`N8N_PROTOCOL` 和 `N8N_EDITOR_BASE_URL` 与 Canvas 中显示的公网地址一致。
 
 ## 更多资源
 
-- [n8n 工作流示例](https://n8n.io/workflows) - 浏览社区创建的工作流模板
-- [n8n 节点文档](https://docs.n8n.io/integrations/) - 所有可用节点的完整参考
-- [n8n 表达式参考](https://docs.n8n.io/code/expressions/) - 工作流中使用表达式的指南
-- [n8n 最佳实践](https://docs.n8n.io/workflows/best-practices/) - 构建高效工作流的技巧
-- [PostgreSQL 最佳实践](https://wiki.postgresql.org/wiki/Don%27t_Do_This) - 数据库优化建议
-- [Redis 最佳实践](https://redis.io/docs/management/optimization/) - 队列优化指南
-
-## 开发工作流
-
-### 创建工作流
-
-创建你的第一个工作流：
-
-1. **进入编辑器**：访问 n8n URL 并登录
-2. **新建工作流**：点击顶部菜单的「Add Workflow」
-3. **添加节点**：从左侧面板拖拽节点到画布
-4. **配置节点**：点击每个节点进行设置
-5. **连接节点**：在节点之间绘制连线定义流程
-6. **测试执行**：点击「Execute Workflow」按钮进行测试
-7. **激活**：将工作流切换为「Active」状态以启用自动执行
-
-### 使用 Webhook
-
-n8n 提供两种 Webhook 端点：
-
-**生产 Webhook：**
-```
-https://<app-host>.<domain>/webhook/<workflow-id>
-```
-- 工作流激活后使用
-- URL 固定不变
-- 用于生产环境集成
-
-**测试 Webhook：**
-```
-https://<app-host>.<domain>/webhook-test/<workflow-id>
-```
-- 工作流开发阶段使用
-- 仅在工作流编辑器打开时有效
-- 用于激活前的测试
-
-### 管理凭据
-
-1. 进入左侧菜单的 **Credentials**
-2. 点击 **Add Credential**
-3. 选择服务类型（如 Gmail、Slack、GitHub）
-4. 填写所需的认证信息
-5. 测试连接
-6. 保存凭据
-7. 在工作流节点中使用该凭据
-
-**重要提示**：凭据使用 `N8N_ENCRYPTION_KEY` 进行加密。初始部署后切勿修改此密钥，否则所有凭据都将无法访问。
-
-### 工作流最佳实践
-
-1. **错误处理**：始终添加错误处理工作流，优雅地处理失败情况
-2. **数据验证**：处理前验证输入数据，防止错误发生
-3. **执行限制**：为循环迭代和数据处理设置合理限制
-4. **日志记录**：使用「Set」节点记录关键数据点，便于调试
-5. **充分测试**：激活前用各种输入场景彻底测试工作流
-6. **文档说明**：为复杂工作流添加注释说明逻辑
-7. **模块化设计**：将复杂自动化拆分为更小的可复用工作流
-
-### 队列模式优化
-
-使用队列模式时，考虑以下优化策略：
-
-1. **Worker 扩展**：增加 Worker 副本数以提高吞吐量
-2. **并发配置**：调整 `N8N_CONCURRENCY` 环境变量（默认：10）
-3. **工作流设计**：将工作流设计为无状态，以便更好地并行执行
-4. **资源分配**：监控 Worker 资源使用情况，调整 CPU/内存限制
-5. **Redis 调优**：对于超高并发场景，考虑增加 Redis 资源
-
-### 监控与维护
-
-**执行历史：**
-- 在「Executions」标签页查看所有工作流执行记录
-- 按状态筛选（成功、错误、等待中）
-- 检查执行数据和错误信息
-
-**性能监控：**
-- 在 Sealos 画布中监控资源使用情况
-- 在工作流执行历史中查看执行耗时
-- 查看队列模式部署的 Worker 日志
-
-**备份与恢复：**
-- 工作流定义存储在数据库中
-- 生产环境建议定期备份数据库
-- 将重要工作流导出为 JSON 进行版本控制
-
-### 升级 n8n
-
-升级到新版本的步骤：
-
-1. 更新 StatefulSet/Deployment 中的镜像标签
-2. 通过 Sealos 画布应用更改
-3. n8n 启动时会自动运行数据库迁移
-4. 升级后验证所有工作流是否正常运行
-
-**注意**：升级前务必查阅 [n8n 发布说明](https://docs.n8n.io/release-notes/)，尤其是大版本更新。
-
-## 安全注意事项
-
-### 凭据管理
-
-- 所有凭据使用 `N8N_ENCRYPTION_KEY` 静态加密存储
-- 切勿共享或暴露加密密钥
-- 不同部署环境使用独立的凭据
-- 定期轮换凭据中使用的 API 密钥和令牌
-
-### Webhook 安全
-
-- 尽可能使用 Webhook 认证（HTTP Basic Auth、Header Auth）
-- 验证 Webhook 载荷，防止注入攻击
-- 使用 HTTPS（Sealos 自动提供）
-- 敏感 Webhook 考虑 IP 白名单
-
-### 访问控制
-
-- 为管理员和用户账号使用强密码
-- 根据角色限制用户访问权限（owner、member、viewer）
-- 定期审查用户访问权限，移除不活跃账号
-- 如你的 n8n 版本支持，启用双因素认证
-
-### 网络安全
-
-- 所有外部通信使用带 SSL 证书的 HTTPS
-- 内部服务通信使用 Kubernetes 服务网络
-- 数据库和 Redis 不对外暴露
-- Webhook 端点是唯一面向公网的入口
+- [n8n 文档](https://docs.n8n.io/)
+- [n8n 工作流模板](https://n8n.io/workflows)
+- [n8n 社区论坛](https://community.n8n.io/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
 
 ## 许可证
 
-本 Sealos 模板采用 MIT 许可证。n8n 采用 [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md)——商业使用请参阅许可证详情。
+本 Sealos 模板遵循 Sealos templates 仓库的许可证。n8n 本身采用 [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md)。

--- a/template/n8n/index.yaml
+++ b/template/n8n/index.yaml
@@ -64,7 +64,7 @@ spec:
         - Pacific/Auckland
         - UTC
     use_queue_mode:
-      description: 'Enable queue mode with Redis and workers for improved scalability and parallel execution (requires PostgreSQL)'
+      description: 'Enable queue mode with Redis and workers for parallel workflow execution (requires PostgreSQL)'
       type: boolean
       default: 'false'
       required: false
@@ -120,35 +120,29 @@ kind: Cluster
 metadata:
   finalizers:
     - cluster.kubeblocks.io/finalizer
-  name: ${{ defaults.app_name }}-redis
   labels:
-    clusterdefinition.kubeblocks.io/name: redis
     kb.io/database: redis-7.2.7
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
     app.kubernetes.io/version: 7.2.7
-    helm.sh/chart: redis-cluster-0.9.0
+    clusterversion.kubeblocks.io/name: redis-7.2.7
+    clusterdefinition.kubeblocks.io/name: redis
     sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+  name: ${{ defaults.app_name }}-redis
 spec:
-  clusterDefinitionRef: redis
   affinity:
     podAntiAffinity: Preferred
+    tenancy: SharedNode
     topologyKeys:
       - kubernetes.io/hostname
-  tolerations:
-    - key: kb-data
-      operator: Equal
-      value: "true"
-      effect: NoSchedule
+  clusterDefinitionRef: redis
   componentSpecs:
-    - name: redis
-      componentDef: redis-7
+    - componentDef: redis-7
+      name: redis
+      replicas: 1
       enabledLogs:
         - running
       env:
         - name: CUSTOM_SENTINEL_MASTER_NAME
-      serviceVersion: 7.2.7
-      serviceAccountName: ${{ defaults.app_name }}-redis
-      replicas: 1
       resources:
         limits:
           cpu: 500m
@@ -156,6 +150,10 @@ spec:
         requests:
           cpu: 50m
           memory: 51Mi
+      serviceAccountName: ${{ defaults.app_name }}-redis
+      serviceVersion: 7.2.7
+      switchPolicy:
+        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -169,11 +167,12 @@ spec:
       replicas: 1
       resources:
         limits:
-          cpu: 100m
-          memory: 100Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: 50m
+          memory: 51Mi
+      serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
       volumeClaimTemplates:
         - name: data
@@ -187,7 +186,7 @@ spec:
   topology: replication
 ${{ endif() }}
 
-${{ if(inputs.use_queue_mode === 'true' || inputs.use_postgresql === 'true') }}
+${{ if(inputs.use_postgresql === 'true' || inputs.use_queue_mode === 'true') }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -239,8 +238,11 @@ metadata:
   finalizers:
     - cluster.kubeblocks.io/finalizer
   labels:
+    kb.io/database: postgresql-16.4.0
     clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
   annotations: {}
   name: ${{ defaults.app_name }}-pg
@@ -251,10 +253,12 @@ spec:
     tenancy: SharedNode
     topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
     - componentDefRef: postgresql
-      monitor: true
+      disableExporter: true
+      enabledLogs:
+        - running
       name: postgresql
       replicas: 1
       resources:
@@ -289,22 +293,38 @@ spec:
     spec:
       containers:
         - name: pgsql-init
-          image: postgres:14-alpine
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
           env:
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: endpoint
+            - name: PG_DATABASE
+              value: n8n
           command:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE n8n;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
+              set -eu
+              for i in $(seq 1 60); do
+                if pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                sleep 2
+              done
+              pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1
+              if ! psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='$(PG_DATABASE)'" | grep -q 1; then
+                psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$(PG_DATABASE)\";"
+              fi
+      restartPolicy: OnFailure
+  backoffLimit: 3
   ttlSecondsAfterFinished: 300
 ${{ endif() }}
 
@@ -314,7 +334,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: n8nio/n8n:2.1.4
+    originImageName: n8nio/n8n:2.22.4
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -335,6 +355,8 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       initContainers:
         - name: take-data-dir-ownership
           image: alpine
@@ -345,14 +367,12 @@ spec:
               mountPath: /data
       containers:
         - name: ${{ defaults.app_name }}
-          image: n8nio/n8n:2.1.4
+          image: n8nio/n8n:2.22.4
           env:
             - name: N8N_PORT
               value: "5678"
             - name: WEBHOOK_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/
-            - name: QUEUE_HEALTH_CHECK_ACTIVE
-              value: "true"
             - name: N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS
               value: "true"
             - name: GENERIC_TIMEZONE
@@ -361,7 +381,42 @@ spec:
               value: ${{ inputs.timezone }}
             - name: N8N_PROXY_HOPS
               value: "1"
-            ${{ if(inputs.use_queue_mode === 'true' || inputs.use_postgresql === 'true') }}
+            - name: N8N_HOST
+              value: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: N8N_PROTOCOL
+              value: https
+            - name: N8N_EDITOR_BASE_URL
+              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/
+            - name: N8N_ENCRYPTION_KEY
+              value: ${{ defaults.N8N_ENCRYPTION_KEY }}
+            - name: N8N_RUNNERS_GRANT_TOKEN_TTL
+              value: "120"
+            ${{ if(inputs.use_queue_mode === 'true') }}
+            - name: EXECUTIONS_MODE
+              value: queue
+            - name: N8N_RUNNERS_MODE
+              value: external
+            - name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
+              value: 0.0.0.0
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
+            - name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
+              value: "true"
+            - name: QUEUE_HEALTH_CHECK_ACTIVE
+              value: "true"
+            - name: QUEUE_BULL_REDIS_HOST
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
+            - name: QUEUE_BULL_REDIS_PORT
+              value: "6379"
+            - name: QUEUE_BULL_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-redis-redis-account-default
+                  key: password
+            ${{ endif() }}
+            ${{ if(inputs.use_postgresql === 'true' || inputs.use_queue_mode === 'true') }}
+            - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: "30"
             - name: DB_TYPE
               value: 'postgresdb'
             - name: DB_POSTGRESDB_PORT
@@ -387,40 +442,13 @@ spec:
             - name: DB_POSTGRESDB_DATABASE
               value: 'n8n'
             ${{ endif() }}
-            ${{ if(inputs.use_queue_mode === 'true') }}
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
-            - name: N8N_RUNNERS_MODE
-              value: "external"
-            - name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
-              value: "0.0.0.0"
-            - name: N8N_RUNNERS_AUTH_TOKEN
-              value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
-            - name: EXECUTIONS_MODE
-              value: 'queue'
-            - name: N8N_ENCRYPTION_KEY
-              value: ${{ defaults.N8N_ENCRYPTION_KEY }}
-            - name: QUEUE_BULL_REDIS_HOST
-              value: ${{ defaults.app_name }}-redis-redis.${{ SEALOS_NAMESPACE }}.svc
-            - name: QUEUE_BULL_REDIS_PORT
-              value: '6379'
-            - name: QUEUE_BULL_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-redis-redis-account-default
-                  key: password
-            - name: N8N_DISABLE_PRODUCTION_MAIN_PROCESS
-              value: 'true'
-            - name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
-              value: true
-            ${{ endif() }}
           resources:
             requests:
               cpu: 50m
-              memory: 51Mi
+              memory: 102Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1024Mi
           ports:
             - name: http
               protocol: TCP
@@ -429,11 +457,27 @@ spec:
           volumeMounts:
             - name: vn-homevn-nodevn-vn-n8n
               mountPath: /home/node/.n8n
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 20
+            initialDelaySeconds: 120
+            periodSeconds: 20
+            timeoutSeconds: 5
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -447,6 +491,27 @@ spec:
           requests:
             storage: 1Gi
 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
+spec:
+  ports:
+    - name: http
+      port: 5678
+      protocol: TCP
+    ${{ if(inputs.use_queue_mode === 'true') }}
+    - name: broker
+      port: 5679
+      protocol: TCP
+    ${{ endif() }}
+  selector:
+    app: ${{ defaults.app_name }}
+
 ${{ if(inputs.use_queue_mode === 'true') }}
 ---
 apiVersion: apps/v1
@@ -454,7 +519,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-runners
   annotations:
-    originImageName: n8nio/runners:2.1.4
+    originImageName: n8nio/runners:2.22.4
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -472,12 +537,15 @@ spec:
         app: ${{ defaults.app_name }}-runners
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-runners
-          image: n8nio/runners:2.1.4
+          image: n8nio/runners:2.22.4
+          imagePullPolicy: IfNotPresent
           env:
             - name: N8N_RUNNERS_TASK_BROKER_URI
-              value: "http://${{ defaults.app_name }}:5679"
+              value: http://${{ defaults.app_name }}:5679
             - name: N8N_RUNNERS_AUTH_TOKEN
               value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
           resources:
@@ -487,7 +555,24 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
-          imagePullPolicy: IfNotPresent
+          ports:
+            - name: health
+              protocol: TCP
+              containerPort: 5680
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
 
 ---
 apiVersion: apps/v1
@@ -495,7 +580,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-worker
   annotations:
-    originImageName: n8nio/n8n:2.1.4
+    originImageName: n8nio/n8n:2.22.4
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -513,14 +598,33 @@ spec:
         app: ${{ defaults.app_name }}-worker
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
+      initContainers:
+        - name: wait-for-main-healthz
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until wget -qO- "http://${{ defaults.app_name }}:5678/healthz" | grep -q '"status":"ok"'; do
+                echo "waiting for n8n main healthz"
+                sleep 3
+              done
       containers:
         - name: ${{ defaults.app_name }}-worker
-          image: n8nio/n8n:2.1.4
+          image: n8nio/n8n:2.22.4
+          imagePullPolicy: IfNotPresent
           command:
-            - tini
-            - --
-          args:
-            - /docker-entrypoint.sh
+            - n8n
             - worker
           env:
             - name: GENERIC_TIMEZONE
@@ -528,24 +632,32 @@ spec:
             - name: TZ
               value: ${{ inputs.timezone }}
             - name: EXECUTIONS_MODE
-              value: 'queue'
+              value: queue
             - name: N8N_ENCRYPTION_KEY
               value: ${{ defaults.N8N_ENCRYPTION_KEY }}
+            - name: N8N_RUNNERS_MODE
+              value: external
+            - name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
+              value: 0.0.0.0
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
+            - name: N8N_RUNNERS_GRANT_TOKEN_TTL
+              value: "120"
+            - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: "30"
+            - name: QUEUE_HEALTH_CHECK_ACTIVE
+              value: "true"
             - name: QUEUE_BULL_REDIS_HOST
-              value: ${{ defaults.app_name }}-redis-redis.${{ SEALOS_NAMESPACE }}.svc
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
             - name: QUEUE_BULL_REDIS_PORT
-              value: '6379'
+              value: "6379"
             - name: QUEUE_BULL_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-redis-redis-account-default
                   key: password
-            - name: N8N_CONCURRENCY
-              value: '10'
-            - name: QUEUE_HEALTH_CHECK_ACTIVE
-              value: 'true'
             - name: DB_TYPE
-              value: 'postgresdb'
+              value: postgresdb
             - name: DB_POSTGRESDB_PORT
               valueFrom:
                 secretKeyRef:
@@ -567,17 +679,7 @@ spec:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: host
             - name: DB_POSTGRESDB_DATABASE
-              value: 'n8n'
-            - name: N8N_PROXY_HOPS
-              value: "1"
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
-            - name: N8N_RUNNERS_MODE
-              value: "external"
-            - name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
-              value: "0.0.0.0"
-            - name: N8N_RUNNERS_AUTH_TOKEN
-              value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
+              value: n8n
           resources:
             requests:
               cpu: 20m
@@ -585,19 +687,20 @@ spec:
             limits:
               cpu: 200m
               memory: 512Mi
-          imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /healthz
               port: 5678
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 20
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /healthz/readiness
+              path: /healthz
               port: 5678
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
 
 ---
 apiVersion: apps/v1
@@ -605,7 +708,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-worker-runners
   annotations:
-    originImageName: n8nio/runners:2.1.4
+    originImageName: n8nio/runners:2.22.4
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -623,12 +726,15 @@ spec:
         app: ${{ defaults.app_name }}-worker-runners
     spec:
       automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-worker-runners
-          image: n8nio/runners:2.1.4
+          image: n8nio/runners:2.22.4
+          imagePullPolicy: IfNotPresent
           env:
             - name: N8N_RUNNERS_TASK_BROKER_URI
-              value: "http://${{ defaults.app_name }}-worker:5679"
+              value: http://${{ defaults.app_name }}-worker:5679
             - name: N8N_RUNNERS_AUTH_TOKEN
               value: ${{ defaults.N8N_RUNNERS_AUTH_TOKEN }}
           resources:
@@ -638,26 +744,24 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
-          imagePullPolicy: IfNotPresent
-${{ endif() }}
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-spec:
-  ports:
-    - name: http
-      port: 5678
-      protocol: TCP
-    - name: broker
-      port: 5679
-      protocol: TCP
-  selector:
-    app: ${{ defaults.app_name }}
+          ports:
+            - name: health
+              protocol: TCP
+              containerPort: 5680
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
 
 ---
 apiVersion: v1
@@ -666,6 +770,7 @@ metadata:
   name: ${{ defaults.app_name }}-worker
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-worker
+    app: ${{ defaults.app_name }}-worker
 spec:
   ports:
     - name: broker
@@ -673,6 +778,7 @@ spec:
       protocol: TCP
   selector:
     app: ${{ defaults.app_name }}-worker
+${{ endif() }}
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -682,6 +788,7 @@ metadata:
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
+    app: ${{ defaults.app_name }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
@@ -723,6 +830,7 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}


### PR DESCRIPTION
## What this PR does

- Updates the n8n Sealos template runtime to n8n 2.22.4.
- Updates PostgreSQL to the current pinned Sealos template version, PostgreSQL 16.4.0.
- Restores and fixes Redis-backed queue mode with n8n worker and external runner resources.
- Aligns Redis and workload resources with the docker-to-sealos resource rules.
- Refreshes English and Chinese README content, including queue mode, resource sizing, and first owner account setup/login guidance.

## Validation

- `python3 path_converter.py --self-test`
- `python3 test_check_consistency.py`
- `python3 test_compose_to_template.py`
- `python3 test_check_must_coverage.py`
- `python3 check_consistency.py --skill ... --references ... --rules-file ...`
- `python3 check_consistency.py --skill ... --references ... --rules-file ... --artifacts template/n8n/index.yaml`
- `python3 check_must_coverage.py --skill ... --mapping ... --rules-file ...`
- `node deploy-template.mjs template/n8n/index.yaml --dry-run`
- `node deploy-template.mjs template/n8n/index.yaml --dry-run --args-json '{"use_postgresql":"true","timezone":"Asia/Shanghai"}'`
- `node deploy-template.mjs template/n8n/index.yaml --dry-run --args-json '{"use_queue_mode":"true","timezone":"Asia/Shanghai"}'`
- Deployed queue mode smoke test: web UI, `/healthz`, and `/rest/settings` returned HTTP 200; worker and runners became Ready.
- Deleted all online test resources, including Instance resources.
