### PR TITLE
feat(minecraft): update template image and docs

### DIFF
--- a/template/minecraft/README.md
+++ b/template/minecraft/README.md
@@ -1,23 +1,134 @@
-三分钟即可拥有一个强大稳定的 Minecraft 联机服务器。
+# Deploy and Host Minecraft on Sealos
 
-直接打开这个链接：
+Minecraft is a sandbox multiplayer game where players build, explore, and run persistent worlds together. This template deploys a Minecraft Java Edition server on Sealos Cloud using `itzg/minecraft-server` with Paper, Fabric, or Forge runtime options.
 
-+ [https://bja.sealos.run/?openapp=system-template%3FtemplateName%3Dminecraft](https://bja.sealos.run/?openapp=system-template%3FtemplateName%3Dminecraft)
+![Minecraft template screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/website-screenshot.webp)
 
-> 没错，你看到的就是 Sealos 的应用模板，这些模板可用于快速创建和部署网站和各种应用程序。你可以在模板市场中找到各种类型的模板，这些模板不仅包含了前端项目，还包含了后端和其他各类应用的部署，具体可参考 [Sealos 模板市场相关文档](https://sealos.run/docs/guides/templates/)。
+## About Hosting Minecraft
 
-接下来你只需要选择服务器的核心（TYPE），输入服务器的 Minecraft 版本（VERSION），然后点击右上角的「去 Sealos 部署」。
+This template runs a single persistent Minecraft server in a StatefulSet. Sealos provisions a NodePort service for the game port and persistent storage for `/data`, so worlds, server properties, logs, plugins, and generated runtime files survive restarts.
 
-> 如果您是第一次使用 Sealos，则需要注册登录 Sealos 公有云账号，登录之后会立即跳转到模板的部署页面。
+The default configuration uses Paper with `VERSION=LATEST`, which resolves to the newest compatible Minecraft server release at deployment time. The template pins the container image to `itzg/minecraft-server:2026.5.3-java25`, uses Java 25 for current Minecraft releases, and sets a balanced default memory profile for a small multiplayer server.
 
-跳转进来之后，点击右上角的「部署应用」开始部署，部署完成后，直接点击应用的「详情」进入该应用的详情页面。
+## Common Use Cases
 
-![](https://cdn.jsdelivr.net/gh/yangchuansheng/imghosting-test@main/uPic/2024-03-02-21-03-IPhnsg.png)
+- **Friends-only survival server**: Host a private Java Edition world for a small group.
+- **Plugin-based Paper server**: Start with Paper and add plugins through the persistent `/data/plugins` directory after deployment.
+- **Modded Fabric or Forge server**: Choose Fabric or Forge and set the Minecraft version that matches your modpack.
+- **Classroom or community world**: Keep a long-running world online with Sealos-managed storage and restart handling.
 
-等待应用变成 Running 状态，然后点击日志按钮查看日志，只要出现了下面的日志，便是启动成功了：
+## Dependencies for Minecraft Hosting
 
-![](https://cdn.jsdelivr.net/gh/yangchuansheng/imghosting-test@main/uPic/2024-03-02-21-05-ovzT6f.png)
+The Sealos template includes the Minecraft server container, persistent storage, and a TCP NodePort service for client connections. No database or web application login is required.
 
-启动成功后，你可以关闭或者最小化「应用管理」App，然后回到「模板市场」的 minecraft 应用界面，拉到最下面的「Others」，你会看到有一个类型叫「Service」的资源，它的描述部分有一个字段是这样写的：`25565:31483/TCP`。25565 后面的端口就是公网端口，比如这里的公网端口就是 31483。
+### Deployment Dependencies
 
-那么你这个 Minecraft 服务器的地址就是 `bja.sealos.run:31483`
+- [Minecraft Server on Docker documentation](https://docker-minecraft-server.readthedocs.io/) - Runtime options for `itzg/minecraft-server`
+- [itzg/docker-minecraft-server GitHub](https://github.com/itzg/docker-minecraft-server) - Image source and configuration reference
+- [PaperMC Documentation](https://docs.papermc.io/) - Paper server documentation
+- [Sealos App Store](https://sealos.io/products/app-store/minecraft) - Minecraft template page
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Minecraft StatefulSet**: Runs `itzg/minecraft-server:2026.5.3-java25` with the selected server type and version.
+- **Persistent Volume**: Stores `/data`, including world data, server configuration, plugins, mods, and logs.
+- **NodePort Service**: Exposes TCP port `25565` for Minecraft Java Edition clients.
+
+**Configuration:**
+
+- `TYPE` selects the server runtime: `PAPER`, `FABRIC`, or `FORGE`.
+- `VERSION` controls the Minecraft server version. The default `LATEST` resolves to the newest compatible release for the selected runtime.
+- `MEMORY` is set to `1024M`, with a `2G` container memory limit to leave headroom for startup, Paper patching, and JVM overhead.
+- `USE_AIKAR_FLAGS` is enabled for JVM tuning.
+
+**License Information:**
+
+This Sealos template is provided under the repository license. Minecraft is owned by Mojang Studios and Microsoft; `itzg/docker-minecraft-server` is maintained by its upstream project under its own license.
+
+## Why Deploy Minecraft on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that simplifies application deployment and management. By deploying Minecraft on Sealos, you get:
+
+- **One-Click Deployment**: Start a Minecraft server from the template page without writing Kubernetes YAML.
+- **Persistent Worlds**: Store world data on persistent storage so it survives container restarts.
+- **Easy Runtime Selection**: Choose Paper, Fabric, or Forge from template parameters.
+- **Public TCP Access**: Connect from Minecraft Java Edition through the NodePort shown by Sealos.
+- **Resource Control**: Adjust CPU, memory, and storage from the Sealos Canvas when your player count grows.
+
+## Deployment Guide
+
+1. Open the [Minecraft template](https://sealos.io/products/app-store/minecraft) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog:
+   - **TYPE**: Choose `PAPER` for a plugin-friendly default, or choose `FABRIC`/`FORGE` for modded servers.
+   - **VERSION**: Keep `LATEST` for the newest compatible server release, or enter a specific Minecraft version required by your plugins or mods.
+3. If Sealos asks you to sign in, register or log in to your Sealos Cloud account. After sign-in, the deployment flow returns to the template.
+4. Wait for deployment to complete. A fresh Paper world typically starts in a few minutes because the server downloads runtime files and prepares the initial world.
+5. In the Canvas, open the Minecraft Service resource and find the mapped TCP port for `25565`, for example `25565:33789/TCP`.
+6. Connect from Minecraft Java Edition using the region domain and mapped port:
+   - **Server Address**: `usw-1.sealos.io:<mapped-port>`
+   - Example: `usw-1.sealos.io:33789`
+
+## Access and Login
+
+Minecraft is not a web application and does not create a template-specific web account. Players connect from the Minecraft Java Edition client with their normal Minecraft/Microsoft account.
+
+The template itself does not enable a whitelist by default. If you need a private allowlist, open the running server files or console in Sealos and configure Minecraft `server.properties`, `whitelist.json`, or RCON according to your server policy.
+
+## Configuration
+
+After deployment, you can manage the server through Sealos:
+
+- **AI Dialog**: Describe resource or configuration changes and let AI apply updates.
+- **Resource Cards**: Open the StatefulSet, Service, or storage cards to inspect and adjust settings.
+- **Server Files**: Use the persistent `/data` directory for plugins, mods, logs, and world data.
+- **Minecraft Console/RCON**: Use server logs or RCON-compatible tools for operator commands when enabled.
+
+## Scaling
+
+Minecraft servers are usually scaled vertically rather than by adding replicas, because a single world process owns the game state. To support more players or heavier plugins:
+
+1. Open the Canvas for your deployment.
+2. Click the Minecraft StatefulSet resource card.
+3. Increase CPU and memory limits, and adjust `MEMORY` if you intentionally raise the JVM heap.
+4. Expand persistent storage before the world, plugins, or backups approach the current capacity.
+
+## Troubleshooting
+
+### Server is deployed but the client cannot connect
+
+- Confirm the Pod is `Running` and ready.
+- Open the Service resource and copy the NodePort mapped from `25565`.
+- Use the Sealos region domain with that mapped port, not the internal ClusterIP.
+
+### Paper, Fabric, or Forge fails to start
+
+- Check whether the selected `VERSION` is supported by the chosen `TYPE`.
+- For Fabric or Forge modpacks, ensure the mods match the selected Minecraft version.
+- Inspect server logs in Sealos for Java version, mod loading, or EULA-related errors.
+
+### The server needs more capacity
+
+- Increase the StatefulSet memory and CPU limits.
+- Keep JVM heap below the container memory limit so startup and native overhead have room.
+- Expand the persistent volume before the world or backups fill the disk.
+
+### Getting Help
+
+- [Minecraft Server on Docker docs](https://docker-minecraft-server.readthedocs.io/)
+- [itzg/docker-minecraft-server issues](https://github.com/itzg/docker-minecraft-server/issues)
+- [Sealos documentation](https://sealos.io/docs/)
+
+## Additional Resources
+
+- [PaperMC Downloads](https://papermc.io/downloads)
+- [Fabric Documentation](https://docs.fabricmc.net/)
+- [Forge Documentation](https://docs.minecraftforge.net/)
+- [Minecraft EULA](https://www.minecraft.net/eula)
+
+## License
+
+This Sealos template is provided under the repository license. Minecraft, Paper, Fabric, Forge, and `itzg/docker-minecraft-server` each follow their own upstream licenses and terms.

--- a/template/minecraft/README_zh.md
+++ b/template/minecraft/README_zh.md
@@ -1,23 +1,134 @@
-三分钟即可拥有一个强大稳定的 Minecraft 联机服务器。
+# 在 Sealos 上部署和托管 Minecraft
 
-直接打开这个链接：
+Minecraft 是一款沙盒多人游戏，玩家可以一起建造、探索并长期运行共享世界。这个模板基于 `itzg/docker-minecraft-server` 在 Sealos Cloud 上部署 Minecraft Java 版服务器，并支持 Paper、Fabric 或 Forge 运行时。
 
-+ [https://bja.sealos.run/?openapp=system-template%3FtemplateName%3Dminecraft](https://bja.sealos.run/?openapp=system-template%3FtemplateName%3Dminecraft)
+![Minecraft 模板截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/website-screenshot.webp)
 
-> 没错，你看到的就是 Sealos 的应用模板，这些模板可用于快速创建和部署网站和各种应用程序。你可以在模板市场中找到各种类型的模板，这些模板不仅包含了前端项目，还包含了后端和其他各类应用的部署，具体可参考 [Sealos 模板市场相关文档](https://sealos.run/docs/guides/templates/)。
+## 关于 Minecraft 托管
 
-接下来你只需要选择服务器的核心（TYPE），输入服务器的 Minecraft 版本（VERSION），然后点击右上角的「去 Sealos 部署」。
+这个模板以 StatefulSet 方式运行单节点 Minecraft 服务器。Sealos 会为游戏端口创建 NodePort Service，并为 `/data` 提供持久化存储，因此世界数据、服务器配置、日志、插件和运行时文件会在重启后保留。
 
-> 如果您是第一次使用 Sealos，则需要注册登录 Sealos 公有云账号，登录之后会立即跳转到模板的部署页面。
+默认配置使用 Paper，并将 `VERSION` 设置为 `LATEST`，部署时会解析为当前兼容的最新 Minecraft 服务端版本。模板固定使用 `itzg/minecraft-server:2026.5.3-java25` 镜像，为当前 Minecraft 版本提供 Java 25 运行环境，并为小型多人服务器设置了更稳妥的默认内存配置。
 
-跳转进来之后，点击右上角的「部署应用」开始部署，部署完成后，直接点击应用的「详情」进入该应用的详情页面。
+## 常见使用场景
 
-![](https://cdn.jsdelivr.net/gh/yangchuansheng/imghosting-test@main/uPic/2024-03-02-21-03-IPhnsg.png)
+- **好友生存服**：为小团队托管私有 Java 版世界。
+- **Paper 插件服**：使用 Paper 启动，并在部署后通过持久化的 `/data/plugins` 目录添加插件。
+- **Fabric 或 Forge 模组服**：选择 Fabric 或 Forge，并设置与模组包匹配的 Minecraft 版本。
+- **课堂或社区服务器**：用 Sealos 管理存储和重启，让长期世界保持在线。
 
-等待应用变成 Running 状态，然后点击日志按钮查看日志，只要出现了下面的日志，便是启动成功了：
+## Minecraft 托管依赖
 
-![](https://cdn.jsdelivr.net/gh/yangchuansheng/imghosting-test@main/uPic/2024-03-02-21-05-ovzT6f.png)
+Sealos 模板包含 Minecraft 服务端容器、持久化存储，以及用于客户端连接的 TCP NodePort Service。该应用不需要数据库，也没有 Web 应用登录流程。
 
-启动成功后，你可以关闭或者最小化「应用管理」App，然后回到「模板市场」的 minecraft 应用界面，拉到最下面的「Others」，你会看到有一个类型叫「Service」的资源，它的描述部分有一个字段是这样写的：`25565:31483/TCP`。25565 后面的端口就是公网端口，比如这里的公网端口就是 31483。
+### 部署依赖
 
-那么你这个 Minecraft 服务器的地址就是 `bja.sealos.run:31483`
+- [Minecraft Server on Docker 文档](https://docker-minecraft-server.readthedocs.io/) - `itzg/minecraft-server` 运行时配置
+- [itzg/docker-minecraft-server GitHub](https://github.com/itzg/docker-minecraft-server) - 镜像源码和配置参考
+- [PaperMC 文档](https://docs.papermc.io/) - Paper 服务端文档
+- [Sealos 应用商店](https://sealos.io/products/app-store/minecraft) - Minecraft 模板页面
+
+### 实现细节
+
+**架构组件：**
+
+这个模板会部署以下资源：
+
+- **Minecraft StatefulSet**：运行 `itzg/minecraft-server:2026.5.3-java25`，并根据参数选择服务端类型和版本。
+- **持久化卷**：保存 `/data`，包括世界数据、服务端配置、插件、模组和日志。
+- **NodePort Service**：暴露 TCP `25565` 端口，供 Minecraft Java 版客户端连接。
+
+**配置：**
+
+- `TYPE` 用于选择服务端运行时：`PAPER`、`FABRIC` 或 `FORGE`。
+- `VERSION` 用于控制 Minecraft 服务端版本。默认 `LATEST` 会解析为所选运行时兼容的最新版本。
+- `MEMORY` 设置为 `1024M`，容器内存限制为 `2G`，为启动、Paper patch 和 JVM 额外开销保留空间。
+- `USE_AIKAR_FLAGS` 已启用，用于 JVM 参数优化。
+
+**许可证信息：**
+
+这个 Sealos 模板遵循仓库许可证。Minecraft 归 Mojang Studios 和 Microsoft 所有；`itzg/docker-minecraft-server` 由其上游项目维护，并遵循其自身许可证。
+
+## 为什么在 Sealos 上部署 Minecraft？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，可以简化应用部署和管理。在 Sealos 上部署 Minecraft 可以获得：
+
+- **一键部署**：从模板页面启动 Minecraft 服务器，不需要手写 Kubernetes YAML。
+- **世界持久化**：世界数据保存在持久化存储中，容器重启后仍会保留。
+- **运行时可选**：通过模板参数选择 Paper、Fabric 或 Forge。
+- **公网 TCP 访问**：通过 Sealos 显示的 NodePort 从 Minecraft Java 版客户端连接。
+- **资源可调整**：玩家数量或插件负载增加时，可以在 Sealos Canvas 中调整 CPU、内存和存储。
+
+## 部署指南
+
+1. 打开 [Minecraft 模板](https://sealos.io/products/app-store/minecraft)，点击 **Deploy Now**。
+2. 在弹窗中配置参数：
+   - **TYPE**：建议默认选择 `PAPER`；如果需要模组服务器，可以选择 `FABRIC` 或 `FORGE`。
+   - **VERSION**：保留 `LATEST` 可使用当前兼容的最新服务端版本；如果插件或模组要求固定版本，请填写对应 Minecraft 版本。
+3. 如果 Sealos 要求登录，请注册或登录 Sealos Cloud 账号。登录后会回到模板部署流程。
+4. 等待部署完成。首次启动 Paper 世界通常需要几分钟，因为服务端会下载运行时文件并生成初始世界。
+5. 在 Canvas 中打开 Minecraft 的 Service 资源，找到 `25565` 对应的公网端口，例如 `25565:33789/TCP`。
+6. 在 Minecraft Java 版客户端中使用区域域名和映射端口连接：
+   - **服务器地址**：`usw-1.sealos.io:<映射端口>`
+   - 示例：`usw-1.sealos.io:33789`
+
+## 访问与登录
+
+Minecraft 不是 Web 应用，也不会创建模板专属的网页账号。玩家需要用自己的 Minecraft Java 版客户端和正常的 Minecraft/Microsoft 账号进入游戏。
+
+模板默认不启用白名单。如果需要私有白名单，可以在 Sealos 中打开运行中的服务器文件或控制台，并根据服务器策略配置 Minecraft `server.properties`、`whitelist.json` 或 RCON。
+
+## 配置
+
+部署后，可以通过 Sealos 管理服务器：
+
+- **AI 对话框**：描述要修改的资源或配置，让 AI 协助应用变更。
+- **资源卡片**：打开 StatefulSet、Service 或存储卡片，查看并调整设置。
+- **服务器文件**：通过持久化的 `/data` 目录管理插件、模组、日志和世界数据。
+- **Minecraft 控制台/RCON**：启用后可通过服务器日志或兼容 RCON 的工具执行管理员命令。
+
+## 扩容
+
+Minecraft 服务器通常采用纵向扩容，而不是增加副本，因为单个世界进程持有游戏状态。若要支持更多玩家或更重的插件负载：
+
+1. 打开该部署的 Canvas。
+2. 点击 Minecraft StatefulSet 资源卡片。
+3. 增加 CPU 和内存限制；如需提高 JVM 堆内存，再同步调整 `MEMORY`。
+4. 当世界、插件或备份接近当前容量时，提前扩展持久化存储。
+
+## 故障排查
+
+### 服务已部署但客户端无法连接
+
+- 确认 Pod 已经是 `Running` 且 Ready。
+- 打开 Service 资源，复制 `25565` 映射出来的 NodePort。
+- 使用 Sealos 区域域名和映射端口连接，不要使用内部 ClusterIP。
+
+### Paper、Fabric 或 Forge 启动失败
+
+- 检查所选 `VERSION` 是否被当前 `TYPE` 支持。
+- 如果是 Fabric 或 Forge 模组包，确认模组与 Minecraft 版本一致。
+- 在 Sealos 中查看服务端日志，定位 Java 版本、模组加载或 EULA 相关错误。
+
+### 服务器需要更多容量
+
+- 提高 StatefulSet 的内存和 CPU 限制。
+- 保持 JVM 堆内存低于容器内存限制，为启动过程和原生开销留出余量。
+- 在世界或备份占满磁盘前扩展持久化卷。
+
+### 获取帮助
+
+- [Minecraft Server on Docker 文档](https://docker-minecraft-server.readthedocs.io/)
+- [itzg/docker-minecraft-server Issues](https://github.com/itzg/docker-minecraft-server/issues)
+- [Sealos 文档](https://sealos.io/docs/)
+
+## 更多资源
+
+- [PaperMC 下载](https://papermc.io/downloads)
+- [Fabric 文档](https://docs.fabricmc.net/)
+- [Forge 文档](https://docs.minecraftforge.net/)
+- [Minecraft EULA](https://www.minecraft.net/eula)
+
+## 许可证
+
+这个 Sealos 模板遵循仓库许可证。Minecraft、Paper、Fabric、Forge 和 `itzg/docker-minecraft-server` 分别遵循各自上游项目的许可证和使用条款。

--- a/template/minecraft/index.yaml
+++ b/template/minecraft/index.yaml
@@ -1,146 +1,164 @@
-apiVersion: 'app.sealos.io/v1'
+apiVersion: "app.sealos.io/v1"
 kind: Template
 metadata:
-  name: minecraft
+    name: minecraft
 spec:
-  title: 'Minecraft'
-  author: 'Sealos'
-  description: 'Minecraft 专有版服务器，支持 Forge 和 Fabric。'
-  url: 'https://docker-minecraft-server.readthedocs.io/'
-  gitRepo: 'https://github.com/itzg/docker-minecraft-server'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/logo.png'
-  screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/website-screenshot.webp'
-  templateType: inline
-  locale: zh
-  categories:
-    - game
-  defaults:
-    app_name:
-      type: string
-      value: minecraft-${{ random(8) }}
-  inputs:
-    TYPE:
-      description: 'server type'
-      type: choice
-      options:
-        - 'FORGE'
-        - 'FABRIC'
-        - 'PAPER'
-      default: 'PAPER'
-      required: true
-    VERSION:
-      description: 'minecraft version'
-      type: string
-      default: 'LATEST'
-      required: true
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/README_zh.md'
+    title: "Minecraft"
+    author: "Sealos"
+    description: "A self-hosted Minecraft Java Edition server powered by itzg/docker-minecraft-server, with Paper, Fabric, or Forge runtime options."
+    url: "https://docker-minecraft-server.readthedocs.io/"
+    gitRepo: "https://github.com/itzg/docker-minecraft-server"
+    readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/README.md"
+    icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/logo.png"
+    screenshots:
+        - "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/website-screenshot.webp"
+    templateType: inline
+    locale: en
+    categories:
+        - game
+    defaults:
+        app_name:
+            type: string
+            value: minecraft-${{ random(8) }}
+    inputs:
+        TYPE:
+            description: "server type"
+            type: choice
+            options:
+                - "FORGE"
+                - "FABRIC"
+                - "PAPER"
+            default: "PAPER"
+            required: true
+        VERSION:
+            description: "Minecraft server version. Use LATEST to let the selected server type resolve the newest compatible release."
+            type: string
+            default: "LATEST"
+            required: true
+    i18n:
+        zh:
+            description: "基于 itzg/docker-minecraft-server 的自托管 Minecraft Java 版服务器，支持 Paper、Fabric 或 Forge 运行时。"
+            readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/minecraft/README_zh.md"
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: ${{ defaults.app_name }}
-  annotations:
-    originImageName: itzg/minecraft-server
-    deploy.cloud.sealos.io/minReplicas: '1'
-    deploy.cloud.sealos.io/maxReplicas: '1'
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app: ${{ defaults.app_name }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 1
-  minReadySeconds: 10
-  serviceName: ${{ defaults.app_name }}
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}
-  template:
-    metadata:
-      labels:
+    name: ${{ defaults.app_name }}
+    annotations:
+        originImageName: itzg/minecraft-server:2026.5.3-java25
+        deploy.cloud.sealos.io/minReplicas: "1"
+        deploy.cloud.sealos.io/maxReplicas: "1"
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
         app: ${{ defaults.app_name }}
-    spec:
-      terminationGracePeriodSeconds: 10
-      automountServiceAccountToken: false
-      initContainers:
-        - name: take-data-dir-ownership
-          image: alpine
-          command:
-            ['/bin/sh', '-c', 'chown -R 1000:1000 /data; chmod -R 770 /data']
-          volumeMounts:
-            - name: vn-minecraft
-              mountPath: /data
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: itzg/minecraft-server
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: EULA
-              value: 'TRUE'
-            - name: TYPE
-              value: ${{ inputs.TYPE }}
-            - name: VERSION
-              value: ${{ inputs.VERSION }}
-            - name: REMOVE_OLD_MODS
-              value: 'false'
-            - name: PLUGINS
-              value: ''
-            - name: MODS
-              value: ''
-            - name: MODPACK
-              value: ''
-          volumeMounts:
-            - mountPath: /data
+spec:
+    replicas: 1
+    revisionHistoryLimit: 1
+    minReadySeconds: 10
+    serviceName: ${{ defaults.app_name }}
+    selector:
+        matchLabels:
+            app: ${{ defaults.app_name }}
+    template:
+        metadata:
+            labels:
+                app: ${{ defaults.app_name }}
+        spec:
+            terminationGracePeriodSeconds: 10
+            automountServiceAccountToken: false
+            initContainers:
+                - name: take-data-dir-ownership
+                  image: alpine:3.22.4
+                  imagePullPolicy: IfNotPresent
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 12Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi
+                  command:
+                      [
+                          "/bin/sh",
+                          "-c",
+                          "chown -R 1000:1000 /data; chmod -R 770 /data",
+                      ]
+                  volumeMounts:
+                      - name: vn-minecraft
+                        mountPath: /data
+            containers:
+                - name: ${{ defaults.app_name }}
+                  image: itzg/minecraft-server:2026.5.3-java25
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: EULA
+                        value: "TRUE"
+                      - name: TYPE
+                        value: ${{ inputs.TYPE }}
+                      - name: VERSION
+                        value: ${{ inputs.VERSION }}
+                      - name: MEMORY
+                        value: "1024M"
+                      - name: USE_AIKAR_FLAGS
+                        value: "true"
+                      - name: REMOVE_OLD_MODS
+                        value: "false"
+                      - name: PLUGINS
+                        value: ""
+                      - name: MODS
+                        value: ""
+                      - name: MODPACK
+                        value: ""
+                  volumeMounts:
+                      - mountPath: /data
+                        name: vn-minecraft
+                  ports:
+                      - containerPort: 25565
+                        name: game
+                  readinessProbe:
+                      exec:
+                          command:
+                              - mc-monitor
+                              - status
+                      initialDelaySeconds: 30
+                      periodSeconds: 5
+                      failureThreshold: 20
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 200Mi
+                          ephemeral-storage: 400Mi
+                      limits:
+                          cpu: "1"
+                          memory: 2G
+                          ephemeral-storage: 400Mi
+    volumeClaimTemplates:
+        - metadata:
               name: vn-minecraft
-          ports:
-            - containerPort: 25565
-              name: game
-          readinessProbe:
-            exec:
-              command:
-                - mc-monitor
-                - status
-            initialDelaySeconds: 30
-            periodSeconds: 5
-            failureThreshold: 20
-          resources:
-            requests:
-              cpu: 1000m
-              memory: 2048Mi
-              ephemeral-storage: 400Mi
-            limits:
-              cpu: 4000m
-              memory: 8192Mi
-              ephemeral-storage: 400Mi
-  volumeClaimTemplates:
-    - metadata:
-        name: vn-minecraft
-        annotations:
-          path: /data
-          value: '2'
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 2Gi
+              annotations:
+                  path: /data
+                  value: "1"
+          spec:
+              accessModes:
+                  - ReadWriteOnce
+              resources:
+                  requests:
+                      storage: 1Gi
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}-nodeport
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        app: ${{ defaults.app_name }}
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  type: NodePort
-  ports:
-    - protocol: TCP
-      port: 25565
-      targetPort: 25565
-      name: game
-  selector:
-    app: ${{ defaults.app_name }}
+    type: NodePort
+    ports:
+        - protocol: TCP
+          port: 25565
+          targetPort: 25565
+          name: game
+    selector:
+        app: ${{ defaults.app_name }}


### PR DESCRIPTION
## Summary
- update the Minecraft template to `itzg/minecraft-server:2026.5.3-java25`
- tune memory, storage, image pull secrets, and service metadata for Sealos deployment
- rewrite English and Chinese READMEs with deployment, connection, and troubleshooting guidance

## Validation
- `check_consistency.py` passed for `template/minecraft/index.yaml`
- `quality_gate.py` passed for the Minecraft template artifact
- template API dry-run succeeded with `TYPE=PAPER`, `VERSION=LATEST`
- live Sealos deployment reached Ready with Paper `26.1.2` and Minecraft protocol `775`
- in-cluster and external NodePort Minecraft status checks succeeded
- all live test Instance resources, apps, pods, services, and PVCs were cleaned up
- `git diff --check upstream/kb-0.9...HEAD` passed
