### PR TITLE
feat(rustdesk): update server template and docs

### DIFF
--- a/template/rustdesk/README.md
+++ b/template/rustdesk/README.md
@@ -1,23 +1,130 @@
-为远程连接工具 rustdesk 在 sealos 中建立服务端。    
+# Deploy and Host RustDesk Server on Sealos
 
-1. 按照模板一键部署    
+RustDesk Server provides the self-hosted ID/rendezvous and relay services used by RustDesk clients. This template deploys the RustDesk Server S6 image with persistent key storage, NodePort exposure for client traffic, and a Sealos App entry that points to the regional TCP gateway.
 
-> TIPS：建议 ENCRYPTED_ONLY 选择 1，这样只允许建立加密连接，不易被别人白嫖    
+## About Hosting RustDesk Server
 
-2. 部署成功，应用处于 running 状态后，在日志中找到暴露的域名 (这里示例是 ENCRYPTED_ONLY=0 的情况)：   
+RustDesk Server runs the `hbbs` rendezvous service and the `hbbr` relay service in one StatefulSet. The template stores the server key pair and lightweight SQLite metadata under `/data`, so the public key remains stable across restarts.
 
-![](https://github.com/labring-actions/templates/assets/45360163/6c4042f7-3537-4aee-8c5f-d5a136d18c03)
+This deployment is not a web dashboard and does not require browser login or account registration. Users connect from the RustDesk desktop or mobile client by entering the Sealos TCP gateway host, the allocated NodePort values, and, when encryption is enabled, the public key printed in the pod logs.
 
-3. 在我的应用--Other 中找到映射的端口：    
+## Common Use Cases
 
-![](https://github.com/labring-actions/templates/assets/45360163/e8edc007-f41a-4415-bb0e-244bcb4e91f9)
+- **Private Remote Desktop Relay**: Route RustDesk remote desktop sessions through infrastructure you control.
+- **Team Support Gateway**: Provide a shared ID and relay server for support engineers and managed devices.
+- **Encrypted Client Access**: Require RustDesk clients to use the server public key by setting `ENCRYPTED_ONLY` to `1`.
+- **Portable Lab Environments**: Run an isolated relay for testing remote access workflows without maintaining your own Kubernetes manifests.
 
-4. 在你的客户端填入信息如下：
+## Dependencies for RustDesk Server Hosting
 
-> TIPS：当 ENCRYPTED_ONLY 选择1时，必须填入下图设置中的 Key。其内容从上面图 1 中的日志获取。
+The Sealos template includes all required runtime resources: a RustDesk Server S6 container, persistent storage for `/data`, a NodePort Service for RustDesk client ports, and a Sealos App link for the TCP gateway host.
 
-![](https://github.com/labring-actions/templates/assets/45360163/437b342e-2439-4312-a697-6e0e8117bea8)
+### Deployment Dependencies
 
-5. 点击客户端左上角**主页**，看到底部状态栏绿色**就绪**，即部署+连接成功。Enjoy！
+- [RustDesk Server GitHub Repository](https://github.com/rustdesk/rustdesk-server) - Server source code and release notes
+- [RustDesk Documentation](https://rustdesk.com/docs/) - RustDesk client and self-hosting documentation
+- [RustDesk Server Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6) - Container image used by this template
+- [Sealos App Store](https://sealos.io/products/app-store/rustdesk) - One-click deployment entry
 
-> TIPS：管理好自己的中继/ID 服务器信息，泄密会造成难以评估的后果！
+## Implementation Details
+
+**Architecture Components:**
+
+This template deploys one stateful service:
+
+- **RustDesk Server**: Runs `hbbs` for ID/rendezvous traffic and `hbbr` for relay traffic.
+- **Persistent Volume**: Stores `/data`, including the generated `id_ed25519` key pair and RustDesk server metadata.
+- **NodePort Service**: Exposes RustDesk client ports `21115/tcp`, `21116/tcp`, `21116/udp`, and `21117/tcp` through the Sealos TCP gateway.
+- **Sealos App Link**: Shows the gateway host `tcp.${{ SEALOS_CLOUD_DOMAIN }}` in Canvas.
+
+**Configuration:**
+
+- `ENCRYPTED_ONLY=1` requires clients to configure the server public key. This is the recommended setting.
+- `ENCRYPTED_ONLY=0` allows clients to connect without the server public key, which is easier for quick tests but less restrictive.
+- The `RELAY` environment variable is set from the generated Sealos host so `hbbs` advertises the correct relay address.
+- The template uses the pinned image `rustdesk/rustdesk-server-s6:1.1.15`, matching the latest RustDesk Server release stream available for the S6 server image.
+
+**Resource Profile:**
+
+Live Sealos testing verified the service with `1m` CPU / `5Mi` memory requests and `20m` CPU / `24Mi` memory limits while both `hbbs` and `hbbr` stayed healthy. Increase resources from Canvas if you expect many concurrent remote desktop sessions or sustained relay bandwidth.
+
+**License Information:**
+
+RustDesk Server is licensed under AGPL-3.0. This Sealos template is provided as deployment automation for RustDesk Server.
+
+## Why Deploy RustDesk Server on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, public access, storage, and day-2 operations. By deploying RustDesk Server on Sealos, you get:
+
+- **One-Click Deployment**: Deploy RustDesk Server from the App Store without writing Kubernetes YAML.
+- **Persistent Key Storage**: Keep the generated RustDesk server key pair stable across restarts.
+- **Instant TCP Gateway Access**: Use the Sealos regional TCP gateway and allocated NodePorts for RustDesk clients.
+- **Easy Customization**: Adjust encryption mode, resources, and storage through Canvas and AI-assisted operations.
+- **Pay-as-You-Go Efficiency**: Start with a minimal resource profile and scale only when your relay traffic needs it.
+- **Kubernetes Foundation**: Run RustDesk Server on managed Kubernetes primitives without managing cluster internals.
+
+## Deployment Guide
+
+1. Open the [RustDesk template](https://sealos.io/products/app-store/rustdesk) and click **Deploy Now**.
+2. Configure `ENCRYPTED_ONLY` in the popup dialog. Use `1` for encrypted-only access with a public key, or `0` for less restrictive test deployments.
+3. Wait for deployment to complete (typically 2-3 minutes). After deployment, you will be redirected to Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Open the RustDesk Server pod logs and copy the line that starts with `Key:`. This is required when `ENCRYPTED_ONLY=1`.
+5. Open the Service resource in Canvas and note the allocated NodePort values for:
+   - **ID Server**: `rendezvous-tcp` / `rendezvous-udp` on port `21116`
+   - **Relay Server**: `relay` on port `21117`
+   - **NAT Test**: `heartbeat` on port `21115`
+6. In your RustDesk client, open **Settings → Network → ID/Relay Server** and enter:
+   - **ID Server**: `tcp.${{ SEALOS_CLOUD_DOMAIN }}:<rendezvous-nodeport>`
+   - **Relay Server**: `tcp.${{ SEALOS_CLOUD_DOMAIN }}:<relay-nodeport>`
+   - **API Server**: leave blank unless you run a separate RustDesk API service
+   - **Key**: paste the pod log key when `ENCRYPTED_ONLY=1`
+7. Save the settings. The RustDesk client status should become ready after it reaches the self-hosted ID server.
+
+## Configuration
+
+After deployment, you can configure RustDesk Server through:
+
+- **AI Dialog**: Describe resource or environment changes and let Sealos apply updates.
+- **Resource Cards**: Click the StatefulSet, Service, or storage cards in Canvas to inspect and modify settings.
+- **RustDesk Client Settings**: Configure client-side ID server, relay server, and key values.
+
+There is no built-in RustDesk Server web login in this template. Access is controlled by the RustDesk client configuration and, when enabled, the server public key.
+
+## Scaling
+
+To scale resources for heavier relay traffic:
+
+1. Open the Canvas for your deployment.
+2. Click the RustDesk StatefulSet resource card.
+3. Increase CPU and memory limits according to active sessions and relay bandwidth.
+4. Apply the changes in the dialog and wait for the pod to roll out.
+
+Keep a single replica unless you have a custom multi-server RustDesk topology. The generated key and local metadata are tied to the StatefulSet volume.
+
+## Troubleshooting
+
+### Client does not become ready
+
+- **Cause**: The client is using the wrong TCP gateway host, NodePort, or key.
+- **Solution**: Recheck the Service NodePorts, use `tcp.${{ SEALOS_CLOUD_DOMAIN }}` as the host, and copy the latest `Key:` value from pod logs when `ENCRYPTED_ONLY=1`.
+
+### Relay works inconsistently
+
+- **Cause**: The relay NodePort or server key is missing from the client configuration.
+- **Solution**: Set both the ID Server and Relay Server fields in the RustDesk client. If encrypted-only mode is enabled, also set the Key field.
+
+### Pod is running but clients cannot connect
+
+- **Cause**: Client traffic is not reaching the exposed NodePorts.
+- **Solution**: Confirm the Service lists NodePorts for `21116/tcp`, `21116/udp`, `21117/tcp`, and `21115/tcp`, then test from a network that allows outbound TCP/UDP to the gateway.
+
+## Additional Resources
+
+- [RustDesk Website](https://rustdesk.com/)
+- [RustDesk Server Releases](https://github.com/rustdesk/rustdesk-server/releases)
+- [RustDesk Documentation](https://rustdesk.com/docs/)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is provided under the repository license. RustDesk Server itself is licensed under AGPL-3.0.

--- a/template/rustdesk/README_zh.md
+++ b/template/rustdesk/README_zh.md
@@ -1,23 +1,130 @@
-为远程连接工具 rustdesk 在 sealos 中建立服务端。    
+# 在 Sealos 上部署和托管 RustDesk Server
 
-1. 按照模板一键部署    
+RustDesk Server 为 RustDesk 客户端提供自托管 ID/会合服务和中继服务。此模板会在 Sealos Cloud 上部署 RustDesk Server S6 镜像，提供持久化密钥存储、面向客户端流量的 NodePort 暴露，以及指向区域 TCP 网关的 Sealos 应用入口。
 
-> TIPS：建议 ENCRYPTED_ONLY 选择 1，这样只允许建立加密连接，不易被别人白嫖    
+## 关于托管 RustDesk Server
 
-2. 部署成功，应用处于 running 状态后，在日志中找到暴露的域名 (这里示例是 ENCRYPTED_ONLY=0 的情况)：   
+RustDesk Server 在同一个 StatefulSet 中运行 `hbbs` 会合服务和 `hbbr` 中继服务。模板会把服务器密钥对和轻量 SQLite 元数据保存在 `/data`，因此重启后公钥仍保持稳定。
 
-![](https://github.com/labring-actions/templates/assets/45360163/6c4042f7-3537-4aee-8c5f-d5a136d18c03)
+此部署不是 Web 控制台，不需要浏览器登录或注册账号。用户需要在 RustDesk 桌面端或移动端中填写 Sealos TCP 网关主机、分配到的 NodePort，以及在启用加密时填写 Pod 日志中的公钥。
 
-3. 在我的应用--Other 中找到映射的端口：    
+## 常见使用场景
 
-![](https://github.com/labring-actions/templates/assets/45360163/e8edc007-f41a-4415-bb0e-244bcb4e91f9)
+- **私有远程桌面中继**：通过自己控制的基础设施转发 RustDesk 远程桌面会话。
+- **团队支持网关**：为支持工程师和受管设备提供共享 ID 与中继服务器。
+- **加密客户端接入**：将 `ENCRYPTED_ONLY` 设置为 `1`，要求 RustDesk 客户端使用服务器公钥。
+- **可移植实验环境**：无需维护 Kubernetes 清单，即可运行隔离的远程访问测试中继。
 
-4. 在你的客户端填入信息如下：
+## RustDesk Server 托管依赖
 
-> TIPS：当 ENCRYPTED_ONLY 选择1时，必须填入下图设置中的 Key。其内容从上面图 1 中的日志获取。
+此 Sealos 模板包含所有必需运行资源：RustDesk Server S6 容器、用于 `/data` 的持久化存储、面向 RustDesk 客户端端口的 NodePort Service，以及展示 TCP 网关主机的 Sealos App 链接。
 
-![](https://github.com/labring-actions/templates/assets/45360163/437b342e-2439-4312-a697-6e0e8117bea8)
+### 部署依赖
 
-5. 点击客户端左上角**主页**，看到底部状态栏绿色**就绪**，即部署+连接成功。Enjoy！
+- [RustDesk Server GitHub 仓库](https://github.com/rustdesk/rustdesk-server) - 服务器源码和发布说明
+- [RustDesk 文档](https://rustdesk.com/docs/) - RustDesk 客户端与自托管文档
+- [RustDesk Server Docker Hub](https://hub.docker.com/r/rustdesk/rustdesk-server-s6) - 此模板使用的容器镜像
+- [Sealos 应用商店](https://sealos.io/products/app-store/rustdesk) - 一键部署入口
 
-> TIPS：管理好自己的中继/ID 服务器信息，泄密会造成难以评估的后果！
+## 实现细节
+
+**架构组件：**
+
+此模板部署一个有状态服务：
+
+- **RustDesk Server**：运行 `hbbs` 处理 ID/会合流量，运行 `hbbr` 处理中继流量。
+- **持久化卷**：保存 `/data`，包括生成的 `id_ed25519` 密钥对和 RustDesk 服务器元数据。
+- **NodePort Service**：通过 Sealos TCP 网关暴露 RustDesk 客户端端口 `21115/tcp`、`21116/tcp`、`21116/udp` 和 `21117/tcp`。
+- **Sealos App 链接**：在 Canvas 中展示网关主机 `tcp.${{ SEALOS_CLOUD_DOMAIN }}`。
+
+**配置：**
+
+- `ENCRYPTED_ONLY=1` 要求客户端配置服务器公钥，这是推荐设置。
+- `ENCRYPTED_ONLY=0` 允许客户端不配置服务器公钥即可连接，适合快速测试，但限制更弱。
+- `RELAY` 环境变量由生成的 Sealos 主机名设置，确保 `hbbs` 对外声明正确的中继地址。
+- 模板使用固定镜像 `rustdesk/rustdesk-server-s6:1.1.15`，对应 S6 服务器镜像可用的最新 RustDesk Server 发布流。
+
+**资源配置：**
+
+Sealos 在线测试已验证：服务在 `1m` CPU / `5Mi` 内存 requests 与 `20m` CPU / `24Mi` 内存 limits 下，`hbbs` 和 `hbbr` 均保持健康。如果你预计有大量并发远程桌面会话或持续中继带宽，请在 Canvas 中提高资源。
+
+**许可证信息：**
+
+RustDesk Server 使用 AGPL-3.0 许可证。此 Sealos 模板作为 RustDesk Server 的部署自动化提供。
+
+## 为什么在 Sealos 上部署 RustDesk Server？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一应用部署、公网访问、存储和后续运维。在 Sealos 上部署 RustDesk Server 可以获得：
+
+- **一键部署**：直接从应用商店部署 RustDesk Server，无需编写 Kubernetes YAML。
+- **持久化密钥存储**：重启后保留生成的 RustDesk 服务器密钥对。
+- **即时 TCP 网关访问**：为 RustDesk 客户端使用 Sealos 区域 TCP 网关和分配到的 NodePort。
+- **易于自定义**：通过 Canvas 和 AI 辅助运维调整加密模式、资源和存储。
+- **按量付费效率**：从最小资源配置开始，只在中继流量需要时扩容。
+- **Kubernetes 基础能力**：使用托管 Kubernetes 原语运行 RustDesk Server，无需管理集群细节。
+
+## 部署指南
+
+1. 打开 [RustDesk 模板](https://sealos.io/products/app-store/rustdesk)，点击 **Deploy Now**。
+2. 在弹窗中配置 `ENCRYPTED_ONLY`。使用 `1` 启用需要公钥的加密接入，或使用 `0` 进行限制较少的测试部署。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会进入 Canvas。后续如需修改，可以在 AI 对话框描述需求，或点击对应资源卡片调整配置。
+4. 打开 RustDesk Server Pod 日志，复制以 `Key:` 开头的那一行。当 `ENCRYPTED_ONLY=1` 时必须填写此公钥。
+5. 在 Canvas 中打开 Service 资源，记录以下端口分配到的 NodePort：
+   - **ID Server**：`rendezvous-tcp` / `rendezvous-udp`，对应端口 `21116`
+   - **Relay Server**：`relay`，对应端口 `21117`
+   - **NAT Test**：`heartbeat`，对应端口 `21115`
+6. 在 RustDesk 客户端中打开 **设置 → 网络 → ID/中继服务器**，填写：
+   - **ID Server**：`tcp.${{ SEALOS_CLOUD_DOMAIN }}:<rendezvous-nodeport>`
+   - **Relay Server**：`tcp.${{ SEALOS_CLOUD_DOMAIN }}:<relay-nodeport>`
+   - **API Server**：留空，除非你另行部署 RustDesk API 服务
+   - **Key**：当 `ENCRYPTED_ONLY=1` 时，粘贴 Pod 日志中的公钥
+7. 保存设置。RustDesk 客户端连通自托管 ID Server 后，状态应变为就绪。
+
+## 配置
+
+部署后，你可以通过以下方式配置 RustDesk Server：
+
+- **AI 对话框**：描述资源或环境变量调整需求，由 Sealos 应用变更。
+- **资源卡片**：在 Canvas 中点击 StatefulSet、Service 或存储卡片，查看并修改配置。
+- **RustDesk 客户端设置**：配置客户端侧 ID Server、Relay Server 和 Key。
+
+此模板不包含 RustDesk Server Web 登录功能。访问控制由 RustDesk 客户端配置决定；启用加密模式时，还由服务器公钥限制。
+
+## 扩缩容
+
+如需为更高的中继流量提升资源：
+
+1. 打开此部署的 Canvas。
+2. 点击 RustDesk StatefulSet 资源卡片。
+3. 根据活跃会话数和中继带宽提高 CPU 与内存 limits。
+4. 在对话框中应用变更，并等待 Pod 滚动更新完成。
+
+除非你有自定义多服务器 RustDesk 拓扑，否则建议保持单副本。生成的密钥和本地元数据与 StatefulSet 持久化卷绑定。
+
+## 故障排查
+
+### 客户端无法进入就绪状态
+
+- **原因**：客户端填写了错误的 TCP 网关主机、NodePort 或 Key。
+- **解决方案**：重新检查 Service NodePort，使用 `tcp.${{ SEALOS_CLOUD_DOMAIN }}` 作为主机；当 `ENCRYPTED_ONLY=1` 时，从 Pod 日志复制最新 `Key:` 值。
+
+### 中继连接不稳定
+
+- **原因**：客户端缺少 Relay NodePort 或服务器公钥配置。
+- **解决方案**：同时填写 RustDesk 客户端中的 ID Server 和 Relay Server。如果启用了加密模式，也要填写 Key 字段。
+
+### Pod 正常运行但客户端无法连接
+
+- **原因**：客户端流量没有到达暴露的 NodePort。
+- **解决方案**：确认 Service 已列出 `21116/tcp`、`21116/udp`、`21117/tcp` 和 `21115/tcp` 的 NodePort，然后在允许访问该网关 TCP/UDP 出站流量的网络中测试。
+
+## 其他资源
+
+- [RustDesk 官网](https://rustdesk.com/)
+- [RustDesk Server Releases](https://github.com/rustdesk/rustdesk-server/releases)
+- [RustDesk 文档](https://rustdesk.com/docs/)
+- [Sealos 文档](https://sealos.io/docs)
+
+## 许可证
+
+此 Sealos 模板按仓库许可证提供。RustDesk Server 本身使用 AGPL-3.0 许可证。

--- a/template/rustdesk/index.yaml
+++ b/template/rustdesk/index.yaml
@@ -1,137 +1,175 @@
 apiVersion: app.sealos.io/v1
 kind: Template
 metadata:
-  name: rustdesk
+    name: rustdesk
 spec:
-  title: RustDesk
-  url: 'https://rustdesk.com/'
-  gitRepo: 'https://github.com/rustdesk/rustdesk'
-  author: 'L.King'
-  description: 'An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/logo.png'
-  screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/website-screenshot.webp'
-
-  templateType: inline
-  locale: zh
-  defaults:
-    app_host:
-      type: string
-      value: ${{ random(8) }}
-    app_name:
-      type: string
-      value: rustdesk-${{ random(8) }}
-  inputs:
-    ENCRYPTED_ONLY:
-      description: '1: Restricted to secure data transmission with public key only, 0: Allows for unsecure data transmission'
-      type: choice
-      options:
-        - 1
-        - 0
-      required: true
-
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/README_zh.md'
+    title: RustDesk
+    url: "https://rustdesk.com/"
+    gitRepo: "https://github.com/rustdesk/rustdesk-server"
+    author: "Sealos"
+    description: "An open-source remote desktop server for self-hosted RustDesk ID/rendezvous and relay services."
+    readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/README.md"
+    icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/logo.png"
+    screenshots:
+        - "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/website-screenshot.webp"
+    templateType: inline
+    locale: en
+    categories:
+        - tool
+    defaults:
+        app_host:
+            type: string
+            value: rustdesk-${{ random(8) }}
+        app_name:
+            type: string
+            value: rustdesk-${{ random(8) }}
+    inputs:
+        ENCRYPTED_ONLY:
+            description: "Use 1 to require encrypted connections with the server public key; use 0 to allow unencrypted connections."
+            type: choice
+            options:
+                - "1"
+                - "0"
+            default: "1"
+            required: true
+    i18n:
+        zh:
+            description: "用于自托管 RustDesk ID/会合服务和中继服务的开源远程桌面服务器。"
+            readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/README_zh.md"
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: ${{ defaults.app_name }}
-  annotations:
-    originImageName: rustdesk/rustdesk-server-s6:latest
-    deploy.cloud.sealos.io/minReplicas: '1'
-    deploy.cloud.sealos.io/maxReplicas: '1'
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    app: ${{ defaults.app_name }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 1
-  minReadySeconds: 10
-  serviceName: ${{ defaults.app_name }}
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}
-  template:
-    metadata:
-      labels:
+    name: ${{ defaults.app_name }}
+    annotations:
+        originImageName: rustdesk/rustdesk-server-s6:1.1.15
+        deploy.cloud.sealos.io/minReplicas: "1"
+        deploy.cloud.sealos.io/maxReplicas: "1"
+        docker-to-sealos.resource-override-source: "Live Sealos resource tuning on 2026-05-29 verified RustDesk server at requests cpu=1m,memory=5Mi and limits cpu=20m,memory=24Mi."
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
         app: ${{ defaults.app_name }}
-    spec:
-      terminationGracePeriodSeconds: 10
-      automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: rustdesk/rustdesk-server-s6:latest
-          env:
-            - name: RELAY
-              value: '${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}'
-            - name: ENCRYPTED_ONLY
-              value: '${{ inputs.ENCRYPTED_ONLY }}'
-          resources:
-            requests:
-              cpu: 20m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
-          ports:
-            - containerPort: 21115
-              protocol: TCP
-              name: 'heartbeat'
-            - containerPort: 21116
-              protocol: TCP
-              name: 'rendezvous-tcp'
-            - containerPort: 21116
-              protocol: UDP
-              name: 'rendezvous-udp'
-            - containerPort: 21117
-              protocol: TCP
-              name: 'relay'
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: vn-data
-              mountPath: /data
-      volumes: []
-  volumeClaimTemplates:
-    - metadata:
-        annotations:
-          path: /data
-          value: '1'
-        name: vn-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 256Mi
-
+spec:
+    replicas: 1
+    revisionHistoryLimit: 1
+    minReadySeconds: 10
+    serviceName: ${{ defaults.app_name }}
+    selector:
+        matchLabels:
+            app: ${{ defaults.app_name }}
+    template:
+        metadata:
+            labels:
+                app: ${{ defaults.app_name }}
+        spec:
+            terminationGracePeriodSeconds: 10
+            automountServiceAccountToken: false
+            containers:
+                - name: ${{ defaults.app_name }}
+                  image: rustdesk/rustdesk-server-s6:1.1.15
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: RELAY
+                        value: "${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}"
+                      - name: ENCRYPTED_ONLY
+                        value: "${{ inputs.ENCRYPTED_ONLY }}"
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 12Mi
+                      limits:
+                          cpu: 100m
+                          memory: 128Mi
+                  ports:
+                      - containerPort: 21115
+                        protocol: TCP
+                        name: heartbeat
+                      - containerPort: 21116
+                        protocol: TCP
+                        name: rendezvous-tcp
+                      - containerPort: 21116
+                        protocol: UDP
+                        name: rendezvous-udp
+                      - containerPort: 21117
+                        protocol: TCP
+                        name: relay
+                  startupProbe:
+                      exec:
+                          command:
+                              - /usr/bin/healthcheck.sh
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      failureThreshold: 30
+                      timeoutSeconds: 5
+                  readinessProbe:
+                      exec:
+                          command:
+                              - /usr/bin/healthcheck.sh
+                      periodSeconds: 10
+                      failureThreshold: 3
+                      timeoutSeconds: 5
+                  livenessProbe:
+                      exec:
+                          command:
+                              - /usr/bin/healthcheck.sh
+                      periodSeconds: 30
+                      failureThreshold: 3
+                      timeoutSeconds: 5
+                  volumeMounts:
+                      - name: vn-data
+                        mountPath: /data
+    volumeClaimTemplates:
+        - metadata:
+              annotations:
+                  path: /data
+                  value: "1"
+              name: vn-data
+          spec:
+              accessModes:
+                  - ReadWriteOnce
+              resources:
+                  requests:
+                      storage: 256Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}-nodeport
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+        app: ${{ defaults.app_name }}
 spec:
-  type: NodePort
-  ports:
-    - protocol: UDP
-      port: 21116
-      targetPort: 21116
-      name: 'rendezvous-udp'
-    - protocol: TCP
-      port: 21116
-      targetPort: 21116
-      name: 'rendezvous-tcp'
-    - protocol: TCP
-      port: 21117
-      targetPort: 21117
-      name: 'relay'
-    - protocol: TCP
-      port: 21115
-      targetPort: 21115
-      name: 'heartbeat'
-  selector:
-    app: ${{ defaults.app_name }}
+    type: NodePort
+    ports:
+        - protocol: UDP
+          port: 21116
+          targetPort: 21116
+          name: rendezvous-udp
+        - protocol: TCP
+          port: 21116
+          targetPort: 21116
+          name: rendezvous-tcp
+        - protocol: TCP
+          port: 21117
+          targetPort: 21117
+          name: relay
+        - protocol: TCP
+          port: 21115
+          targetPort: 21115
+          name: heartbeat
+    selector:
+        app: ${{ defaults.app_name }}
+---
+apiVersion: app.sealos.io/v1
+kind: App
+metadata:
+    name: ${{ defaults.app_name }}
+    labels:
+        cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+    data:
+        url: tcp.${{ SEALOS_CLOUD_DOMAIN }}
+    displayType: normal
+    icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/rustdesk/logo.png"
+    name: RustDesk
+    type: link


### PR DESCRIPTION
## Summary
- Pin RustDesk Server S6 to 1.1.15 and add App metadata plus health probes.
- Tune the runtime resource profile from live Sealos validation.
- Rewrite English and Chinese README files with RustDesk client connection guidance.

## Validation
- `DOCKER_TO_SEALOS_ARTIFACTS=/Users/longnv/.codex/worktrees/1c9c/templates/template/rustdesk/index.yaml python3 /Users/longnv/.codex/worktrees/1c9c/templates/.agents/skills/docker-to-sealos/scripts/quality_gate.py`
- `git diff --check`
- Live deployed `rustdesk-tkxtpqcr` on Sealos and verified Pod Ready, `healthcheck.sh`, and TCP gateway connectivity.
- Cleaned live test resources including Instance, App, StatefulSet, Service, PVC, and Pod.
