### PR TITLE
fix(postiz): update Sealos template and docs

### DIFF
--- a/template/postiz/README.md
+++ b/template/postiz/README.md
@@ -1,34 +1,166 @@
-# Postiz
+# Deploy and Host Postiz on Sealos
 
-## Overview
+Postiz is an open source social media scheduling and management platform for planning, publishing, and tracking social posts. This template deploys Postiz with PostgreSQL, Redis, Temporal, Elasticsearch, and persistent storage on Sealos Cloud.
 
-Postiz is an open source social media management platform.
+![Postiz Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/website-screenshot.webp)
 
-This Sealos template deploys **Postiz** as the `postiz` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Postiz
 
-## Deploy on Sealos
+Postiz provides a self-hosted workspace for social media teams to schedule posts, manage channels, and coordinate publishing workflows. The Sealos template runs Postiz `v2.21.8` with the bundled frontend, backend API, orchestrator, and Nginx gateway in the main application container.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The deployment also provisions PostgreSQL for application and Temporal metadata, Redis for queue and cache services, Temporal for workflow execution, Elasticsearch for Temporal visibility, and persistent volumes for uploads and runtime configuration. Sealos creates the public HTTPS endpoint, service discovery, database resources, and storage resources automatically.
 
-## Access
+This template is configured for the simplest first-run setup: local email-and-password registration is enabled by default. OAuth providers, Resend, email verification, and password reset email delivery are not required for creating the first account.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Social media scheduling**: Plan and publish posts across connected social channels from one self-hosted dashboard.
+- **Team content operations**: Coordinate content calendars, drafts, and publishing workflows in a private workspace.
+- **Agency publishing workflows**: Manage multiple client social accounts while keeping data in your own Sealos workspace.
+- **Self-hosted social tooling**: Run Postiz without depending on a hosted SaaS account or external identity provider for first login.
+
+## Dependencies for Postiz Hosting
+
+The Sealos template includes all required runtime dependencies: the Postiz application image, PostgreSQL 16.4, Redis 7.2, Temporal 1.28, Elasticsearch 7.17, persistent upload storage, and persistent configuration storage.
+
+### Deployment Dependencies
+
+- [Postiz Website](https://postiz.com/) - Product website and overview
+- [Postiz Documentation](https://docs.postiz.com/introduction) - Official documentation and setup guides
+- [Postiz Source Repository](https://github.com/gitroomhq/postiz-app) - Source code and issue tracker
+- [Sealos Documentation](https://sealos.io/docs) - Sealos Cloud documentation
+
+## Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Postiz application**: Runs `ghcr.io/gitroomhq/postiz-app:v2.21.8` and serves the web UI, API, Nginx gateway, and orchestrator through port `5000`.
+- **PostgreSQL 16.4**: Stores Postiz application data and the Temporal metadata databases. A setup job creates the `postiz` database before the app starts.
+- **Redis 7.2**: Provides cache and queue backing services for Postiz.
+- **Temporal 1.28**: Runs workflow processing required by Postiz background jobs.
+- **Temporal Elasticsearch 7.17**: Stores Temporal visibility data with a 256 MiB heap.
+- **Persistent volumes**: Store uploads at `/uploads` and application configuration at `/config`.
+
+**Configuration:**
+
+The template automatically generates the app name, public hostname, and JWT secret. The app uses local storage by default and sets `DISABLE_REGISTRATION=false`, so the first user can register with an email address and password immediately after deployment.
+
+Default service-to-service connections are configured through Kubernetes DNS and Sealos-provisioned database credentials. PostgreSQL connection limits are set conservatively so Postiz and Temporal can share the default database baseline.
+
+**Resource Profile:**
+
+| Component | CPU limit | Memory limit | Notes |
+| --- | ---: | ---: | --- |
+| Postiz app | `500m` | `4096Mi` | Covers Nginx, frontend, backend, and orchestrator in one container; 4 GiB is required for cold-start workflow bundle generation. |
+| PostgreSQL | `500m` | `512Mi` | Uses the Sealos PostgreSQL database baseline. |
+| Redis | `500m` | `512Mi` | Uses the Sealos Redis and Sentinel database baseline. |
+| Temporal | `500m` | `512Mi` | Runs the Temporal service and default namespace setup. |
+| Temporal Elasticsearch | `500m` | `1024Mi` | Runs Elasticsearch with a 256 MiB heap for Temporal visibility. |
+
+**License Information:**
+
+This Sealos template is provided as part of the Sealos templates repository. Postiz itself is licensed under the GNU Affero General Public License v3.0.
+
+## Why Deploy Postiz on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. It is well suited for running modern SaaS tools, workflow systems, and multi-service applications. By deploying Postiz on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Postiz, PostgreSQL, Redis, Temporal, Elasticsearch, ingress, and storage from one template.
+- **Kubernetes Without Operational Overhead**: Use Kubernetes-backed workloads, service discovery, persistent storage, and health checks without writing YAML by hand.
+- **Instant Public Access**: Sealos provisions a public HTTPS URL for the Postiz web interface.
+- **Easy Customization**: Adjust environment variables, resources, and storage through the Canvas, AI dialog, or resource cards.
+- **Persistent Storage Included**: Uploaded media and application configuration survive restarts and redeployments.
+- **Pay-As-You-Go Resources**: Tune CPU, memory, and storage to match your actual workload.
+- **Operational Visibility**: Inspect logs, workload status, and resource usage from the Sealos dashboard.
+
+Deploy Postiz on Sealos and focus on social publishing workflows instead of managing the underlying infrastructure.
+
+## Deployment Guide
+
+1. Open the [Postiz template](https://sealos.io/products/app-store/postiz) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog. For the simplest setup, keep the default values.
+3. Wait for deployment to complete. It typically takes 2-3 minutes, but the first startup can take longer because PostgreSQL, Redis, Temporal, Elasticsearch, and Postiz all need to initialize. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog to let Sealos apply updates, or click the relevant resource cards to modify settings.
+4. Access Postiz through the generated public URL and create the first local account.
+
+## First Login and Registration
+
+Postiz is a web application that requires a user account. This template enables local registration by default, so the first account can be created with only an email address and password.
+
+1. Open the generated Postiz URL after deployment.
+2. A new deployment opens the local sign-up page at `/auth`. If you land on the login page instead, open `/auth` manually or use the sign-up option in the UI.
+3. Ignore OAuth buttons for the first account and use the local registration form below the separator.
+4. Enter an email address, a password, and the workspace or company name, then click **Create Account**.
+5. The account is activated immediately because the default template does not configure an email provider or email verification.
+6. If Postiz asks you to sign in after registration, open `/auth/login` and use the same email address and password.
+
+Use an email address as the username. A direct login attempt returns `Invalid user name or password` until that email has been registered in the current deployment. The registration page is `/auth`; `/auth/register` is not a Postiz route. GitHub OAuth, Google OAuth, X/Twitter API credentials, Resend, and email verification are optional later integrations, not requirements for the first login.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Postiz through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `GITHUB_CLIENT_ID` | GitHub OAuth Client ID (optional) | `false` | `` |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth Client Secret (optional) | `false` | `<redacted>` |
-| `RESEND_API_KEY` | Resend email service API key (optional) | `false` | `<redacted>` |
-| `X_API_KEY` | X/Twitter API key (optional) | `false` | `<redacted>` |
-| `X_API_SECRET` | X/Twitter API secret (optional) | `false` | `<redacted>` |
+- **AI Dialog**: Describe the changes you want and let Sealos apply updates.
+- **Resource Cards**: Click the StatefulSet, Deployment, database, cache, ingress, or storage cards to modify settings.
+- **Postiz UI**: Connect social channels and configure publishing integrations from inside Postiz.
+- **Environment Variables**: Add OAuth, email, or social provider credentials only when you are ready to enable those integrations.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+Important default environment settings:
 
-## Official Links
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `DISABLE_REGISTRATION` | `false` | Allows local user registration. |
+| `IS_GENERAL` | `true` | Enables the general self-hosted Postiz experience. |
+| `STORAGE_PROVIDER` | `local` | Stores uploads on the mounted `/uploads` volume. |
+| `TEMPORAL_NAMESPACE` | `default` | Uses the default Temporal namespace created during deployment. |
 
-- Official website: https://postiz.com/
-- Source repository: https://github.com/gitroomhq/postiz-app
+## Scaling
+
+To scale or tune Postiz:
+
+1. Open the Canvas for your deployment.
+2. Click the relevant resource card, such as the Postiz StatefulSet, Temporal Deployment, PostgreSQL cluster, Redis cluster, or Elasticsearch StatefulSet.
+3. Adjust CPU, memory, storage, or replica settings according to your workload.
+4. Apply the changes in the dialog and monitor workload readiness from the Sealos dashboard.
+
+For small self-hosted workspaces, keep the default single-replica topology. Increase resources before connecting many channels, processing large media uploads, or running high-volume publishing workflows.
+
+## Troubleshooting
+
+### The page is not ready immediately after deployment
+
+Wait for all components to become Running. Temporal and Elasticsearch may take longer than the main web container during cold start.
+
+### Login says `Invalid user name or password`
+
+Create the account first on `/auth`. Direct login only works after the email address exists in the current Postiz deployment.
+
+### Registration asks for email activation
+
+Check whether an email provider or verification setting was added after deployment. With the default template configuration, local users are activated immediately.
+
+### Social posting fails
+
+Confirm that the relevant social provider credentials are configured and that the channel has been connected from the Postiz UI.
+
+### Uploads fail
+
+Check the `/uploads` persistent volume and available storage capacity.
+
+### Getting Help
+
+- [Postiz Documentation](https://docs.postiz.com/introduction)
+- [Postiz GitHub Issues](https://github.com/gitroomhq/postiz-app/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Postiz Website](https://postiz.com/)
+- [Postiz Source Repository](https://github.com/gitroomhq/postiz-app)
+- [Sealos App Store](https://sealos.io/products/app-store)
+- [Sealos Documentation](https://sealos.io/docs)
+
+## License
+
+This Sealos template is provided as part of the Sealos templates repository. Postiz itself is licensed under the [GNU Affero General Public License v3.0](https://github.com/gitroomhq/postiz-app/blob/main/LICENSE).

--- a/template/postiz/README_zh.md
+++ b/template/postiz/README_zh.md
@@ -1,34 +1,166 @@
-# Postiz
+# 在 Sealos 上部署和托管 Postiz
 
-## 应用概览
+Postiz 是一款开源社交媒体排程与管理平台，用于规划、发布和跟踪社交媒体内容。此模板会在 Sealos Cloud 上部署 Postiz，并配套 PostgreSQL、Redis、Temporal、Elasticsearch 和持久化存储。
 
-部署包含 PostgreSQL 与 Redis 的 Postiz 自托管版本。
+![Postiz 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/website-screenshot.webp)
 
-此 Sealos 模板会将 **Postiz** 部署为 `postiz` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于 Postiz 托管
 
-## 在 Sealos 上部署
+Postiz 为社交媒体团队提供自托管工作区，可用于排程内容、管理渠道并协同发布流程。此 Sealos 模板运行 Postiz `v2.21.8`，主应用容器内包含前端、后端 API、orchestrator 和 Nginx 网关。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+部署时还会创建 PostgreSQL、Redis、Temporal、Elasticsearch 以及持久化卷。PostgreSQL 用于保存 Postiz 应用数据和 Temporal 元数据；Redis 提供缓存和队列能力；Temporal 负责后台工作流；Elasticsearch 存储 Temporal visibility 数据；持久化卷用于保存上传文件和运行配置。Sealos 会自动创建公网 HTTPS 入口、服务发现、数据库资源和存储资源。
 
-## 访问方式
+此模板默认采用最简单的首次使用方式：启用本地邮箱和密码注册。创建首个账号不需要 OAuth、Resend、邮件验证码或密码重置邮件服务。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
+
+- **社交媒体排程**：在一个自托管仪表盘中规划并发布多个社交渠道的内容。
+- **团队内容运营**：在私有工作区中协同管理内容日历、草稿和发布流程。
+- **代理机构发布流程**：为多个客户管理社交账号，同时将数据保存在自己的 Sealos 工作区。
+- **自托管社交工具**：首次登录不依赖托管版 SaaS 账号或外部身份提供商。
+
+## Postiz 托管依赖
+
+此 Sealos 模板包含运行 Postiz 所需的依赖：Postiz 应用镜像、PostgreSQL 16.4、Redis 7.2、Temporal 1.28、Elasticsearch 7.17、上传文件持久化存储和配置持久化存储。
+
+### 部署依赖
+
+- [Postiz 官网](https://postiz.com/) - 产品介绍与概览
+- [Postiz 文档](https://docs.postiz.com/introduction) - 官方文档与配置指南
+- [Postiz 源码仓库](https://github.com/gitroomhq/postiz-app) - 源码与问题跟踪
+- [Sealos 文档](https://sealos.io/docs) - Sealos Cloud 文档
+
+## 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Postiz 应用**：运行 `ghcr.io/gitroomhq/postiz-app:v2.21.8`，通过 `5000` 端口提供 Web UI、API、Nginx 网关和 orchestrator。
+- **PostgreSQL 16.4**：存储 Postiz 应用数据和 Temporal 元数据。初始化 Job 会在应用启动前创建 `postiz` 数据库。
+- **Redis 7.2**：为 Postiz 提供缓存和队列支撑。
+- **Temporal 1.28**：运行 Postiz 后台任务所需的工作流处理能力。
+- **Temporal Elasticsearch 7.17**：以 256 MiB heap 存储 Temporal visibility 数据。
+- **持久化卷**：将上传文件保存到 `/uploads`，将应用配置保存到 `/config`。
+
+**配置：**
+
+模板会自动生成应用名称、公网域名和 JWT 密钥。应用默认使用本地存储，并设置 `DISABLE_REGISTRATION=false`，因此首个用户可以在部署完成后直接用邮箱和密码注册。
+
+服务之间通过 Kubernetes DNS 和 Sealos 自动生成的数据库凭据连接。PostgreSQL 连接数采用保守配置，确保 Postiz 与 Temporal 可以共享默认数据库资源基线。
+
+**资源配置：**
+
+| 组件 | CPU 限制 | 内存限制 | 说明 |
+| --- | ---: | ---: | --- |
+| Postiz 应用 | `500m` | `4096Mi` | 一个容器内包含 Nginx、前端、后端和 orchestrator；冷启动生成工作流 bundle 需要 4 GiB 内存。 |
+| PostgreSQL | `500m` | `512Mi` | 使用 Sealos PostgreSQL 数据库基线。 |
+| Redis | `500m` | `512Mi` | 使用 Sealos Redis 与 Sentinel 数据库基线。 |
+| Temporal | `500m` | `512Mi` | 运行 Temporal 服务和默认 namespace 初始化。 |
+| Temporal Elasticsearch | `500m` | `1024Mi` | 以 256 MiB heap 运行 Elasticsearch，供 Temporal visibility 使用。 |
+
+**许可证信息：**
+
+此 Sealos 模板作为 Sealos templates 仓库的一部分提供。Postiz 本身采用 GNU Affero General Public License v3.0 许可证。
+
+## 为什么在 Sealos 上部署 Postiz？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，覆盖从云端 IDE 开发到生产部署和运维管理的完整应用生命周期。它适合运行现代 SaaS 工具、工作流系统和多服务应用。在 Sealos 上部署 Postiz，你可以获得：
+
+- **一键部署**：通过一个模板部署 Postiz、PostgreSQL、Redis、Temporal、Elasticsearch、访问入口和存储。
+- **无需运维 Kubernetes**：直接使用 Kubernetes 支撑的工作负载、服务发现、持久化存储和健康检查，无需手写 YAML。
+- **即时公网访问**：Sealos 会为 Postiz Web 界面生成公网 HTTPS 地址。
+- **易于调整配置**：可通过 Canvas、AI 对话或资源卡片调整环境变量、资源和存储。
+- **内置持久化存储**：上传媒体和应用配置会在重启或重新部署后保留。
+- **按量使用资源**：根据实际负载调整 CPU、内存和存储。
+- **运维可观测**：可在 Sealos 控制台查看日志、工作负载状态和资源使用情况。
+
+在 Sealos 上部署 Postiz，可以把精力放在社交内容发布流程上，而不是底层基础设施管理。
+
+## 部署指南
+
+1. 打开 [Postiz 模板](https://sealos.io/products/app-store/postiz)，点击 **Deploy Now**。
+2. 在弹窗中配置参数。最简单的部署方式是保持默认值。
+3. 等待部署完成。通常需要 2-3 分钟，但首次启动可能更久，因为 PostgreSQL、Redis、Temporal、Elasticsearch 和 Postiz 都需要初始化。部署开始或完成后会进入 Canvas。后续如果要调整配置，可在 AI 对话中描述需求让 Sealos 应用变更，也可以点击相关资源卡片手动修改。
+4. 通过生成的公网地址访问 Postiz，并创建第一个本地账号。
+
+## 首次登录与注册
+
+Postiz 是 Web 应用，使用前需要用户账号。此模板默认启用本地注册，因此首个账号只需要邮箱和密码即可创建。
+
+1. 部署完成后打开生成的 Postiz 地址。
+2. 全新部署会打开本地注册页面 `/auth`。如果进入的是登录页，请手动打开 `/auth`，或使用界面中的注册入口。
+3. 首个账号不需要 OAuth。即使页面显示 OAuth 按钮，也请使用分隔线下方的本地注册表单。
+4. 输入邮箱、密码和工作区或公司名称，然后点击 **Create Account**。
+5. 默认模板没有配置邮件服务或邮件验证，因此账号会立即激活。
+6. 如果注册后页面要求登录，请打开 `/auth/login`，使用同一个邮箱和密码登录。
+
+用户名请使用邮箱地址。该邮箱在当前部署中尚未注册前，直接登录会返回 `Invalid user name or password`。注册页面是 `/auth`，`/auth/register` 不是 Postiz 路由。GitHub OAuth、Google OAuth、X/Twitter API 凭据、Resend 和邮件验证码都是后续可选集成，不是首次登录的前置条件。
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+部署后可以通过以下方式配置 Postiz：
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `GITHUB_CLIENT_ID` | `GITHUB_CLIENT_ID` 部署参数。 | `否` | `` |
-| `GITHUB_CLIENT_SECRET` | `GITHUB_CLIENT_SECRET` 部署参数。 | `否` | `<已隐藏>` |
-| `RESEND_API_KEY` | `RESEND_API_KEY` 部署参数。 | `否` | `<已隐藏>` |
-| `X_API_KEY` | `X_API_KEY` 部署参数。 | `否` | `<已隐藏>` |
-| `X_API_SECRET` | `X_API_SECRET` 部署参数。 | `否` | `<已隐藏>` |
+- **AI 对话**：描述你希望修改的内容，让 Sealos 应用变更。
+- **资源卡片**：点击 StatefulSet、Deployment、数据库、缓存、Ingress 或存储等资源卡片修改设置。
+- **Postiz UI**：在 Postiz 内连接社交渠道并配置发布集成。
+- **环境变量**：只有在准备启用 OAuth、邮件或社交平台集成时，才需要添加对应凭据。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+关键默认环境变量：
 
-## 官方链接
+| 配置 | 默认值 | 作用 |
+| --- | --- | --- |
+| `DISABLE_REGISTRATION` | `false` | 允许本地用户注册。 |
+| `IS_GENERAL` | `true` | 启用通用自托管 Postiz 使用体验。 |
+| `STORAGE_PROVIDER` | `local` | 将上传文件保存到 `/uploads` 持久化卷。 |
+| `TEMPORAL_NAMESPACE` | `default` | 使用部署时创建的默认 Temporal namespace。 |
 
-- 官方网站: https://postiz.com/
-- 源码仓库: https://github.com/gitroomhq/postiz-app
+## 扩容与资源调整
+
+如需扩容或调优 Postiz：
+
+1. 打开当前部署的 Canvas。
+2. 点击相关资源卡片，例如 Postiz StatefulSet、Temporal Deployment、PostgreSQL 集群、Redis 集群或 Elasticsearch StatefulSet。
+3. 根据负载调整 CPU、内存、存储或副本设置。
+4. 在对话中应用变更，并从 Sealos 控制台观察工作负载就绪状态。
+
+小型自托管工作区建议保留默认单副本拓扑。连接大量渠道、处理大体积媒体上传或运行高频发布流程前，建议先增加资源。
+
+## 故障排查
+
+### 部署后页面没有立即就绪
+
+等待所有组件进入 Running 状态。冷启动时，Temporal 和 Elasticsearch 可能比主 Web 容器更慢。
+
+### 登录提示 `Invalid user name or password`
+
+请先在 `/auth` 创建账号。只有该邮箱已经存在于当前 Postiz 部署中，才能直接登录。
+
+### 注册时要求邮件激活
+
+检查部署后是否额外添加了邮件服务或验证配置。使用默认模板时，本地用户会立即激活。
+
+### 社交平台发布失败
+
+确认已配置对应社交平台凭据，并已在 Postiz UI 中完成渠道连接。
+
+### 上传失败
+
+检查 `/uploads` 持久化卷和可用存储容量。
+
+### 获取帮助
+
+- [Postiz 文档](https://docs.postiz.com/introduction)
+- [Postiz GitHub Issues](https://github.com/gitroomhq/postiz-app/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Postiz 官网](https://postiz.com/)
+- [Postiz 源码仓库](https://github.com/gitroomhq/postiz-app)
+- [Sealos 应用商店](https://sealos.io/products/app-store)
+- [Sealos 文档](https://sealos.io/docs)
+
+## 许可证
+
+此 Sealos 模板作为 Sealos templates 仓库的一部分提供。Postiz 本身采用 [GNU Affero General Public License v3.0](https://github.com/gitroomhq/postiz-app/blob/main/LICENSE) 许可证。

--- a/template/postiz/index.yaml
+++ b/template/postiz/index.yaml
@@ -7,140 +7,61 @@ spec:
   url: "https://postiz.com/"
   gitRepo: "https://github.com/gitroomhq/postiz-app"
   author: "Sealos"
-  description: "Postiz is an open source social media management platform."
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/logo.svg'
+  description: "Postiz is an open source social media scheduling and management platform."
+  readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/README.md"
+  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/logo.svg"
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/website-screenshot.webp'
+    - "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/website-screenshot.webp"
   templateType: inline
   categories:
-    - backend
     - tool
+    - backend
   locale: en
   i18n:
     zh:
-      title: "Postiz"
-      description: "部署包含 PostgreSQL 与 Redis 的 Postiz 自托管版本。"
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/README_zh.md'
+      description: "开源社交媒体排程与管理平台，支持本地账号注册、PostgreSQL、Redis 和 Temporal 工作流。"
+      readme: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/README_zh.md"
   defaults:
     app_name:
       type: string
       value: postiz-${{ random(8) }}
     app_host:
       type: string
-      value: ${{ random(8) }}
-    JWT_SECRET:
+      value: postiz-${{ random(8) }}
+    jwt_secret:
       type: string
-      value: ${{ random(8) }}
-  inputs:
-    GITHUB_CLIENT_ID:
-      description: "GitHub OAuth Client ID (optional)"
-      type: string
-      default: ""
-      required: false
-    GITHUB_CLIENT_SECRET:
-      description: "GitHub OAuth Client Secret (optional)"
-      type: string
-      default: ""
-      required: false
-    RESEND_API_KEY:
-      description: "Resend email service API key (optional)"
-      type: string
-      default: ""
-      required: false
-    X_API_KEY:
-      description: "X/Twitter API key (optional)"
-      type: string
-      default: ""
-      required: false
-    X_API_SECRET:
-      description: "X/Twitter API secret (optional)"
-      type: string
-      default: ""
-      required: false
+      value: ${{ random(64) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: Cluster
-metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
-spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 rules:
-  - apiGroups:
-      - "*"
-    resources:
-      - "*"
-    verbs:
-      - "*"
-
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -148,115 +69,33 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-pg
-
----
-# Init DB: create database "postiz"
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-pg-init
-spec:
-  ttlSecondsAfterFinished: 300
-  backoffLimit: 0
-  completions: 1
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: pgsql-init
-          image: postgres:14-alpine
-          env:
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE postiz;' &>/dev/null; do echo waiting for postgres; sleep 1; done
----
-# Redis (via KubeBlocks)
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ${{ defaults.app_name }}-redis
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
-rules:
-  - apiGroups:
-      - "*"
-    resources:
-      - "*"
-    verbs:
-      - "*"
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-redis
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-redis
-subjects:
-  - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-redis
-
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
+  name: ${{ defaults.app_name }}-pg
   finalizers:
     - cluster.kubeblocks.io/finalizer
-  name: ${{ defaults.app_name }}-redis
   labels:
-    clusterdefinition.kubeblocks.io/name: redis
-    kb.io/database: redis-7.2.7
-    app.kubernetes.io/instance: ${{ defaults.app_name }}
-    app.kubernetes.io/version: 7.2.7
-    helm.sh/chart: redis-cluster-0.9.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
 spec:
-  clusterDefinitionRef: redis
   affinity:
     podAntiAffinity: Preferred
-    topologyKeys:
-      - kubernetes.io/hostname
-  tolerations:
-    - key: kb-data
-      operator: Equal
-      value: "true"
-      effect: NoSchedule
+    tenancy: SharedNode
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
-    - name: redis
-      componentDef: redis-7
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
       enabledLogs:
         - running
-      env:
-        - name: CUSTOM_SENTINEL_MASTER_NAME
-      serviceVersion: 7.2.7
-      serviceAccountName: ${{ defaults.app_name }}-redis
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
       resources:
         limits:
           cpu: 500m
@@ -272,17 +111,164 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-    - componentDef: redis-sentinel-7
-      name: redis-sentinel
+            storageClassName: openebs-backup
+  terminationPolicy: Delete
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-pg-init
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: pgsql-init
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PG_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: endpoint
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              export PGPASSWORD="${PG_PASSWORD}"
+              PG_HOST="${PG_ENDPOINT%:*}"
+              PG_PORT="${PG_ENDPOINT##*:}"
+              until pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U postgres; do
+                echo "waiting for PostgreSQL readiness"
+                sleep 2
+              done
+              for i in $(seq 1 120); do
+                if psql -h "${PG_HOST}" -p "${PG_PORT}" -U postgres -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='postiz'" | grep -q 1; then
+                  exit 0
+                fi
+                if psql -h "${PG_HOST}" -p "${PG_PORT}" -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"postiz\";" >/dev/null 2>&1; then
+                  exit 0
+                fi
+                echo "waiting for PostgreSQL to create postiz"
+                sleep 2
+              done
+              echo "failed to create database postiz" >&2
+              exit 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${{ defaults.app_name }}-redis
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/managed-by: kbcli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${{ defaults.app_name }}-redis
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/managed-by: kbcli
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${{ defaults.app_name }}-redis
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/managed-by: kbcli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ defaults.app_name }}-redis
+subjects:
+  - kind: ServiceAccount
+    name: ${{ defaults.app_name }}-redis
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${{ defaults.app_name }}-redis
+  finalizers:
+    - cluster.kubeblocks.io/finalizer
+  labels:
+    kb.io/database: redis-7.2.7
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-redis
+    app.kubernetes.io/version: 7.2.7
+    clusterversion.kubeblocks.io/name: redis-7.2.7
+    clusterdefinition.kubeblocks.io/name: redis
+    sealos-db-provider-cr: ${{ defaults.app_name }}-redis
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+    topologyKeys:
+      - kubernetes.io/hostname
+  clusterDefinitionRef: redis
+  componentSpecs:
+    - name: redis
+      componentDef: redis-7
+      enabledLogs:
+        - running
+      env:
+        - name: CUSTOM_SENTINEL_MASTER_NAME
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-redis
+      serviceVersion: 7.2.7
+      switchPolicy:
+        type: Noop
       resources:
         limits:
-          cpu: 100m
-          memory: 100Mi
+          cpu: 500m
+          memory: 512Mi
         requests:
-          cpu: 10m
-          memory: 10Mi
+          cpu: 50m
+          memory: 51Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
+    - name: redis-sentinel
+      componentDef: redis-sentinel-7
+      replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-redis
       serviceVersion: 7.2.7
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 51Mi
       volumeClaimTemplates:
         - name: data
           spec:
@@ -294,18 +280,239 @@ spec:
   terminationPolicy: Delete
   topology: replication
 ---
-# Application
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-temporal
+  labels:
+    app: ${{ defaults.app_name }}-temporal
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal
+data:
+  vn-etcvn-temporalvn-configvn-dynamicconfigvn-developme-4da89dc5: |
+    limit.maxIDLength:
+      - value: 255
+        constraints: {}
+    system.forceSearchAttributesCacheRefreshOnRead:
+      - value: true
+        constraints: {}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${{ defaults.app_name }}-temporal-es
+  annotations:
+    docker-to-sealos.resource-override-source: 'Empirical Sealos deployment test for Postiz v2.21.8: Elasticsearch 7.17.27 with 256Mi heap requires a 1024Mi memory limit to stay Ready; 512Mi caused unsafe headroom for Temporal visibility storage.'
+    originImageName: elasticsearch:7.17.27
+    deploy.cloud.sealos.io/minReplicas: "1"
+    deploy.cloud.sealos.io/maxReplicas: "1"
+  labels:
+    app: ${{ defaults.app_name }}-temporal-es
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal-es
+spec:
+  revisionHistoryLimit: 1
+  serviceName: ${{ defaults.app_name }}-temporal-es
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-temporal-es
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-temporal-es
+    spec:
+      automountServiceAccountToken: false
+      initContainers:
+        - name: take-data-dir-ownership
+          image: busybox:1.36.1
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "chown -R 1000:0 /usr/share/elasticsearch/data"]
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+          volumeMounts:
+            - name: vn-usrvn-sharevn-elasticsearchvn-data
+              mountPath: /usr/share/elasticsearch/data
+      containers:
+        - name: ${{ defaults.app_name }}-temporal-es
+          image: elasticsearch:7.17.27
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: ES_JAVA_OPTS
+              value: -Xms256m -Xmx256m
+            - name: xpack.security.enabled
+              value: "false"
+          ports:
+            - name: http
+              containerPort: 9200
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 50m
+              memory: 102Mi
+          volumeMounts:
+            - name: vn-usrvn-sharevn-elasticsearchvn-data
+              mountPath: /usr/share/elasticsearch/data
+  volumeClaimTemplates:
+    - metadata:
+        annotations:
+          path: /usr/share/elasticsearch/data
+          value: "1"
+        name: vn-usrvn-sharevn-elasticsearchvn-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: openebs-backup
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-temporal
+  annotations:
+    docker-to-sealos.resource-override-source: 'Empirical Sealos deployment test for Postiz v2.21.8: Temporal 1.28.1 stayed Ready with 500m CPU / 512Mi memory while serving Postiz workflows; SQL connection caps are required so Postiz can start against the 56-connection PostgreSQL baseline.'
+    originImageName: temporalio/auto-setup:1.28.1
+    deploy.cloud.sealos.io/minReplicas: "1"
+    deploy.cloud.sealos.io/maxReplicas: "1"
+  labels:
+    app: ${{ defaults.app_name }}-temporal
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-temporal
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-temporal
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: ${{ defaults.app_name }}-temporal
+          image: temporalio/auto-setup:1.28.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB
+              value: postgres12
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: POSTGRES_SEEDS
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: POSTGRES_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: DBNAME
+              value: temporal
+            - name: VISIBILITY_DBNAME
+              value: temporal_visibility
+            - name: DYNAMIC_CONFIG_FILE_PATH
+              value: config/dynamicconfig/development-sql.yaml
+            - name: ENABLE_ES
+              value: "true"
+            - name: ES_SEEDS
+              value: ${{ defaults.app_name }}-temporal-es
+            - name: ES_VERSION
+              value: v7
+            - name: TEMPORAL_NAMESPACE
+              value: default
+            - name: NUM_HISTORY_SHARDS
+              value: "1"
+            - name: SQL_MAX_CONNS
+              value: "10"
+            - name: SQL_MAX_IDLE_CONNS
+              value: "5"
+            - name: SQL_VIS_MAX_CONNS
+              value: "5"
+          ports:
+            - name: grpc
+              containerPort: 7233
+          startupProbe:
+            tcpSocket:
+              port: grpc
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 51Mi
+          volumeMounts:
+            - name: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developme-4da89dc5
+              mountPath: /etc/temporal/config/dynamicconfig/development-sql.yaml
+              subPath: development-sql.yaml
+      volumes:
+        - name: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developme-4da89dc5
+          configMap:
+            name: ${{ defaults.app_name }}-temporal
+            defaultMode: 420
+            items:
+              - key: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developme-4da89dc5
+                path: development-sql.yaml
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/gitroomhq/postiz-app:v2.5.3
+    docker-to-sealos.resource-override-source: 'Empirical Sealos deployment test for Postiz v2.21.8: combined nginx, frontend, backend and orchestrator workload used about 718Mi at idle; 4Gi memory is required for cold start stability after live Sealos redeploy testing; 2G OOMKilled during Postiz workflow bundle generation, and bare G quantities can be misreported by the Sealos Template API quota preview.'
+    originImageName: ghcr.io/gitroomhq/postiz-app:v2.21.8
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   revisionHistoryLimit: 1
   replicas: 1
@@ -319,12 +526,11 @@ spec:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: ghcr.io/gitroomhq/postiz-app:v2.5.3
+      initContainers:
+        - name: wait-for-dependencies
+          image: busybox:1.36.1
           imagePullPolicy: IfNotPresent
           env:
-            # PostgreSQL (KubeBlocks secret: <app>-pg-conn-credential)
             - name: DB_HOSTNAME
               valueFrom:
                 secretKeyRef:
@@ -335,6 +541,60 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: port
+            - name: REDIS_HOSTNAME
+              value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
+            - name: REDIS_PORT
+              value: "6379"
+            - name: TEMPORAL_HOST
+              value: ${{ defaults.app_name }}-temporal.${{ SEALOS_NAMESPACE }}.svc
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              wait_for_tcp() {
+                name="$1"
+                host="$2"
+                port="$3"
+                for i in $(seq 1 240); do
+                  if nc -z "$host" "$port" >/dev/null 2>&1; then
+                    echo "$name is ready"
+                    return 0
+                  fi
+                  echo "waiting for $name at $host:$port"
+                  sleep 2
+                done
+                echo "$name did not become ready" >&2
+                return 1
+              }
+              wait_for_tcp PostgreSQL "$DB_HOSTNAME" "$DB_PORT"
+              wait_for_tcp Redis "$REDIS_HOSTNAME" "$REDIS_PORT"
+              wait_for_tcp Temporal "$TEMPORAL_HOST" 7233
+              sleep 20
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: ghcr.io/gitroomhq/postiz-app:v2.21.8
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: POSTIZ_POOLER_SERVICE_PORT
+              value: "6432"
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -346,12 +606,13 @@ spec:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
             - name: DATABASE_URL
-              value: postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOSTNAME):$(DB_PORT)/postiz
-            # Redis (KubeBlocks secret: <app>-redis-redis-account-default)
+              value: postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOSTNAME):$(DB_PORT)/postiz?connection_limit=10&pool_timeout=30
+            - name: PORT
+              value: "3000"
             - name: REDIS_HOSTNAME
               value: ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc
             - name: REDIS_PORT
-              value: '6379'
+              value: "6379"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -359,19 +620,12 @@ spec:
                   key: password
             - name: REDIS_URL
               value: redis://:$(REDIS_PASSWORD)@$(REDIS_HOSTNAME):$(REDIS_PORT)/0
-            # App settings
+            - name: TEMPORAL_ADDRESS
+              value: ${{ defaults.app_name }}-temporal.${{ SEALOS_NAMESPACE }}.svc:7233
+            - name: TEMPORAL_NAMESPACE
+              value: default
             - name: JWT_SECRET
-              value: ${{ defaults.JWT_SECRET }}
-            - name: GITHUB_CLIENT_ID
-              value: ${{ inputs.GITHUB_CLIENT_ID }}
-            - name: GITHUB_CLIENT_SECRET
-              value: ${{ inputs.GITHUB_CLIENT_SECRET }}
-            - name: RESEND_API_KEY
-              value: ${{ inputs.RESEND_API_KEY }}
-            - name: X_API_KEY
-              value: ${{ inputs.X_API_KEY }}
-            - name: X_API_SECRET
-              value: ${{ inputs.X_API_SECRET }}
+              value: ${{ defaults.jwt_secret }}
             - name: MAIN_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
             - name: FRONTEND_URL
@@ -379,33 +633,72 @@ spec:
             - name: NEXT_PUBLIC_BACKEND_URL
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/api
             - name: BACKEND_INTERNAL_URL
-              value: "http://localhost:3000"
+              value: http://localhost:3000
             - name: IS_GENERAL
               value: "true"
             - name: DISABLE_REGISTRATION
               value: "false"
             - name: STORAGE_PROVIDER
-              value: "local"
+              value: local
             - name: UPLOAD_DIRECTORY
-              value: "/uploads"
+              value: /uploads
             - name: NEXT_PUBLIC_UPLOAD_DIRECTORY
-              value: "/uploads"
+              value: /uploads
+            - name: API_LIMIT
+              value: "30"
+            - name: FEE_AMOUNT
+              value: "0.05"
+            - name: NX_ADD_PLUGINS
+              value: "false"
+            - name: X_URL
+              value: ""
+            - name: X_API_KEY
+              value: ""
+            - name: X_API_SECRET
+              value: ""
+            - name: GITHUB_CLIENT_ID
+              value: ""
+            - name: GITHUB_CLIENT_SECRET
+              value: ""
+            - name: YOUTUBE_CLIENT_ID
+              value: ""
+            - name: YOUTUBE_CLIENT_SECRET
+              value: ""
+            - name: MASTODON_URL
+              value: https://mastodon.social
+          ports:
+            - name: http
+              containerPort: 5000
+          startupProbe:
+            httpGet:
+              path: /api/auth/can-register
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /api/auth/can-register
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 20
           resources:
-            requests:
-              cpu: 50m
-              memory: 204Mi
             limits:
               cpu: 500m
-              memory: 2048Mi
-          ports:
-            - containerPort: 5000
+              memory: 4096Mi
+            requests:
+              cpu: 50m
+              memory: 409Mi
           volumeMounts:
             - name: vn-uploads
               mountPath: /uploads
             - name: vn-config
               mountPath: /config
-            - name: vn-rootvn-vn-cache
-              mountPath: /root/.cache
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -418,6 +711,7 @@ spec:
         resources:
           requests:
             storage: 1Gi
+        storageClassName: openebs-backup
     - metadata:
         annotations:
           path: /config
@@ -429,27 +723,50 @@ spec:
         resources:
           requests:
             storage: 1Gi
-    - metadata:
-        annotations:
-          path: /root/.cache
-          value: "1"
-        name: vn-rootvn-vn-cache
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+        storageClassName: openebs-backup
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}-temporal-es
+  labels:
+    app: ${{ defaults.app_name }}-temporal-es
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal-es
+spec:
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+  selector:
+    app: ${{ defaults.app_name }}-temporal-es
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}-temporal
+  labels:
+    app: ${{ defaults.app_name }}-temporal
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal
+spec:
+  ports:
+    - name: grpc
+      port: 7233
+      targetPort: grpc
+  selector:
+    app: ${{ defaults.app_name }}-temporal
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 5000
+    - name: http
+      port: 5000
+      targetPort: http
   selector:
     app: ${{ defaults.app_name }}
 ---
@@ -458,6 +775,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -473,7 +791,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* \\.(js|css|gif|jpe?g|png)) {
+      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
         add_header Cache-Control "public";
       }
@@ -493,7 +811,6 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -506,5 +823,5 @@ spec:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
   icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/postiz/logo.svg"
-  name: ${{ defaults.app_name }}
+  name: Postiz
   type: link

--- a/template/postiz/index.yaml
+++ b/template/postiz/index.yaml
@@ -582,6 +582,39 @@ spec:
         - name: ${{ defaults.app_name }}
           image: ghcr.io/gitroomhq/postiz-app:v2.21.8
           imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              cd /app
+
+              wait_for_port() {
+                name="$1"
+                port="$2"
+                i=1
+                while [ "$i" -le 180 ]; do
+                  if node -e 'const net = require("net"); const port = Number(process.argv[1]); const socket = net.createConnection({ host: "127.0.0.1", port }); socket.setTimeout(2000); socket.on("connect", () => { socket.destroy(); process.exit(0) }); socket.on("timeout", () => { socket.destroy(); process.exit(1) }); socket.on("error", () => process.exit(1));' "$port"
+                  then
+                    echo "$name is listening on 127.0.0.1:$port"
+                    return 0
+                  fi
+                  echo "waiting for $name on 127.0.0.1:$port"
+                  sleep 2
+                  i=$((i + 1))
+                done
+                echo "$name did not start on 127.0.0.1:$port" >&2
+                pm2 logs --nostream --lines 120 || true
+                exit 1
+              }
+
+              nginx
+              pm2 delete all || true
+              pnpm run prisma-db-push
+              pnpm run --parallel pm2
+              wait_for_port backend 3000
+              wait_for_port frontend 4200
+              pm2 logs
           env:
             - name: DB_HOSTNAME
               valueFrom:
@@ -683,10 +716,13 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /api/auth/can-register
               port: http
             initialDelaySeconds: 120
             periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## Summary
- update the Postiz template to the current validated deployment shape
- document first-run local registration and login behavior in English and Chinese READMEs
- keep Chinese Sealos template/documentation links on sealos.io as requested
- include the validated 4096Mi main app memory profile and multi-service architecture details

## Verification
- python -m unittest test_check_consistency
- python -m unittest test_compose_to_template
- python -m unittest test_check_must_coverage
- DOCKER_TO_SEALOS_ARTIFACTS=/Users/longnv/.codex/worktrees/5500/templates/template/postiz/index.yaml python -X utf8 scripts/quality_gate.py
- git diff --cached --check before commit

## Cleanup
- Removed all online Postiz test deployments from the Sealos namespace, including Instance resources and leftover KubeBlocks Service/Secret resources.