### PR TITLE
feat(mautic): upgrade template to Mautic 7

### DIFF
--- a/template/mautic/README.md
+++ b/template/mautic/README.md
@@ -1,30 +1,72 @@
-# mautic
+# Deploy and Host Mautic on Sealos
 
-## Overview
+[Mautic](https://www.mautic.org/) is an open source marketing automation platform for email campaigns, landing pages, lead scoring, segmentation, and customer journeys.
 
-Mautic is the world’s largest open source marketing automation software.
+This Sealos template deploys Mautic 7 with the official Apache image, a managed MySQL 8.4.2 database, persistent application storage, cron jobs, and queue workers.
 
-This Sealos template deploys **mautic** as the `mautic` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## Features
+
+- Mautic 7.1.2 using `mautic/mautic:7.1.2-apache`
+- Managed MySQL 8.4.2 database provisioned through KubeBlocks
+- Dedicated web, cron, and worker workloads
+- Persistent volumes for configuration, logs, uploaded files, and images
+- Public HTTPS ingress managed by Sealos
 
 ## Deploy on Sealos
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+1. Open the [Mautic template on Sealos](https://sealos.io/products/app-store/mautic).
+2. Click **Deploy Now**.
+3. Keep the default generated app name and domain, or customize them if needed.
+4. Choose the `TIMEZONE` value for PHP and scheduled tasks.
+5. Click **Deploy** and wait until the application status is running.
 
-## Access
+## First-run setup and login
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+Mautic does not ship with a default administrator account. On the first visit, open the generated public URL and complete the installer:
+
+1. On **Environment Check**, click **Next Step**.
+2. On **Database Setup**, keep the prefilled MySQL values from the template and click **Next Step**.
+3. On **Administrative User**, create your administrator username, password, and email address.
+4. After the installer finishes, sign in at `/s/login` with the administrator account you created.
+
+If the installer or later settings page asks for a site URL, use the public Sealos HTTPS URL shown for your app.
+
+## Resource profile
+
+The template was tuned with live Sealos deployment tests:
+
+| Component | CPU limit | Memory limit | Notes |
+| --- | ---: | ---: | --- |
+| Mautic web | `200m` | `256Mi` | Serves the UI and installer |
+| Mautic cron | `100m` | `256Mi` | Runs scheduled Mautic jobs |
+| Mautic worker | `100m` | `512Mi` | Runs Messenger queue consumers |
+| MySQL | `1000m` | `1024Mi` | Minimum stable KubeBlocks MySQL 8.4.2 profile |
+
+The worker needs more memory than the web container after installation because Messenger consumers are started in parallel.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
-
 | Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `TIMEZONE` | defaults to UTC | `false` | `` |
+| --- | --- | --- | --- |
+| `TIMEZONE` | PHP timezone used by Mautic and scheduled tasks. | No | `UTC` |
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+Email sending is configured inside Mautic after installation. Add your SMTP provider in **Settings → Configuration → Email** before running production campaigns.
 
-## Official Links
+## Data persistence
 
-- Official website: https://www.mautic.org/
-- Source repository: https://github.com/mautic/mautic
+The template persists:
+
+- `/var/www/html/config`
+- `/var/www/html/var/logs`
+- `/var/www/html/docroot/media/files`
+- `/var/www/html/docroot/media/images`
+- MySQL data volume
+
+Deleting the Sealos app removes the application and database resources according to the template termination policy.
+
+## Official links
+
+- Website: https://www.mautic.org/
+- Documentation: https://docs.mautic.org/
+- Source code: https://github.com/mautic/mautic
+- Docker image: https://hub.docker.com/r/mautic/mautic

--- a/template/mautic/README_zh.md
+++ b/template/mautic/README_zh.md
@@ -1,30 +1,72 @@
-# mautic
+# 在 Sealos 上部署 Mautic
 
-## 应用概览
+[Mautic](https://www.mautic.org/) 是一款开源营销自动化平台，可用于邮件营销、落地页、线索评分、客户分群和客户旅程编排。
 
-Mautic 是一款开源的营销自动化平台，提供电子邮件营销、客户旅程设计、潜在客户管理和行为跟踪等功能，帮助企业自动化营销流程、分析用户互动并个性化客户体验。
+此 Sealos 模板会部署 Mautic 7 官方 Apache 镜像、托管 MySQL 8.4.2 数据库、持久化应用存储、定时任务和队列 Worker。
 
-此 Sealos 模板会将 **mautic** 部署为 `mautic` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 功能特性
+
+- 使用 `mautic/mautic:7.1.2-apache` 部署 Mautic 7.1.2
+- 通过 KubeBlocks 创建托管 MySQL 8.4.2 数据库
+- Web、Cron、Worker 工作负载分工运行
+- 持久化配置、日志、上传文件和图片
+- 由 Sealos 自动管理公网 HTTPS 入口
 
 ## 在 Sealos 上部署
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+1. 打开 [Sealos 上的 Mautic 模板](https://sealos.io/products/app-store/mautic)。
+2. 点击 **Deploy Now**。
+3. 保留默认生成的应用名和域名，或按需自定义。
+4. 选择 `TIMEZONE`，用于 PHP 和定时任务。
+5. 点击 **Deploy**，等待应用状态变为运行中。
 
-## 访问方式
+## 首次设置与登录
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+Mautic 没有默认管理员账号。首次打开生成的公网地址时，需要完成安装向导：
+
+1. 在 **Environment Check** 页面点击 **Next Step**。
+2. 在 **Database Setup** 页面保留模板自动填入的 MySQL 配置，点击 **Next Step**。
+3. 在 **Administrative User** 页面创建管理员用户名、密码和邮箱。
+4. 安装完成后，使用刚创建的管理员账号在 `/s/login` 登录。
+
+如果安装向导或后续设置页面要求填写站点地址，请使用 Sealos 为应用生成的公网 HTTPS 地址。
+
+## 资源配置
+
+该模板已通过 Sealos 线上部署测试调试资源下限：
+
+| 组件 | CPU 上限 | 内存上限 | 说明 |
+| --- | ---: | ---: | --- |
+| Mautic Web | `200m` | `256Mi` | 提供界面和安装向导 |
+| Mautic Cron | `100m` | `256Mi` | 运行 Mautic 定时任务 |
+| Mautic Worker | `100m` | `512Mi` | 运行 Messenger 队列消费者 |
+| MySQL | `1000m` | `1024Mi` | MySQL 8.4.2 在 KubeBlocks 下的稳定下限 |
+
+安装完成后，Worker 会启动多个队列消费者，因此它需要比 Web 容器更高的内存。
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
-
 | 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `TIMEZONE` | `TIMEZONE` 部署参数。 | `否` | `` |
+| --- | --- | --- | --- |
+| `TIMEZONE` | Mautic 和定时任务使用的 PHP 时区。 | 否 | `UTC` |
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+邮件发送需要在安装后进入 Mautic 后台配置。生产使用前，请在 **Settings → Configuration → Email** 中添加 SMTP 服务商。
+
+## 数据持久化
+
+模板会持久化以下数据：
+
+- `/var/www/html/config`
+- `/var/www/html/var/logs`
+- `/var/www/html/docroot/media/files`
+- `/var/www/html/docroot/media/images`
+- MySQL 数据卷
+
+删除 Sealos 应用时，应用和数据库资源会按模板的终止策略一并删除。
 
 ## 官方链接
 
-- 官方网站: https://www.mautic.org/
-- 源码仓库: https://github.com/mautic/mautic
+- 官网：https://www.mautic.org/
+- 文档：https://docs.mautic.org/
+- 源码：https://github.com/mautic/mautic
+- Docker 镜像：https://hub.docker.com/r/mautic/mautic

--- a/template/mautic/index.yaml
+++ b/template/mautic/index.yaml
@@ -3,11 +3,11 @@ kind: Template
 metadata:
   name: mautic
 spec:
-  title: 'mautic'
+  title: 'Mautic'
   url: 'https://www.mautic.org/'
   gitRepo: 'https://github.com/mautic/mautic'
   author: 'Sealos'
-  description: 'Mautic is the world’s largest open source marketing automation software.'
+  description: 'Mautic is an open source marketing automation platform for email campaigns, landing pages, lead management, and customer journeys.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mautic/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mautic/logo.png'
   screenshots:
@@ -16,14 +16,12 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Mautic'
-      description: 'Mautic 是一款开源的营销自动化平台，提供电子邮件营销、客户旅程设计、潜在客户管理和行为跟踪等功能，帮助企业自动化营销流程、分析用户互动并个性化客户体验。'
+      description: 'Mautic 是一款开源营销自动化平台，可用于电子邮件营销、落地页、潜在客户管理、客户旅程编排和互动数据分析。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mautic/README_zh.md'
   categories:
     - tool
   defaults:
     app_host:
-      # number or string..
       type: string
       value: mautic-${{ random(8) }}
     app_name:
@@ -31,7 +29,7 @@ spec:
       value: mautic-${{ random(8) }}
   inputs:
     TIMEZONE:
-      description: 'defaults to UTC'
+      description: 'PHP timezone used by Mautic.'
       type: choice
       options:
         - UTC
@@ -46,7 +44,6 @@ metadata:
     app.kubernetes.io/instance: ${{ defaults.app_name }}-mysql
     app.kubernetes.io/managed-by: kbcli
   name: ${{ defaults.app_name }}-mysql
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -63,7 +60,6 @@ rules:
       - '*'
     verbs:
       - '*'
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -80,7 +76,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-mysql
-
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
@@ -88,30 +83,35 @@ metadata:
   finalizers:
     - cluster.kubeblocks.io/finalizer
   labels:
-    clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
+    clusterdefinition.kubeblocks.io/name: mysql
+    clusterversion.kubeblocks.io/name: mysql-8.4.2
   name: ${{ defaults.app_name }}-mysql
 spec:
   affinity:
-    nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterDefinitionRef: mysql
+  clusterVersionRef: mysql-8.4.2
   componentSpecs:
     - componentDefRef: mysql
-      monitor: true
+      enabledLogs:
+        - error
+        - slow
+      monitor: false
       name: mysql
+      noCreatePDB: false
       replicas: 1
       resources:
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 1000m
+          memory: 1024Mi
         requests:
-          cpu: 50m
-          memory: 51Mi
+          cpu: 100m
+          memory: 102Mi
+      rsmTransformPolicy: ToSts
       serviceAccountName: ${{ defaults.app_name }}-mysql
+      switchPolicy:
+        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -120,10 +120,13 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-
+  monitor: {}
+  resources:
+    cpu: '0'
+    memory: '0'
+  storage:
+    size: '0'
   terminationPolicy: Delete
-  tolerations: []
-
 ---
 apiVersion: batch/v1
 kind: Job
@@ -135,8 +138,15 @@ spec:
     spec:
       containers:
         - name: mysql-init
-          image: joseluisq/mysql-client:8.0.30
+          image: mysql:8.4.2
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
           env:
             - name: MAUTIC_USER
               valueFrom:
@@ -162,57 +172,88 @@ spec:
             - /bin/sh
             - -c
             - |
-              until mysql -h $MAUTIC_HOST -P $MAUTIC_PORT -u $MAUTIC_USER -p$MAUTIC_PASSWORD -e 'CREATE DATABASE IF NOT EXISTS mautic;'; do sleep 1; done
+              until mysqladmin ping -h "$MAUTIC_HOST" -P "$MAUTIC_PORT" -u "$MAUTIC_USER" -p"$MAUTIC_PASSWORD" --silent; do sleep 2; done
+              mysql -h "$MAUTIC_HOST" -P "$MAUTIC_PORT" -u "$MAUTIC_USER" -p"$MAUTIC_PASSWORD" -e 'CREATE DATABASE IF NOT EXISTS mautic CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
       restartPolicy: Never
-  backoffLimit: 0
+  backoffLimit: 6
   ttlSecondsAfterFinished: 300
-
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: PersistentVolumeClaim
 metadata:
-  name: ${{ defaults.app_name }}
-data:
-  vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf: |-
-    server {
-        listen 0.0.0.0:80;
-        
-        root /var/www/html/docroot;
-        
-        location / {
-            index index.php;
-            try_files $uri $uri/ /index.php?$query_string;
-        }
-    
-        location ~ \.php$ {
-            include fastcgi_params;
-            fastcgi_param HTTPS "on";
-            fastcgi_pass 127.0.0.1:9000;
-            fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
-        }
-    }
-
+  name: ${{ defaults.app_name }}-config
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${{ defaults.app_name }}-logs
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${{ defaults.app_name }}-media-files
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${{ defaults.app_name }}-media-images
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: mautic/mautic:5.2.3-fpm
+    originImageName: mautic/mautic:7.1.2-apache
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   minReadySeconds: 10
-  serviceName: ${{ defaults.app_name }}
   selector:
     matchLabels:
       app: ${{ defaults.app_name }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -221,23 +262,372 @@ spec:
       terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
       initContainers:
-        - name: take-data-dir-ownership
-          image: mautic/mautic:5.2.3-fpm
-          command: ["/bin/sh", "-c", "if [ ! -f /data/docroot/index.php ]; then cp -rf /var/www/html/docroot/* /data/; chown -R 33:33 /data; fi"]
+        - name: wait-for-mysql
+          image: mautic/mautic:7.1.2-apache
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          env:
+            - name: MAUTIC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MAUTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MAUTIC_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: host
+            - name: MAUTIC_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+          command:
+            - /bin/sh
+            - -c
+            - |
+              php -r '
+                $deadline = time() + 900;
+                do {
+                  try {
+                    $dsn = "mysql:host=" . getenv("MAUTIC_HOST") . ";port=" . getenv("MAUTIC_PORT") . ";charset=utf8mb4";
+                    $pdo = new PDO($dsn, getenv("MAUTIC_USER"), getenv("MAUTIC_PASSWORD"));
+                    $pdo->exec("CREATE DATABASE IF NOT EXISTS mautic CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+                    exit(0);
+                  } catch (Throwable $e) {
+                    sleep(2);
+                  }
+                } while (time() < $deadline);
+                fwrite(STDERR, "MySQL did not become ready in time\n");
+                exit(1);
+              '
+        - name: take-data-dir-ownership
+          image: mautic/mautic:7.1.2-apache
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /mnt/config /mnt/logs /mnt/media-files /mnt/media-images
+              chown -R 33:33 /mnt/config /mnt/logs /mnt/media-files /mnt/media-images
           volumeMounts:
-            - name: vn-varvn-wwwvn-htmlvn-docroot
-              mountPath: /data
+            - name: mautic-config
+              mountPath: /mnt/config
+            - name: mautic-logs
+              mountPath: /mnt/logs
+            - name: mautic-media-files
+              mountPath: /mnt/media-files
+            - name: mautic-media-images
+              mountPath: /mnt/media-images
       containers:
         - name: ${{ defaults.app_name }}
-          image: mautic/mautic:5.2.3-fpm
+          image: mautic/mautic:7.1.2-apache
+          imagePullPolicy: IfNotPresent
           env:
             - name: PHP_INI_VALUE_DATE_TIMEZONE
               value: "${{ inputs.TIMEZONE }}"
-            - name: DOCKER_MAUTIC_RUN_MIGRATIONS
-              value: 'false'
+            - name: SYMFONY_TRUSTED_PROXIES
+              value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
+            - name: SYMFONY_TRUSTED_HEADERS
+              value: x-forwarded-for,x-forwarded-host,x-forwarded-proto,x-forwarded-port
             - name: DOCKER_MAUTIC_LOAD_TEST_DATA
               value: 'false'
+            - name: MAUTIC_MESSENGER_DSN_EMAIL
+              value: doctrine://default
+            - name: MAUTIC_MESSENGER_DSN_HIT
+              value: doctrine://default
+            - name: MAUTIC_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MAUTIC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MAUTIC_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+            - name: MAUTIC_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: host
+            - name: MAUTIC_DB_DATABASE
+              value: mautic
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 80
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: mautic-config
+              mountPath: /var/www/html/config
+            - name: mautic-logs
+              mountPath: /var/www/html/var/logs
+            - name: mautic-media-files
+              mountPath: /var/www/html/docroot/media/files
+            - name: mautic-media-images
+              mountPath: /var/www/html/docroot/media/images
+      volumes:
+        - name: mautic-config
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-config
+        - name: mautic-logs
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-logs
+        - name: mautic-media-files
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-files
+        - name: mautic-media-images
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-images
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-cron
+  annotations:
+    originImageName: mautic/mautic:7.1.2-apache
+    deploy.cloud.sealos.io/minReplicas: '1'
+    deploy.cloud.sealos.io/maxReplicas: '1'
+  labels:
+    app: ${{ defaults.app_name }}-cron
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-cron
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-cron
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-cron
+    spec:
+      terminationGracePeriodSeconds: 10
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - ${{ defaults.app_name }}
+              topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: wait-for-mautic-config
+          image: busybox:1.36.1
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until [ -f /mnt/config/local.php ]; do sleep 5; done
+          volumeMounts:
+            - name: mautic-config
+              mountPath: /mnt/config
+      containers:
+        - name: ${{ defaults.app_name }}-cron
+          image: mautic/mautic:7.1.2-apache
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PHP_INI_VALUE_DATE_TIMEZONE
+              value: "${{ inputs.TIMEZONE }}"
+            - name: SYMFONY_TRUSTED_PROXIES
+              value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
+            - name: SYMFONY_TRUSTED_HEADERS
+              value: x-forwarded-for,x-forwarded-host,x-forwarded-proto,x-forwarded-port
+            - name: DOCKER_MAUTIC_ROLE
+              value: mautic_cron
+            - name: MAUTIC_MESSENGER_DSN_EMAIL
+              value: doctrine://default
+            - name: MAUTIC_MESSENGER_DSN_HIT
+              value: doctrine://default
+            - name: MAUTIC_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MAUTIC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MAUTIC_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+            - name: MAUTIC_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: host
+            - name: MAUTIC_DB_DATABASE
+              value: mautic
+          resources:
+            requests:
+              cpu: 10m
+              memory: 25Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - name: mautic-config
+              mountPath: /var/www/html/config
+            - name: mautic-logs
+              mountPath: /var/www/html/var/logs
+            - name: mautic-media-files
+              mountPath: /var/www/html/docroot/media/files
+            - name: mautic-media-images
+              mountPath: /var/www/html/docroot/media/images
+      volumes:
+        - name: mautic-config
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-config
+        - name: mautic-logs
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-logs
+        - name: mautic-media-files
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-files
+        - name: mautic-media-images
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-images
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-worker
+  annotations:
+    originImageName: mautic/mautic:7.1.2-apache
+    deploy.cloud.sealos.io/minReplicas: '1'
+    deploy.cloud.sealos.io/maxReplicas: '1'
+  labels:
+    app: ${{ defaults.app_name }}-worker
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-worker
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-worker
+    spec:
+      terminationGracePeriodSeconds: 10
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - ${{ defaults.app_name }}
+              topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: wait-for-mautic-config
+          image: busybox:1.36.1
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until [ -f /mnt/config/local.php ]; do sleep 5; done
+          volumeMounts:
+            - name: mautic-config
+              mountPath: /mnt/config
+      containers:
+        - name: ${{ defaults.app_name }}-worker
+          image: mautic/mautic:7.1.2-apache
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PHP_INI_VALUE_DATE_TIMEZONE
+              value: "${{ inputs.TIMEZONE }}"
+            - name: SYMFONY_TRUSTED_PROXIES
+              value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.1
+            - name: SYMFONY_TRUSTED_HEADERS
+              value: x-forwarded-for,x-forwarded-host,x-forwarded-proto,x-forwarded-port
+            - name: DOCKER_MAUTIC_ROLE
+              value: mautic_worker
+            - name: MAUTIC_MESSENGER_DSN_EMAIL
+              value: doctrine://default
+            - name: MAUTIC_MESSENGER_DSN_HIT
+              value: doctrine://default
             - name: MAUTIC_DB_USER
               valueFrom:
                 secretKeyRef:
@@ -267,248 +657,41 @@ spec:
             limits:
               cpu: 100m
               memory: 512Mi
-          ports:
-            - name: http
-              protocol: TCP
-              containerPort: 9000
-          imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: vn-varvn-wwwvn-htmlvn-config
+            - name: mautic-config
               mountPath: /var/www/html/config
-            - name: vn-varvn-wwwvn-htmlvn-varvn-logs
+            - name: mautic-logs
               mountPath: /var/www/html/var/logs
-            - name: vn-optvn-mauticvn-cron
-              mountPath: /opt/mautic/cron
-            - name: vn-varvn-wwwvn-htmlvn-docroot
-              mountPath: /var/www/html/docroot
-            - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-files
+            - name: mautic-media-files
               mountPath: /var/www/html/docroot/media/files
-            - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-images
-              mountPath: /var/www/html/docroot/media/images
-        - env:
-          - name: PHP_INI_VALUE_DATE_TIMEZONE
-            value: "${{ inputs.TIMEZONE }}"
-          - name: DOCKER_MAUTIC_ROLE
-            value: "mautic_cron"
-          - name: MAUTIC_DB_USER
-            valueFrom:
-              secretKeyRef:
-                key: username
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: password
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_PORT
-            valueFrom:
-              secretKeyRef:
-                key: port
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_HOST
-            valueFrom:
-              secretKeyRef:
-                key: host
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_DATABASE
-            value: mautic
-          image: mautic/mautic:5.2.3-fpm
-          imagePullPolicy: IfNotPresent
-          name: ${{ defaults.app_name }}-cron
-          resources:
-            requests:
-              cpu: 10m
-              memory: 51Mi
-            limits:
-              cpu: 100m
-              memory: 512Mi
-          volumeMounts:
-          - mountPath: /etc/nginx/conf.d/default.conf
-            name: vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf
-            subPath: ./etc/nginx/conf.d/default.conf
-          - mountPath: /var/www/html/config
-            name: vn-varvn-wwwvn-htmlvn-config
-          - mountPath: /var/www/html/var/logs
-            name: vn-varvn-wwwvn-htmlvn-varvn-logs
-          - mountPath: /opt/mautic/cron
-            name: vn-optvn-mauticvn-cron
-          - mountPath: /var/www/html/docroot
-            name: vn-varvn-wwwvn-htmlvn-docroot
-          - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-files
-            mountPath: /var/www/html/docroot/media/files
-          - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-images
-            mountPath: /var/www/html/docroot/media/images
-        - env:
-          - name: PHP_INI_VALUE_DATE_TIMEZONE
-            value: "${{ inputs.TIMEZONE }}"
-          - name: DOCKER_MAUTIC_ROLE
-            value: "mautic_worker"
-          - name: MAUTIC_DB_USER
-            valueFrom:
-              secretKeyRef:
-                key: username
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: password
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_PORT
-            valueFrom:
-              secretKeyRef:
-                key: port
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_HOST
-            valueFrom:
-              secretKeyRef:
-                key: host
-                name: mautic-ovqmjzyp-mysql-conn-credential
-          - name: MAUTIC_DB_DATABASE
-            value: mautic
-          image: mautic/mautic:5.2.3-fpm
-          imagePullPolicy: IfNotPresent
-          name: ${{ defaults.app_name }}-worker
-          resources:
-            requests:
-              cpu: 10m
-              memory: 51Mi
-            limits:
-              cpu: 100m
-              memory: 512Mi
-          volumeMounts:
-          - mountPath: /etc/nginx/conf.d/default.conf
-            name: vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf
-            subPath: ./etc/nginx/conf.d/default.conf
-          - mountPath: /var/www/html/config
-            name: vn-varvn-wwwvn-htmlvn-config
-          - mountPath: /var/www/html/var/logs
-            name: vn-varvn-wwwvn-htmlvn-varvn-logs
-          - mountPath: /opt/mautic/cron
-            name: vn-optvn-mauticvn-cron
-          - mountPath: /var/www/html/docroot
-            name: vn-varvn-wwwvn-htmlvn-docroot
-          - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-files
-            mountPath: /var/www/html/docroot/media/files
-          - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-images
-            mountPath: /var/www/html/docroot/media/images
-        - name: ${{ defaults.app_name }}-nginx
-          image: nginx:1.27
-          resources:
-            requests:
-              cpu: 10m
-              memory: 12Mi
-            limits:
-              cpu: 100m
-              memory: 128Mi
-          ports:
-            - name: http
-              protocol: TCP
-              containerPort: 80
-          imagePullPolicy: IfNotPresent
-          readinessProbe:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - curl -sf http://127.0.0.1/index.php
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          volumeMounts:
-            - name: vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf
-              mountPath: /etc/nginx/conf.d/default.conf
-              subPath: ./etc/nginx/conf.d/default.conf
-            - name: vn-varvn-wwwvn-htmlvn-docroot
-              mountPath: /var/www/html/docroot
-            - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-files
-              mountPath: /var/www/html/docroot/media/files
-            - name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-images
+            - name: mautic-media-images
               mountPath: /var/www/html/docroot/media/images
       volumes:
-        - name: vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf
-          configMap:
-            name: ${{ defaults.app_name }}
-            items:
-              - key: vn-etcvn-nginxvn-confvn-dvn-defaultvn-conf
-                path: ./etc/nginx/conf.d/default.conf
-  volumeClaimTemplates:
-    - metadata:
-        annotations:
-          path: /var/www/html/config
-          value: '1'
-        name: vn-varvn-wwwvn-htmlvn-config
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        annotations:
-          path: /var/www/html/var/logs
-          value: '1'
-        name: vn-varvn-wwwvn-htmlvn-varvn-logs
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        annotations:
-          path: /opt/mautic/cron
-          value: '1'
-        name: vn-optvn-mauticvn-cron
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        annotations:
-          path: /var/www/html/docroot
-          value: '1'
-        name: vn-varvn-wwwvn-htmlvn-docroot
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-files
-        annotations:
-          path: /var/www/html/docroot/media/files
-          value: '1'
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        name: vn-varvn-wwwvn-htmlvn-docrootvn-mediavn-images
-        annotations:
-          path: /var/www/html/docroot/media/images
-          value: '1'
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-
+        - name: mautic-config
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-config
+        - name: mautic-logs
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-logs
+        - name: mautic-media-files
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-files
+        - name: mautic-media-images
+          persistentVolumeClaim:
+            claimName: ${{ defaults.app_name }}-media-images
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 80
+    - name: http
+      port: 80
+      targetPort: 80
   selector:
     app: ${{ defaults.app_name }}
 ---
@@ -517,6 +700,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -552,7 +736,6 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -564,6 +747,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mautic/logo.png"
-  name: "Mautic"
+  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mautic/logo.png'
+  name: 'Mautic'
   type: link


### PR DESCRIPTION
## Summary
- upgrade Mautic to `mautic/mautic:7.1.2-apache`
- switch the bundled database to KubeBlocks MySQL `mysql-8.4.2`
- split web, cron, and worker workloads with tuned Sealos resource limits
- rewrite English and Chinese README files with first-run setup and login guidance

## Validation
- `python -X utf8 - <<'PY' ... yaml.safe_load_all(template/mautic/index.yaml) ... PY`
- `DOCKER_TO_SEALOS_ARTIFACTS=/Users/longnv/.codex/worktrees/7feb/templates/template/mautic/index.yaml python -X utf8 /Users/longnv/.codex/plugins/cache/local-plugins/sealos/0.1.0/skills/docker-to-sealos/scripts/quality_gate.py`
- `git diff --check upstream/kb-0.9...HEAD`
- live Sealos deployment verified: web/cron/worker ready, MySQL running, installer reachable and admin login completed

## Live test cleanup
All Mautic test resources were removed after validation, including Sealos Instance resources.
