### PR TITLE
[codex] fix mongodb secret names in templates

### DIFF
--- a/template/Ruiqi-Waf/index.yaml
+++ b/template/Ruiqi-Waf/index.yaml
@@ -171,7 +171,7 @@ spec:
             - name: MONGO_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: JWT_SECRET
               value: ${{ defaults.jwt_secret }}

--- a/template/laf/index.yaml
+++ b/template/laf/index.yaml
@@ -255,7 +255,7 @@ spec:
             - name: MONGO_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: DATABASE_URL
               value: "mongodb://root:$(MONGO_PASSWORD)@${{ defaults.app_name }}-mongo-mongodb.${{ SEALOS_NAMESPACE }}.svc:27017/sys_db?authSource=admin&w=majority"

--- a/template/librechat/index.yaml
+++ b/template/librechat/index.yaml
@@ -77,7 +77,7 @@ spec:
             - name: MONGO_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: MONGO_URI
               value: >-

--- a/template/overleaf/index.yaml
+++ b/template/overleaf/index.yaml
@@ -92,7 +92,7 @@ spec:
                   key: password
             - name: OVERLEAF_MONGO_URL
               value: >-
-                mongodb://root:$(OVERLEAF_MONGO_PASS)@${{ defaults.app_name }}-mongo-mongodb.${{ SEALOS_NAMESPACE }}.svc:27017/sharelatex?authSource=admin
+                mongodb://root:$(OVERLEAF_MONGO_PASS)@${{ defaults.app_name }}-mongodb-mongodb.${{ SEALOS_NAMESPACE }}.svc:27017/sharelatex?authSource=admin
             - name: OVERLEAF_REDIS_HOST
               value: ${{ defaults.app_name }}-redis-redis
             - name: OVERLEAF_REDIS_PORT

--- a/template/rocketchat-micro/index.yaml
+++ b/template/rocketchat-micro/index.yaml
@@ -132,12 +132,12 @@ spec:
             - name: MONGO_INITDB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: MONGO_HOST
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: host
           command:
             - /bin/bash
@@ -258,12 +258,12 @@ spec:
             - name: MONGO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: MONGO_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: endpoint
             - name: MONGO_URL
               value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb
@@ -545,12 +545,12 @@ spec:
         - name: MONGO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: password
         - name: MONGO_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: endpoint
         - name: MONGO_URL
           value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb
@@ -634,12 +634,12 @@ spec:
         - name: MONGO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: password
         - name: MONGO_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: endpoint
         - name: MONGO_URL
           value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb
@@ -723,12 +723,12 @@ spec:
         - name: MONGO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: password
         - name: MONGO_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: endpoint
         - name: MONGO_URL
           value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb
@@ -821,12 +821,12 @@ spec:
         - name: MONGO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: password
         - name: MONGO_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: endpoint
         - name: MONGO_URL
           value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb
@@ -910,12 +910,12 @@ spec:
         - name: MONGO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: password
         - name: MONGO_ENDPOINT
           valueFrom:
             secretKeyRef:
-              name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+              name: ${{ defaults.app_name }}-mongo-mongodb-account-root
               key: endpoint
         - name: MONGO_URL
           value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb

--- a/template/rocketchat/index.yaml
+++ b/template/rocketchat/index.yaml
@@ -134,12 +134,12 @@ spec:
             - name: MONGO_INITDB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: MONGO_HOST
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: host
           command:
             - /bin/bash
@@ -212,12 +212,12 @@ spec:
             - name: MONGO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: password
             - name: MONGO_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: ${{ defaults.app_name }}-mongodb-mongodb-account-root
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
                   key: endpoint
             - name: MONGO_URL
               value: mongodb://rocketchat:rocketchat@$(MONGO_ENDPOINT)/rocketchat?replicaSet=${{ defaults.app_name }}-mongo-mongodb


### PR DESCRIPTION
## What changed

- Fixed MongoDB root Secret references for templates whose KubeBlocks Cluster is named `${{ defaults.app_name }}-mongo`.
- Fixed the Overleaf MongoDB service host to match its `${{ defaults.app_name }}-mongodb` Cluster.

## Why

Some templates referenced `${{ defaults.app_name }}-mongodb-mongodb-account-root` while the actual MongoDB Cluster and generated Secret use `${{ defaults.app_name }}-mongo-mongodb-account-root`. That prevents pods and init jobs from starting because the referenced Secret does not exist.

## Validation

- Ran a repository scan for single MongoDB Cluster Secret/service naming mismatches.
- Ran `git diff --check`.
