### PR TITLE
feat(templates): refresh batch Sealos apps

### DIFF
--- a/template/langflow/README.md
+++ b/template/langflow/README.md
@@ -1,30 +1,126 @@
-# Langflow
+# Deploy and Host Langflow on Sealos
 
-## Overview
+Langflow is a visual low-code builder for RAG, agentic workflows, and AI applications. This template deploys Langflow 1.9.5 as a single persistent service on Sealos Cloud, with optional PostgreSQL for production storage.
 
-Langflow is a low-code app builder for RAG and multi-agent AI applications. Build, iterate, and deploy AI workflows with a drag-and-drop interface.
+## About Hosting Langflow
 
-This Sealos template deploys **Langflow** as the `langflow` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Langflow provides a browser-based canvas for building AI workflows from reusable components. You can connect language models, tools, vector stores, prompt chains, and agents, then test and iterate flows directly in the web interface.
 
-## Deploy on Sealos
+This Sealos template runs the official `langflowai/langflow` container, exposes it through a managed HTTPS endpoint, and stores Langflow data on persistent volumes. Auto login is disabled for public deployments, so users sign in with the initial superuser credentials configured during deployment.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+When `enable_database` is turned on, the template provisions PostgreSQL 16 through KubeBlocks and initializes a dedicated `langflow` database. If it is left off, Langflow uses the built-in SQLite database stored on the persistent data volume.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **RAG Prototyping**: Build retrieval workflows that combine documents, embeddings, vector databases, and LLM responses.
+- **Agent Workflow Design**: Compose multi-step agent workflows visually before moving them into production systems.
+- **AI App Experiments**: Test prompts, model providers, tools, and data connectors from one interactive workspace.
+- **Team Demos and Education**: Share a hosted Langflow instance for workshops, demos, and internal AI enablement.
+
+## Dependencies for Langflow Hosting
+
+The Sealos template includes the Langflow application container, persistent storage for `/app/data` and `/app/flows`, a managed Ingress endpoint, and optional PostgreSQL.
+
+### Deployment Dependencies
+
+- [Langflow Documentation](https://docs.langflow.org/) - Official Langflow documentation
+- [Langflow GitHub Repository](https://github.com/langflow-ai/langflow) - Source code and release notes
+- [Langflow API Keys and Authentication](https://docs.langflow.org/api-keys-and-authentication) - Authentication and API key behavior
+- [Sealos App Store](https://sealos.io/products/app-store/langflow) - Langflow template page
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Langflow Service**: Official Langflow 1.9.5 container serving the web UI and API on port 7860.
+- **Persistent Storage**: Two persistent volumes for application data and exported flow files.
+- **PostgreSQL (Optional)**: KubeBlocks PostgreSQL 16.4.0 with an idempotent initialization Job when `enable_database` is set to `true`.
+- **Ingress and App Entry**: Sealos-managed HTTPS routing and a dashboard link for the deployed instance.
+
+**Configuration:**
+
+- `admin_username` sets the initial Langflow superuser username. The default is `admin`.
+- `admin_password` sets the initial superuser password and is required for sign-in.
+- `enable_database` switches storage from persistent SQLite to PostgreSQL for larger or production-oriented deployments.
+- `LANGFLOW_AUTO_LOGIN` is set to `false`, so the visual editor requires sign-in instead of anonymous superuser access.
+- `LANGFLOW_SECRET_KEY` is generated per deployment for encryption-sensitive Langflow internals.
+
+**License Information:**
+
+Langflow is released under the MIT License. This Sealos template is provided under the license terms of the templates repository.
+
+## Why Deploy Langflow on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies deployment, networking, storage, and lifecycle operations. By deploying Langflow on Sealos, you get:
+
+- **One-Click Deployment**: Launch Langflow from the App Store without writing Kubernetes YAML.
+- **Managed HTTPS Access**: Each deployment receives a public HTTPS endpoint automatically.
+- **Persistent Storage Included**: Langflow data and flows survive container restarts and upgrades.
+- **Optional Managed Database**: Enable PostgreSQL when you need a managed database backend.
+- **Canvas + AI Operations**: Adjust resources and configuration later through Canvas, resource cards, or the AI dialog.
+- **Pay-As-You-Go Resources**: Start with the included resource profile and scale when your workloads need more capacity.
+
+## Deployment Guide
+
+1. Open the [Langflow template](https://sealos.io/products/app-store/langflow) and click **Deploy Now**.
+2. Configure the deployment parameters:
+   - `admin_username`: Initial superuser username, default `admin`.
+   - `admin_password`: Initial superuser password used to sign in after deployment.
+   - `enable_database`: Set to `true` to use PostgreSQL, or keep `false` to use persistent SQLite.
+3. Wait for deployment to complete. Langflow can take several minutes on first start because the container initializes components and the web server.
+4. Access the application from the Sealos-provided URL and sign in with the configured `admin_username` and `admin_password`.
+5. After sign-in, create your first flow from the welcome screen or upload an existing flow JSON file.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can manage Langflow through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `enable_database` | Enable external database (PostgreSQL) for production use | `false` | `false` |
+- **Langflow UI**: Create flows, manage API keys, configure model providers, and run workflows.
+- **Sealos AI Dialog**: Describe configuration or scaling changes and let Sealos apply them.
+- **Resource Cards**: Open the StatefulSet, Service, Ingress, or PostgreSQL cards in Canvas to inspect or adjust runtime settings.
+- **Environment Variables**: Update Langflow settings such as authentication, database, or feature flags from the workload resource card.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+For public deployments, keep auto login disabled and use a strong superuser password. Configure provider API keys inside Langflow or through Sealos-managed environment variables when needed.
 
-## Official Links
+## Scaling
 
-- Official website: https://www.langflow.org/
-- Source repository: https://github.com/langflow-ai/langflow
+Langflow is deployed as a single persistent StatefulSet. To scale resources:
+
+1. Open the Canvas for your deployment.
+2. Click the Langflow StatefulSet resource card.
+3. Increase CPU or memory if you run large flows, load many components, or use memory-heavy connectors.
+4. Apply the change and wait for the pod to restart and become ready.
+
+The template uses a cold-start validated profile of 2 CPU and 4Gi memory. Lower memory settings may fail during initialization.
+
+## Troubleshooting
+
+### The login page is shown after deployment
+
+This is expected. Auto login is disabled, so use the `admin_username` and `admin_password` configured during deployment.
+
+### The pod restarts during startup
+
+Langflow loads many Python components during cold start. If you manually reduce memory and the pod is OOMKilled, restore the template memory setting or choose a larger Sealos memory tier.
+
+### API provider calls fail from a flow
+
+Confirm that the relevant API key is configured in Langflow and that the provider is reachable from your deployment.
+
+### Getting Help
+
+- [Langflow Documentation](https://docs.langflow.org/)
+- [Langflow GitHub Issues](https://github.com/langflow-ai/langflow/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Langflow Components](https://docs.langflow.org/components-overview)
+- [Langflow API Keys and Authentication](https://docs.langflow.org/api-keys-and-authentication)
+- [Langflow Docker Deployment](https://docs.langflow.org/deployment-docker)
+
+## License
+
+This Sealos template is provided under the templates repository license. Langflow is licensed under the MIT License.

--- a/template/langflow/README_zh.md
+++ b/template/langflow/README_zh.md
@@ -1,30 +1,126 @@
-# Langflow
+# 在 Sealos 上部署和托管 Langflow
 
-## 应用概览
+Langflow 是一个面向 RAG、智能体工作流和 AI 应用的可视化低代码构建器。此模板会在 Sealos Cloud 上部署 Langflow 1.9.5 单服务实例，并可选择启用 PostgreSQL 作为生产存储。
 
-Langflow 是一个用于 RAG 和多代理 AI 应用的低代码应用构建器。通过拖放界面构建、迭代和部署 AI 工作流。
+## 关于托管 Langflow
 
-此 Sealos 模板会将 **Langflow** 部署为 `langflow` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Langflow 提供基于浏览器的画布，用于通过可复用组件构建 AI 工作流。你可以连接语言模型、工具、向量数据库、提示词链和智能体，并在 Web 界面中直接测试和迭代流程。
 
-## 在 Sealos 上部署
+此 Sealos 模板运行官方 `langflowai/langflow` 容器，通过托管 HTTPS 入口暴露服务，并使用持久化卷保存 Langflow 数据。模板会关闭自动登录，因此公网部署需要使用部署时配置的初始超级用户账号登录。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+当 `enable_database` 设置为 `true` 时，模板会通过 KubeBlocks 创建 PostgreSQL 16，并初始化专用的 `langflow` 数据库。如果保持关闭，Langflow 会使用存放在持久化数据卷中的内置 SQLite 数据库。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **RAG 原型构建**：组合文档、嵌入、向量数据库和 LLM 响应，快速构建检索增强工作流。
+- **智能体工作流设计**：以可视化方式编排多步骤智能体流程，再迁移到生产系统。
+- **AI 应用实验**：在一个交互式工作区中测试提示词、模型提供商、工具和数据连接器。
+- **团队演示与教学**：为工作坊、演示或内部 AI 培训提供托管 Langflow 实例。
 
-## 配置说明
+## Langflow 托管依赖
 
-部署时可以配置以下用户可见输入项：
+Sealos 模板包含 Langflow 应用容器、用于 `/app/data` 和 `/app/flows` 的持久化存储、托管 Ingress 入口，以及可选 PostgreSQL。
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `enable_database` | `enable_database` 部署参数。 | `否` | `false` |
+### 部署依赖
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+- [Langflow 文档](https://docs.langflow.org/) - Langflow 官方文档
+- [Langflow GitHub 仓库](https://github.com/langflow-ai/langflow) - 源码和版本说明
+- [Langflow API Keys and Authentication](https://docs.langflow.org/api-keys-and-authentication) - 认证与 API Key 行为说明
+- [Sealos 应用商店](https://sealos.io/products/app-store/langflow) - Langflow 模板页面
 
-## 官方链接
+### 实现细节
 
-- 官方网站: https://www.langflow.org/
-- 源码仓库: https://github.com/langflow-ai/langflow
+**架构组件：**
+
+此模板会部署以下资源：
+
+- **Langflow 服务**：官方 Langflow 1.9.5 容器，在 7860 端口提供 Web UI 和 API。
+- **持久化存储**：两个持久化卷，用于保存应用数据和导出的 flow 文件。
+- **PostgreSQL（可选）**：启用 `enable_database` 后创建 KubeBlocks PostgreSQL 16.4.0，并通过幂等初始化 Job 创建数据库。
+- **Ingress 和应用入口**：Sealos 托管 HTTPS 路由，以及部署后的仪表盘入口。
+
+**配置说明：**
+
+- `admin_username` 设置初始 Langflow 超级用户用户名，默认值为 `admin`。
+- `admin_password` 设置初始超级用户密码，登录时必须使用。
+- `enable_database` 可将存储从持久化 SQLite 切换到 PostgreSQL，适合更大规模或生产场景。
+- `LANGFLOW_AUTO_LOGIN` 设置为 `false`，因此可视化编辑器需要登录，而不是匿名超级用户访问。
+- `LANGFLOW_SECRET_KEY` 会在每次部署时生成，用于 Langflow 内部加密相关能力。
+
+**许可证信息：**
+
+Langflow 使用 MIT License。此 Sealos 模板遵循模板仓库的许可证条款。
+
+## 为什么在 Sealos 上部署 Langflow？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一了部署、网络、存储和生命周期运维。将 Langflow 部署到 Sealos 后，你可以获得：
+
+- **一键部署**：直接从应用商店启动 Langflow，无需编写 Kubernetes YAML。
+- **托管 HTTPS 访问**：每个部署都会自动获得公网 HTTPS 地址。
+- **内置持久化存储**：Langflow 数据和 flow 会在容器重启或升级后保留。
+- **可选托管数据库**：需要托管数据库后端时可启用 PostgreSQL。
+- **Canvas + AI 运维**：部署后可通过 Canvas、资源卡片或 AI 对话调整资源和配置。
+- **按量使用资源**：从模板内置资源配置开始，并在工作负载增加时扩容。
+
+## 部署指南
+
+1. 打开 [Langflow 模板](https://sealos.io/products/app-store/langflow)，点击 **Deploy Now**。
+2. 配置部署参数：
+   - `admin_username`：初始超级用户用户名，默认 `admin`。
+   - `admin_password`：初始超级用户密码，部署完成后用于登录。
+   - `enable_database`：设置为 `true` 使用 PostgreSQL，保持 `false` 则使用持久化 SQLite。
+3. 等待部署完成。Langflow 首次启动需要初始化组件和 Web 服务，通常需要数分钟。
+4. 通过 Sealos 提供的 URL 访问应用，并使用配置的 `admin_username` 和 `admin_password` 登录。
+5. 登录后可从欢迎页创建第一个 flow，或上传已有 flow JSON 文件。
+
+## 配置
+
+部署后可以通过以下方式管理 Langflow：
+
+- **Langflow UI**：创建 flow、管理 API Key、配置模型提供商并运行工作流。
+- **Sealos AI 对话**：描述需要调整的配置或扩容需求，让 Sealos 自动应用变更。
+- **资源卡片**：在 Canvas 中打开 StatefulSet、Service、Ingress 或 PostgreSQL 资源卡片，检查或调整运行时设置。
+- **环境变量**：在工作负载资源卡片中更新认证、数据库或功能开关等 Langflow 配置。
+
+公网部署时建议保持自动登录关闭，并使用强超级用户密码。需要调用外部模型或服务时，请在 Langflow 内或通过 Sealos 托管环境变量配置对应 API Key。
+
+## 扩缩容
+
+Langflow 以单副本持久化 StatefulSet 部署。如需调整资源：
+
+1. 打开当前部署的 Canvas。
+2. 点击 Langflow StatefulSet 资源卡片。
+3. 如果运行大型 flow、加载大量组件或使用高内存连接器，可提高 CPU 或内存。
+4. 应用变更并等待 Pod 重启后重新就绪。
+
+模板使用经过冷启动验证的 2 CPU 和 4Gi 内存配置。手动降低内存可能导致初始化阶段 OOMKilled。
+
+## 故障排查
+
+### 部署后显示登录页
+
+这是预期行为。模板已关闭自动登录，请使用部署时配置的 `admin_username` 和 `admin_password` 登录。
+
+### Pod 在启动时反复重启
+
+Langflow 冷启动时会加载大量 Python 组件。如果手动降低内存后出现 OOMKilled，请恢复模板内存配置或选择更高的 Sealos 内存阶梯。
+
+### flow 调用 API 提供商失败
+
+请确认对应 API Key 已在 Langflow 中配置，并确认部署环境可以访问该提供商。
+
+### 获取帮助
+
+- [Langflow 文档](https://docs.langflow.org/)
+- [Langflow GitHub Issues](https://github.com/langflow-ai/langflow/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Langflow Components](https://docs.langflow.org/components-overview)
+- [Langflow API Keys and Authentication](https://docs.langflow.org/api-keys-and-authentication)
+- [Langflow Docker Deployment](https://docs.langflow.org/deployment-docker)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库许可证。Langflow 使用 MIT License。

--- a/template/langflow/index.yaml
+++ b/template/langflow/index.yaml
@@ -3,61 +3,70 @@ kind: Template
 metadata:
   name: langflow
 spec:
-  title: 'Langflow'
-  url: 'http://www.langflow.org'
-  gitRepo: 'https://github.com/langflow-ai/langflow'
-  author: 'Sealos'
-  description: 'Langflow is a low-code app builder for RAG and multi-agent AI applications. Build, iterate, and deploy AI workflows with a drag-and-drop interface.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/logo.png'
+  title: Langflow
+  url: https://www.langflow.org/
+  gitRepo: https://github.com/langflow-ai/langflow
+  author: Sealos
+  description: Langflow is a low-code visual builder for RAG, agents, and AI applications. Build, test, and share AI workflows through a browser-based interface.
+  readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/README.md
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/logo.png
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/website-screenshot.webp'
+    - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/website-screenshot.webp
   templateType: inline
   locale: en
   i18n:
     zh:
-      title: 'Langflow'
-      description: 'Langflow 是一个用于 RAG 和多代理 AI 应用的低代码应用构建器。通过拖放界面构建、迭代和部署 AI 工作流。'
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/README_zh.md'
+      description: Langflow 是一个用于 RAG、智能体和 AI 应用的低代码可视化构建器，可在浏览器中构建、测试和共享 AI 工作流。
+      readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/README_zh.md
   categories:
     - ai
     - low-code
     - tool
   defaults:
-    app_name:
-      type: string
-      value: langflow-${{ random(8) }}
     app_host:
       type: string
       value: langflow-${{ random(8) }}
+    app_name:
+      type: string
+      value: langflow-${{ random(8) }}
+    secret_key:
+      type: string
+      value: ${{ random(32) }}
   inputs:
+    admin_username:
+      description: Initial Langflow superuser username.
+      type: string
+      default: admin
+      required: true
+    admin_password:
+      description: Initial Langflow superuser password. Use a strong password.
+      type: string
+      default: ''
+      required: true
     enable_database:
-      description: 'Enable external database (PostgreSQL) for production use'
+      description: Enable PostgreSQL instead of the built-in SQLite database.
       type: boolean
       default: 'false'
       required: false
 ---
 ${{ if(inputs.enable_database === 'true') }}
-# PostgreSQL ServiceAccount
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
 ---
-# PostgreSQL Role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 rules:
   - apiGroups:
       - '*'
@@ -65,17 +74,15 @@ rules:
       - '*'
     verbs:
       - '*'
-
 ---
-# PostgreSQL RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -83,33 +90,33 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-pg
-
 ---
-# PostgreSQL Cluster
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: Cluster
 metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
   name: ${{ defaults.app_name }}-pg
+  labels:
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
 spec:
   affinity:
-    nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
+  terminationPolicy: Delete
   componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
       replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
       resources:
         limits:
           cpu: 500m
@@ -117,9 +124,6 @@ spec:
         requests:
           cpu: 50m
           memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -129,53 +133,95 @@ spec:
               requests:
                 storage: 1Gi
             storageClassName: openebs-backup
-  terminationPolicy: Delete
-  tolerations: []
-
 ---
-# PostgreSQL Init Job
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${{ defaults.app_name }}-pg-init
 spec:
-  completions: 1
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 300
   template:
     spec:
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: pgsql-init
-          image: postgres:14-alpine
+        - name: pg-init
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_DATABASE
+              value: langflow
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE langflow;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
+              export PGPASSWORD="$PG_PASSWORD"
+              for i in $(seq 1 90); do
+                if pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                if [ "$i" -eq 90 ]; then
+                  echo "PostgreSQL is not ready" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='langflow'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "langflow";'
+              fi
 ${{ endif() }}
-
 ---
-# Frontend StatefulSet (Main Application)
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: langflowai/langflow-frontend:1.5.0.post2
+    originImageName: langflowai/langflow:1.9.5
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   serviceName: ${{ defaults.app_name }}
   replicas: 1
@@ -194,129 +240,36 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: ${{ defaults.app_name }}
-          image: langflowai/langflow-frontend:1.5.0.post2
+          image: langflowai/langflow:1.9.5
           imagePullPolicy: IfNotPresent
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          env:
-            - name: BACKEND_URL
-              value: "http://${{ defaults.app_name }}-backend:7860"
-            - name: FRONTEND_PORT
-              value: "8080"
-          resources:
-            requests:
-              cpu: 50m
-              memory: 51Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
-          volumeMounts:
-            - name: vn-varvn-cachevn-nginx
-              mountPath: /var/cache/nginx
-          livenessProbe:
-            httpGet:
-              path: /index.html
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /index.html
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 10
-  volumeClaimTemplates:
-    - metadata:
-        annotations:
-          path: /var/cache/nginx
-          value: '1'
-        name: vn-varvn-cachevn-nginx
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-
----
-# Frontend Service
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-spec:
-  type: ClusterIP
-  ports:
-    - port: 8080
-      targetPort: 8080
-      protocol: TCP
-      name: http
-  selector:
-    app: ${{ defaults.app_name }}
-
----
-# Backend StatefulSet
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: ${{ defaults.app_name }}-backend
-  annotations:
-    originImageName: langflowai/langflow-frontend:1.5.0.post2
-    deploy.cloud.sealos.io/minReplicas: '1'
-    deploy.cloud.sealos.io/maxReplicas: '1'
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
-    app: ${{ defaults.app_name }}
-spec:
-  serviceName: ${{ defaults.app_name }}-backend
-  replicas: 1
-  revisionHistoryLimit: 1
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}-backend
-  template:
-    metadata:
-      labels:
-        app: ${{ defaults.app_name }}-backend
-    spec:
-      automountServiceAccountToken: false
-      securityContext:
-        fsGroup: 1000
-        runAsGroup: 1000
-        runAsNonRoot: true
-        runAsUser: 1000
-      containers:
-        - name: ${{ defaults.app_name }}-backend
-          image: langflowai/langflow:1.5.0.post2
-          imagePullPolicy: IfNotPresent
-          command: ["/bin/bash", "-c"]
+          command:
+            - /bin/bash
+            - -ec
           args:
-            - >
-              set -e &&
-              langflow run --host 0.0.0.0 --port 7860
+            - langflow run --host 0.0.0.0 --port 7860
           ports:
             - name: http
               containerPort: 7860
               protocol: TCP
           env:
-            - name: LANGFLOW_BACKEND_ONLY
-              value: "true"
-            - name: LANGFLOW_NUM_WORKERS
-              value: "1"
             - name: LANGFLOW_PORT
-              value: "7860"
+              value: '7860'
+            - name: LANGFLOW_HOST
+              value: 0.0.0.0
+            - name: LANGFLOW_AUTO_LOGIN
+              value: 'false'
+            - name: LANGFLOW_SUPERUSER
+              value: '${{ inputs.admin_username }}'
+            - name: LANGFLOW_SUPERUSER_PASSWORD
+              value: '${{ inputs.admin_password }}'
+            - name: LANGFLOW_SECRET_KEY
+              value: '${{ defaults.secret_key }}'
             - name: LANGFLOW_UPDATE_STARTER_PROJECTS
-              value: "false"
+              value: 'false'
             ${{ if(inputs.enable_database === 'true') }}
             - name: PG_PASSWORD
               valueFrom:
@@ -342,36 +295,41 @@ spec:
               value: postgresql://$(PG_USER):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/langflow
             ${{ else() }}
             - name: LANGFLOW_DATABASE_URL
-              value: "sqlite:////app/data/langflow.db"
+              value: sqlite:////app/data/langflow.db
             ${{ endif() }}
           resources:
-            requests:
-              cpu: 100m
-              memory: 102Mi
             limits:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: 2
+              memory: 4Gi
+            requests:
+              cpu: 200m
+              memory: 400Mi
           volumeMounts:
             - name: vn-appvn-data
               mountPath: /app/data
             - name: vn-appvn-flows
               mountPath: /app/flows
-          livenessProbe:
+          startupProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 10
+            failureThreshold: 60
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -395,32 +353,30 @@ spec:
         resources:
           requests:
             storage: 1Gi
-
 ---
-# Backend Service
 apiVersion: v1
 kind: Service
 metadata:
-  name: ${{ defaults.app_name }}-backend
+  name: ${{ defaults.app_name }}
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
   ports:
-    - port: 7860
+    - name: http
+      port: 7860
       targetPort: 7860
       protocol: TCP
-      name: http
   selector:
-    app: ${{ defaults.app_name }}-backend
-
+    app: ${{ defaults.app_name }}
 ---
-# Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -451,14 +407,12 @@ spec:
               service:
                 name: ${{ defaults.app_name }}
                 port:
-                  number: 8080
+                  number: 7860
   tls:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
-# App CR
 apiVersion: app.sealos.io/v1
 kind: App
 metadata:
@@ -469,6 +423,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/logo.png"
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/langflow/logo.png
   name: Langflow
   type: link

--- a/template/listmonk/README.md
+++ b/template/listmonk/README.md
@@ -1,31 +1,117 @@
-# listmonk
+# Deploy and Host listmonk on Sealos
 
-## Overview
+listmonk is a fast, self-hosted newsletter and mailing list manager. This template deploys listmonk with a Kubeblocks-managed PostgreSQL database and persistent media storage on Sealos Cloud.
 
-High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.
+## About Hosting listmonk
 
-This Sealos template deploys **listmonk** as the `listmonk` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+listmonk provides a web dashboard for managing subscribers, lists, campaigns, templates, and transactional messages. It runs as a single Go application backed by PostgreSQL, so the deployment stays lightweight while preserving mailing list data across restarts.
 
-## Deploy on Sealos
+The Sealos template provisions PostgreSQL, a persistent volume for `/listmonk/uploads`, an internal service, HTTPS ingress, and a dashboard App entry. On first start, listmonk runs its idempotent installer and upgrade flow before serving the admin UI.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Newsletter Publishing**: Create and send recurring updates to product, community, or editorial audiences.
+- **Mailing List Management**: Segment subscribers, manage opt-ins, and maintain reusable email lists.
+- **Campaign Analytics**: Track campaign delivery, opens, clicks, and archive pages from one dashboard.
+- **Transactional Templates**: Manage reusable transactional email templates alongside marketing campaigns.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for listmonk Hosting
+
+The Sealos template includes all required runtime dependencies: the listmonk container image, PostgreSQL, persistent upload storage, service discovery, and HTTPS ingress.
+
+### Deployment Dependencies
+
+- [listmonk Documentation](https://listmonk.app/docs/) - Official installation and configuration guides
+- [listmonk GitHub Repository](https://github.com/knadh/listmonk) - Source code and releases
+- [Sealos App Store](https://sealos.io/products/app-store/listmonk) - One-click template deployment
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **listmonk StatefulSet**: Runs `listmonk/listmonk:v6.1.0`, serves the admin UI and public campaign/subscription pages on port `9000`.
+- **PostgreSQL Cluster**: Kubeblocks-managed PostgreSQL `postgresql-16.4.0` stores users, lists, campaigns, settings, and analytics.
+- **Persistent Upload Volume**: Stores uploaded media at `/listmonk/uploads` so files survive restarts.
+- **Ingress and App Entry**: Exposes listmonk through a Sealos-managed HTTPS URL.
+
+**Configuration:**
+
+The app uses listmonk environment variables and starts with `--config ''`, which follows the official container recommendation for environment-only configuration. PostgreSQL connection values are read from Kubeblocks-managed secrets. The template also updates `app.root_url` to the generated public Sealos URL so campaign links and public pages use the deployed domain.
+
+**Initial Administrator:**
+
+During deployment, you may provide `admin_username` and `admin_password`. If both are provided, listmonk creates that Super Admin account during the first installation. If either field is left empty, open the deployed URL and use the first-time setup form at `/admin/login` to create the Super Admin account; the password must be at least 8 characters.
+
+**License Information:**
+
+listmonk is licensed under the AGPL-3.0 license. This Sealos template is maintained for deploying listmonk on Sealos Cloud.
+
+## Why Deploy listmonk on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. By deploying listmonk on Sealos, you get:
+
+- **One-Click Deployment**: Open the template page, click **Deploy Now**, and let Sealos create the app, database, storage, network, and public URL.
+- **Persistent Data by Default**: PostgreSQL and upload storage are provisioned with persistent volumes.
+- **Instant HTTPS Access**: Each deployment receives a public HTTPS endpoint managed by Sealos.
+- **Easy Customization**: Adjust resources, environment variables, and operational settings from the Canvas using the AI dialog or resource cards.
+- **Kubernetes Foundation**: Run listmonk on Kubernetes without managing manifests, ingress, certificates, or database operators manually.
+
+## Deployment Guide
+
+1. Open the [listmonk template](https://sealos.io/products/app-store/listmonk) and click **Deploy Now**.
+2. Configure the deployment parameters. To pre-create a Super Admin user, set `admin_username` and `admin_password`; otherwise leave them empty and create the first administrator from the web setup page.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Access listmonk via the provided URL:
+   - **Admin dashboard**: Open `/admin/login`. Log in with the configured Super Admin credentials, or complete the first-time setup form if credentials were not provided.
+   - **Public pages**: Subscription, archive, and campaign links use the same generated HTTPS domain.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, configure listmonk through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `ADMIN_PASSWORD` | admin password for the admin dashboard. | `false` | `<redacted>` |
-| `ADMIN_USERNAME` | admin username for the admin dashboard. | `false` | `` |
+- **Admin Dashboard**: Manage SMTP, templates, lists, subscribers, media uploads, privacy settings, and campaign defaults.
+- **Canvas AI Dialog**: Describe operational changes and let Sealos apply updates.
+- **Resource Cards**: Adjust CPU, memory, storage, and environment variables from the Canvas.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+Before sending production email, configure SMTP or another supported messenger in the listmonk admin settings.
 
-## Official Links
+## Scaling
 
-- Official website: https://listmonk.app/
-- Source repository: https://github.com/knadh/listmonk
+listmonk is deployed as a single StatefulSet replica because it stores media on a mounted persistent volume and coordinates campaign work from one application process. To change resources:
+
+1. Open the Canvas for your deployment.
+2. Click the listmonk StatefulSet resource card.
+3. Adjust CPU or memory resources.
+4. Apply the change and wait for the pod to become ready again.
+
+## Troubleshooting
+
+### The admin login shows a setup form
+
+This is expected when `admin_username` or `admin_password` was left empty during deployment. Complete the setup form with an email, username, and password to create the first Super Admin account.
+
+### Login fails after providing deployment credentials
+
+Confirm that `admin_username` is at least 3 characters and `admin_password` is at least 8 characters. If invalid values were provided during the first boot, redeploy or create the first Super Admin account from the setup page if no user was created.
+
+### Email campaigns are not sent
+
+Configure SMTP or another messenger in **Admin → Settings**. The template deploys listmonk itself but does not include a mail relay.
+
+### Getting Help
+
+- [listmonk Documentation](https://listmonk.app/docs/)
+- [listmonk GitHub Issues](https://github.com/knadh/listmonk/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Configuration Reference](https://listmonk.app/docs/configuration/)
+- [API Documentation](https://listmonk.app/docs/apis/)
+- [Roles and Permissions](https://listmonk.app/docs/roles-and-permissions/)
+
+## License
+
+This Sealos template is provided under the repository license. listmonk itself is licensed under AGPL-3.0.

--- a/template/listmonk/README_zh.md
+++ b/template/listmonk/README_zh.md
@@ -1,31 +1,117 @@
-# listmonk
+# 在 Sealos 上部署和托管 listmonk
 
-## 应用概览
+listmonk 是一个快速的自托管 Newsletter 与邮件列表管理平台。此模板会在 Sealos Cloud 上部署 listmonk、Kubeblocks 托管的 PostgreSQL 数据库，以及持久化媒体存储。
 
-listmonk 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+## 关于托管 listmonk
 
-此 Sealos 模板会将 **listmonk** 部署为 `listmonk` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+listmonk 提供 Web 管理后台，用于管理订阅者、列表、邮件活动、模板和事务邮件。它以单个 Go 应用运行，并使用 PostgreSQL 保存数据，因此部署轻量，同时能在重启后保留邮件列表数据。
 
-## 在 Sealos 上部署
+Sealos 模板会创建 PostgreSQL、`/listmonk/uploads` 持久化卷、内部服务、HTTPS Ingress 和仪表盘 App 入口。首次启动时，listmonk 会先执行幂等安装和升级流程，然后启动管理后台。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **Newsletter 发布**：向产品、社区或内容读者定期发送更新。
+- **邮件列表管理**：细分订阅者，管理订阅确认，并维护可复用邮件列表。
+- **邮件活动分析**：在同一后台查看投递、打开、点击和归档页面。
+- **事务邮件模板**：在营销邮件之外管理可复用的事务邮件模板。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## listmonk 托管依赖
 
-## 配置说明
+此 Sealos 模板包含运行所需依赖：listmonk 容器镜像、PostgreSQL、持久化上传存储、服务发现和 HTTPS Ingress。
 
-部署时可以配置以下用户可见输入项：
+### 部署依赖
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `ADMIN_PASSWORD` | `ADMIN_PASSWORD` 部署参数。 | `否` | `<已隐藏>` |
-| `ADMIN_USERNAME` | `ADMIN_USERNAME` 部署参数。 | `否` | `` |
+- [listmonk 文档](https://listmonk.app/docs/) - 官方安装与配置指南
+- [listmonk GitHub 仓库](https://github.com/knadh/listmonk) - 源码与版本发布
+- [Sealos 应用商店](https://sealos.io/products/app-store/listmonk) - 一键部署模板
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 实现细节
 
-## 官方链接
+**架构组件：**
 
-- 官方网站: https://listmonk.app/
-- 源码仓库: https://github.com/knadh/listmonk
+此模板会部署以下服务：
+
+- **listmonk StatefulSet**：运行 `listmonk/listmonk:v6.1.0`，通过 `9000` 端口提供管理后台和公开的邮件活动/订阅页面。
+- **PostgreSQL Cluster**：由 Kubeblocks 托管的 PostgreSQL `postgresql-16.4.0`，保存用户、列表、邮件活动、设置和分析数据。
+- **持久化上传卷**：将上传媒体保存到 `/listmonk/uploads`，重启后文件仍会保留。
+- **Ingress 与 App 入口**：通过 Sealos 托管的 HTTPS URL 暴露 listmonk。
+
+**配置方式：**
+
+应用使用 listmonk 环境变量，并以 `--config ''` 启动，符合官方容器使用环境变量配置的建议。PostgreSQL 连接信息来自 Kubeblocks 管理的 Secret。模板还会把 `app.root_url` 更新为生成的 Sealos 公网 URL，让邮件活动链接和公开页面使用实际部署域名。
+
+**首次管理员：**
+
+部署时可以填写 `admin_username` 和 `admin_password`。如果两者都填写，listmonk 会在首次安装时创建该 Super Admin 账户。如果任一字段留空，请打开部署后的 URL，并在 `/admin/login` 的首次设置表单中创建 Super Admin；密码至少需要 8 个字符。
+
+**许可证信息：**
+
+listmonk 使用 AGPL-3.0 许可证。此 Sealos 模板用于在 Sealos Cloud 上部署 listmonk。
+
+## 为什么在 Sealos 上部署 listmonk？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用从开发、部署到运维的完整生命周期。在 Sealos 上部署 listmonk 可以获得：
+
+- **一键部署**：打开模板页面，点击 **Deploy Now**，Sealos 会创建应用、数据库、存储、网络和公网 URL。
+- **默认持久化数据**：PostgreSQL 和上传存储都会使用持久化卷。
+- **即时 HTTPS 访问**：每次部署都会获得由 Sealos 管理的公网 HTTPS 入口。
+- **易于调整**：可在 Canvas 中通过 AI 对话或资源卡片调整资源、环境变量和运维设置。
+- **Kubernetes 基础能力**：无需手动管理 YAML、Ingress、证书或数据库 Operator，即可运行在 Kubernetes 上。
+
+## 部署指南
+
+1. 打开 [listmonk 模板](https://sealos.io/products/app-store/listmonk)，点击 **Deploy Now**。
+2. 配置部署参数。如需预创建 Super Admin，请填写 `admin_username` 和 `admin_password`；否则留空，并在 Web 首次设置页面创建管理员。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会跳转到 Canvas。后续如需调整，可在 AI 对话中描述需求，或点击相关资源卡片修改配置。
+4. 通过提供的 URL 访问 listmonk：
+   - **管理后台**：打开 `/admin/login`。使用部署时配置的 Super Admin 凭据登录；如果未提供凭据，则先完成首次设置表单。
+   - **公开页面**：订阅、归档和邮件活动链接使用同一个生成的 HTTPS 域名。
+
+## 配置
+
+部署完成后，可以通过以下方式配置 listmonk：
+
+- **管理后台**：管理 SMTP、模板、列表、订阅者、媒体上传、隐私设置和邮件活动默认值。
+- **Canvas AI 对话**：描述需要的运维变更，让 Sealos 帮助应用更新。
+- **资源卡片**：在 Canvas 中调整 CPU、内存、存储和环境变量。
+
+在生产环境发送邮件前，请先在 listmonk 管理设置中配置 SMTP 或其他支持的发送器。
+
+## 扩缩容
+
+listmonk 以单副本 StatefulSet 部署，因为它在挂载的持久化卷中保存媒体，并由单个应用进程协调邮件活动。调整资源的步骤：
+
+1. 打开当前部署的 Canvas。
+2. 点击 listmonk StatefulSet 资源卡片。
+3. 调整 CPU 或内存资源。
+4. 应用修改并等待 Pod 重新就绪。
+
+## 故障排查
+
+### 管理登录页显示设置表单
+
+如果部署时 `admin_username` 或 `admin_password` 留空，这是正常现象。填写邮箱、用户名和密码即可创建第一个 Super Admin 账户。
+
+### 填写部署凭据后无法登录
+
+确认 `admin_username` 至少 3 个字符，`admin_password` 至少 8 个字符。如果首次启动时提供了无效值，请重新部署；如果还没有创建用户，也可以从设置页面创建第一个 Super Admin。
+
+### 邮件活动没有发送
+
+请在 **Admin → Settings** 中配置 SMTP 或其他发送器。模板只部署 listmonk 本身，不包含邮件中继服务。
+
+### 获取帮助
+
+- [listmonk 文档](https://listmonk.app/docs/)
+- [listmonk GitHub Issues](https://github.com/knadh/listmonk/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [配置参考](https://listmonk.app/docs/configuration/)
+- [API 文档](https://listmonk.app/docs/apis/)
+- [角色和权限](https://listmonk.app/docs/roles-and-permissions/)
+
+## 许可证
+
+此 Sealos 模板遵循仓库许可证。listmonk 本身使用 AGPL-3.0 许可证。

--- a/template/listmonk/index.yaml
+++ b/template/listmonk/index.yaml
@@ -3,107 +3,61 @@ kind: Template
 metadata:
   name: listmonk
 spec:
-  title: 'listmonk'
-  url: 'https://listmonk.app/'
-  gitRepo: 'https://github.com/knadh/listmonk'
-  author: 'Sealos'
-  description: 'High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app.'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/logo.png'
+  title: listmonk
+  url: https://listmonk.app/
+  gitRepo: https://github.com/knadh/listmonk
+  author: Sealos
+  description: High-performance self-hosted newsletter and mailing list manager with a modern admin dashboard.
+  readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/README.md
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/logo.png
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/website-screenshot.webp'
+    - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/website-screenshot.webp
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: 高性能自托管邮件列表与 Newsletter 管理平台，提供现代化管理后台。
+      readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/README_zh.md
   categories:
     - tool
   defaults:
     app_host:
-      # number or string..
       type: string
       value: listmonk-${{ random(8) }}
     app_name:
       type: string
       value: listmonk-${{ random(8) }}
   inputs:
-    ADMIN_USERNAME:
-      description: 'admin username for the admin dashboard.'
+    admin_username:
+      description: Optional initial Super Admin username. Leave empty to create the first administrator in the web setup page.
       type: string
       default: ''
       required: false
-    ADMIN_PASSWORD:
-      description: 'admin password for the admin dashboard.'
+    admin_password:
+      description: Optional initial Super Admin password. Must be at least 8 characters when provided.
       type: string
       default: ''
       required: false
 
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/README_zh.md'
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: Cluster
-metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
-spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 rules:
   - apiGroups:
       - '*'
@@ -116,11 +70,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: ${{ defaults.app_name }}-pg
   labels:
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -130,125 +84,238 @@ subjects:
     name: ${{ defaults.app_name }}-pg
 
 ---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-16.4.0
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
+      replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 51Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ${{ defaults.app_name }}-pg-init
 spec:
-  completions: 1
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 300
   template:
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      restartPolicy: OnFailure
       containers:
-        - name: pgsql-init
-          image: senzing/postgresql-client:2.2.4
+        - name: pg-init
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE listmonk;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-install
-spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: listmonk-install
-          image: listmonk/listmonk:v3.0.0
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: LISTMONK_app__address
-              value: "0.0.0.0:9000"
-            - name: LISTMONK_app__admin_username
-              value: ${{ inputs.ADMIN_USERNAME }}
-            - name: LISTMONK_app__admin_password
-              value: ${{ inputs.ADMIN_PASSWORD }}
-            - name: LISTMONK_db__host
-              value: ${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc
-            - name: LISTMONK_db__port
-              value: 5432
-            - name: LISTMONK_db__user
-              value: postgres
-            - name: LISTMONK_db__password
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: LISTMONK_db__database
+            - name: PG_DATABASE
               value: listmonk
-            - name: LISTMONK_db__ssl_mode
-              value: disable
+            - name: PUBLIC_URL
+              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
-              until yes | ./listmonk --install --config config-demo.toml; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
+              export PGPASSWORD="$PG_PASSWORD"
+              for i in $(seq 1 90); do
+                if pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                if [ "$i" -eq 90 ]; then
+                  echo "PostgreSQL is not ready" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='listmonk'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "listmonk";'
+              fi
+              for i in $(seq 1 90); do
+                if psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DATABASE" -tAc "SELECT to_regclass('public.settings')" | grep -q settings; then
+                  psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DATABASE" -v ON_ERROR_STOP=1 -c "UPDATE settings SET value = to_jsonb('$PUBLIC_URL'::text) WHERE key = 'app.root_url';"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "listmonk settings table was not created in time" >&2
+              exit 1
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: listmonk/listmonk:v3.0.0
+    originImageName: listmonk/listmonk:v6.1.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
+  serviceName: ${{ defaults.app_name }}
   selector:
     matchLabels:
       app: ${{ defaults.app_name }}
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   template:
     metadata:
       labels:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: listmonk/listmonk:v3.0.0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: init-uploads
+          image: busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -c
+            - mkdir -p /listmonk/uploads
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+          volumeMounts:
+            - name: vn-listmonkvn-uploads
+              mountPath: /listmonk/uploads
+        - name: listmonk-setup
+          image: listmonk/listmonk:v6.1.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              for i in $(seq 1 90); do
+                if ./listmonk --install --idempotent --yes --config ''; then
+                  break
+                fi
+                if [ "$i" -eq 90 ]; then
+                  ./listmonk --install --idempotent --yes --config ''
+                fi
+                sleep 2
+              done
+              ./listmonk --upgrade --yes --config ''
           env:
             - name: TZ
-              value: Asia/Shanghai
+              value: Etc/UTC
             - name: LISTMONK_app__address
-              value: "0.0.0.0:9000"
-            - name: LISTMONK_app__admin_username
-              value: ${{ inputs.ADMIN_USERNAME }}
-            - name: LISTMONK_app__admin_password
-              value: ${{ inputs.ADMIN_PASSWORD }}
+              value: 0.0.0.0:9000
+            - name: LISTMONK_ADMIN_USER
+              value: ${{ inputs.admin_username }}
+            - name: LISTMONK_ADMIN_PASSWORD
+              value: ${{ inputs.admin_password }}
             - name: LISTMONK_db__host
-              value: ${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
             - name: LISTMONK_db__port
-              value: 5432
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
             - name: LISTMONK_db__user
-              value: postgres
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: LISTMONK_db__password
               valueFrom:
                 secretKeyRef:
@@ -258,17 +325,120 @@ spec:
               value: listmonk
             - name: LISTMONK_db__ssl_mode
               value: disable
+            - name: LISTMONK_db__max_open
+              value: '25'
+            - name: LISTMONK_db__max_idle
+              value: '25'
+            - name: LISTMONK_db__max_lifetime
+              value: 300s
           resources:
-            requests:
-              cpu: 20m
-              memory: 12Mi
             limits:
               cpu: 200m
-              memory: 128Mi
-          ports:
-            - containerPort: 9000
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: listmonk/listmonk:v6.1.0
           imagePullPolicy: IfNotPresent
-
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -ec
+            - ./listmonk --config ''
+          env:
+            - name: TZ
+              value: Etc/UTC
+            - name: LISTMONK_app__address
+              value: 0.0.0.0:9000
+            - name: LISTMONK_ADMIN_USER
+              value: ${{ inputs.admin_username }}
+            - name: LISTMONK_ADMIN_PASSWORD
+              value: ${{ inputs.admin_password }}
+            - name: LISTMONK_db__host
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: LISTMONK_db__port
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: LISTMONK_db__user
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: LISTMONK_db__password
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: LISTMONK_db__database
+              value: listmonk
+            - name: LISTMONK_db__ssl_mode
+              value: disable
+            - name: LISTMONK_db__max_open
+              value: '25'
+            - name: LISTMONK_db__max_idle
+              value: '25'
+            - name: LISTMONK_db__max_lifetime
+              value: 300s
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+          volumeMounts:
+            - name: vn-listmonkvn-uploads
+              mountPath: /listmonk/uploads
+  volumeClaimTemplates:
+    - metadata:
+        name: vn-listmonkvn-uploads
+        annotations:
+          path: /listmonk/uploads
+          value: '1'
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 
 ---
 apiVersion: v1
@@ -276,13 +446,16 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 9000
+    - name: http
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
-
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -290,6 +463,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -300,7 +474,6 @@ metadata:
       large_client_header_buffers 4 128k;
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
@@ -316,7 +489,7 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /()(.*)
+            path: /
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -338,6 +511,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/logo.png"
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/listmonk/logo.png
   name: listmonk
   type: link

--- a/template/lobe-chat/README.md
+++ b/template/lobe-chat/README.md
@@ -1,33 +1,122 @@
-# Lobe Chat
+# Deploy and Host Lobe Chat on Sealos
 
-## Overview
+Lobe Chat is an open-source AI chat workspace for ChatGPT-compatible and multi-provider LLM workflows. This template deploys the lightweight client-side Lobe Chat image with a public HTTPS endpoint on Sealos Cloud.
 
-An open-source, modern-design ChatGPT/LLMs UI/Framework. Supports speech-synthesis, multi-modal, and extensible (function call) plugin system.
+## About Hosting Lobe Chat
 
-This Sealos template deploys **Lobe Chat** as the `lobe-chat` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Lobe Chat runs as a single Next.js application on Sealos. The template exposes the web UI through Sealos Ingress, keeps the container image pinned, and generates a per-deployment authentication secret so built-in session APIs work correctly.
 
-## Deploy on Sealos
+This template is best for personal or team chat access where conversation data can remain in the browser. For server-side accounts, shared cloud sync, PostgreSQL, object storage, and external identity login, use the separate Lobe Chat Database Version template.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Personal AI workspace**: Use one interface for OpenAI-compatible chat models and custom model lists.
+- **Team demo environment**: Share a hosted Lobe Chat URL protected by an optional access code.
+- **Model gateway frontend**: Point `OPENAI_PROXY_URL` at an OpenAI-compatible gateway or proxy.
+- **Prompt and agent experiments**: Test assistants, plugins, and multimodal chat UI features from a managed HTTPS endpoint.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for Lobe Chat Hosting
+
+The Sealos template includes the Lobe Chat application container, a Kubernetes Deployment, a Service, an Ingress, and an App shortcut. It does not provision PostgreSQL, Redis, or object storage for this lightweight version.
+
+### Deployment Dependencies
+
+- [Lobe Chat Documentation](https://lobehub.com/docs) - Official documentation
+- [Self-hosting Guide](https://lobehub.com/docs/self-hosting/start) - Deployment options and configuration
+- [Docker Image](https://hub.docker.com/r/lobehub/lobe-chat) - Published container tags
+- [GitHub Repository](https://github.com/lobehub/lobe-chat) - Source code and issues
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Lobe Chat Web App**: Next.js application served from `lobehub/lobe-chat:1.143.3` on port `3210`.
+- **Service**: Internal ClusterIP service routing traffic to the application pod.
+- **Ingress**: Public HTTPS route using the generated Sealos domain.
+- **App Shortcut**: Sealos dashboard link that opens the deployed Lobe Chat URL.
+
+**Configuration:**
+
+- `OPENAI_API_KEY` can preconfigure an OpenAI API key, but users can also configure providers from the UI after deployment.
+- `OPENAI_PROXY_URL` defaults to `https://api.openai.com/v1` and can point to any compatible API gateway.
+- `ACCESS_CODE` is optional. Set a strong value to require an access password before users can use the app.
+- `OPENAI_MODEL_LIST` can add, hide, or rename visible model IDs.
+
+**Login and Registration:**
+
+This lightweight template does not create server-side user accounts and does not require an initial registration step. Open the deployed URL, enter the optional `ACCESS_CODE` if configured, then add or confirm model provider settings in the Lobe Chat interface. Server-side email/password registration and SSO belong to the database version.
+
+**License Information:**
+
+Lobe Chat is licensed under the Apache-2.0 license. This Sealos template is provided under the template repository license.
+
+## Why Deploy Lobe Chat on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that manages deployment, networking, scaling, and operations from a unified dashboard. By deploying Lobe Chat on Sealos, you get:
+
+- **One-Click Deployment**: Open the template page, configure a few inputs, and let Sealos create the Kubernetes resources.
+- **Managed HTTPS Access**: Each deployment receives a public HTTPS URL without manual certificate or ingress setup.
+- **Resource Controls**: Adjust CPU and memory from the Canvas when traffic or model usage patterns change.
+- **AI-Assisted Operations**: Use the Sealos AI dialog or resource cards to update environment variables and runtime settings.
+- **Pay-as-You-Go Efficiency**: Start with the tested baseline resources and scale only when needed.
+
+## Deployment Guide
+
+1. Open the [Lobe Chat template](https://sealos.io/products/app-store/lobe-chat) and click **Deploy Now**.
+2. Configure the parameters in the popup dialog. To use OpenAI directly, fill in `OPENAI_API_KEY`; to protect the app, set `ACCESS_CODE`.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **Lobe Chat Web UI**: Open the generated Sealos URL, enter the access code if configured, and start configuring model providers or chats.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Lobe Chat through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `ACCESS_CODE` | Add a password to access this service; you can set a long password to avoid leaking. If this value contains a comma, it is a password array. | `false` | `` |
-| `OPENAI_API_KEY` | This is the API key you apply on the OpenAI account page | `false` | `<redacted>` |
-| `OPENAI_MODEL_LIST` | Used to control the model list. Use + to add a model, - to hide a model, and model_name=display_name to customize the display name of a model, separated by commas. | `false` | `` |
-| `OPENAI_PROXY_URL` | If you manually configure the OpenAI interface proxy, you can use this configuration item to override the default OpenAI API request base URL | `false` | `https://api.openai.com/v1` |
+- **AI Dialog**: Describe environment variable changes such as model list or proxy URL updates.
+- **Resource Cards**: Open the Deployment resource card to edit CPU, memory, replicas, or environment variables.
+- **Lobe Chat UI**: Configure provider credentials and chat preferences from the application settings when you do not preconfigure them through template inputs.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+The tested baseline for this template is `200m` CPU and `1024Mi` memory (512Mi was not stable during cold-start validation) with requests derived as `20m` CPU and `102Mi` memory. To scale:
 
-- Official website: https://github.com/lobehub/lobe-chat
-- Source repository: https://github.com/lobehub/lobe-chat
+1. Open the Canvas for your deployment.
+2. Click the Lobe Chat Deployment resource card.
+3. Increase CPU or memory if concurrent users, long sessions, or plugin usage require more capacity.
+4. Apply the change and wait for the rollout to complete.
+
+## Troubleshooting
+
+### Common Issues
+
+**The app opens but model calls fail**
+- Cause: `OPENAI_API_KEY`, `OPENAI_PROXY_URL`, or provider settings are missing or invalid.
+- Solution: Update the template inputs or configure provider credentials in the Lobe Chat UI.
+
+**An access password is requested**
+- Cause: `ACCESS_CODE` was configured during deployment.
+- Solution: Enter the configured access code, or update the Deployment environment variable from the Sealos Canvas.
+
+**Server-side login or registration is needed**
+- Cause: This lightweight template is browser-storage oriented.
+- Solution: Deploy the Lobe Chat Database Version template for PostgreSQL-backed accounts and SSO.
+
+### Getting Help
+
+- [Official Documentation](https://lobehub.com/docs)
+- [Self-hosting Documentation](https://lobehub.com/docs/self-hosting/start)
+- [GitHub Issues](https://github.com/lobehub/lobe-chat/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [LobeHub Website](https://lobehub.com)
+- [Lobe Chat GitHub](https://github.com/lobehub/lobe-chat)
+- [Model Provider Environment Variables](https://lobehub.com/docs/self-hosting/environment-variables/model-provider)
+- [Access Code and Basic Variables](https://lobehub.com/docs/self-hosting/environment-variables/basic)
+
+## License
+
+This Sealos template is provided under the templates repository license. Lobe Chat itself is licensed under Apache-2.0.

--- a/template/lobe-chat/README_zh.md
+++ b/template/lobe-chat/README_zh.md
@@ -1,33 +1,122 @@
-# Lobe Chat
+# 在 Sealos 上部署和托管 Lobe Chat
 
-## 应用概览
+Lobe Chat 是一个开源 AI 聊天工作区，适用于 ChatGPT 兼容接口和多模型提供商工作流。此模板会在 Sealos Cloud 上部署轻量版 Lobe Chat，并提供公网 HTTPS 访问入口。
 
-Lobe Chat 是一款现代化设计的开源 ChatGPT/LLMs 聊天应用与开发框架，支持语音合成、多模态、可扩展的（function call）插件系统。
+## 关于 Lobe Chat 托管
 
-此 Sealos 模板会将 **Lobe Chat** 部署为 `lobe-chat` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Lobe Chat 以单个 Next.js 应用运行在 Sealos 上。模板通过 Sealos Ingress 暴露 Web UI，固定容器镜像版本，并为每次部署生成独立的认证密钥，确保内置会话 API 正常工作。
 
-## 在 Sealos 上部署
+此模板适合个人或团队快速使用，聊天数据可保存在浏览器中。如果需要服务端账号、云端同步、PostgreSQL、对象存储或外部身份登录，请使用单独的 Lobe Chat 数据库版模板。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **个人 AI 工作区**：用统一界面访问 OpenAI 兼容模型和自定义模型列表。
+- **团队演示环境**：通过可选访问码保护托管后的 Lobe Chat URL。
+- **模型网关前端**：将 `OPENAI_PROXY_URL` 指向 OpenAI 兼容网关或代理。
+- **提示词和 Agent 实验**：在托管 HTTPS 入口中测试助手、插件和多模态聊天界面。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## Lobe Chat 托管依赖
 
-## 配置说明
+此 Sealos 模板包含 Lobe Chat 应用容器、Kubernetes Deployment、Service、Ingress 和 App 快捷入口。轻量版不会自动创建 PostgreSQL、Redis 或对象存储。
 
-部署时可以配置以下用户可见输入项：
+### 部署依赖
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `ACCESS_CODE` | `ACCESS_CODE` 部署参数。 | `否` | `` |
-| `OPENAI_API_KEY` | `OPENAI_API_KEY` 部署参数。 | `否` | `<已隐藏>` |
-| `OPENAI_MODEL_LIST` | `OPENAI_MODEL_LIST` 部署参数。 | `否` | `` |
-| `OPENAI_PROXY_URL` | `OPENAI_PROXY_URL` 部署参数。 | `否` | `https://api.openai.com/v1` |
+- [Lobe Chat 文档](https://lobehub.com/docs) - 官方文档
+- [自托管指南](https://lobehub.com/docs/self-hosting/start) - 部署方式和配置说明
+- [Docker 镜像](https://hub.docker.com/r/lobehub/lobe-chat) - 已发布的容器标签
+- [GitHub 仓库](https://github.com/lobehub/lobe-chat) - 源码和问题反馈
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 实现细节
 
-## 官方链接
+**架构组件：**
 
-- 官方网站: https://github.com/lobehub/lobe-chat
-- 源码仓库: https://github.com/lobehub/lobe-chat
+此模板会部署以下资源：
+
+- **Lobe Chat Web 应用**：使用 `lobehub/lobe-chat:1.143.3` 镜像，在 `3210` 端口提供 Next.js 应用。
+- **Service**：集群内 ClusterIP 服务，将流量转发到应用 Pod。
+- **Ingress**：使用生成的 Sealos 域名提供公网 HTTPS 访问。
+- **App 快捷入口**：在 Sealos 控制台中打开已部署的 Lobe Chat URL。
+
+**配置：**
+
+- `OPENAI_API_KEY` 可预配置 OpenAI API Key，用户也可以在部署后从 UI 中配置模型提供商。
+- `OPENAI_PROXY_URL` 默认是 `https://api.openai.com/v1`，也可以指向任意兼容 API 网关。
+- `ACCESS_CODE` 为可选项。设置强访问码后，用户需要输入密码才能使用应用。
+- `OPENAI_MODEL_LIST` 可用于新增、隐藏或重命名可见模型 ID。
+
+**登录和注册：**
+
+此轻量版模板不会创建服务端用户账号，也不需要初始化注册。打开部署后的 URL，如配置了 `ACCESS_CODE`，先输入访问码，然后在 Lobe Chat 界面中添加或确认模型提供商设置。服务端邮箱密码注册和 SSO 属于数据库版能力。
+
+**许可证信息：**
+
+Lobe Chat 使用 Apache-2.0 许可证。此 Sealos 模板遵循模板仓库许可证。
+
+## 为什么在 Sealos 上部署 Lobe Chat？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，可以在统一控制台中管理部署、网络、扩缩容和运维。在 Sealos 上部署 Lobe Chat 可以获得：
+
+- **一键部署**：打开模板页面，填写少量参数，由 Sealos 创建 Kubernetes 资源。
+- **托管 HTTPS 访问**：每次部署都会获得公网 HTTPS URL，无需手动配置证书或 Ingress。
+- **资源控制**：当流量或模型使用方式变化时，可从 Canvas 调整 CPU 和内存。
+- **AI 辅助运维**：通过 Sealos AI 对话框或资源卡片更新环境变量和运行时设置。
+- **按量使用**：从已验证的基础资源开始，只在需要时扩容。
+
+## 部署指南
+
+1. 打开 [Lobe Chat 模板](https://sealos.io/products/app-store/lobe-chat)，点击 **Deploy Now**。
+2. 在弹窗中配置参数。直接使用 OpenAI 时填写 `OPENAI_API_KEY`；如需保护应用，设置 `ACCESS_CODE`。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas。后续如需修改配置，可在 AI 对话框中描述需求，或点击对应资源卡片调整设置。
+4. 通过提供的 URL 访问应用：
+   - **Lobe Chat Web UI**：打开生成的 Sealos URL，如配置了访问码则先输入访问码，然后开始配置模型提供商或聊天。
+
+## 配置
+
+部署后，你可以通过以下方式配置 Lobe Chat：
+
+- **AI 对话框**：描述需要变更的环境变量，例如模型列表或代理 URL。
+- **资源卡片**：打开 Deployment 资源卡片，编辑 CPU、内存、副本数或环境变量。
+- **Lobe Chat UI**：如果未通过模板输入预配置，可在应用设置中配置模型提供商凭据和聊天偏好。
+
+## 扩缩容
+
+此模板的验证基线为 `200m` CPU 和 `1024Mi` 内存（冷启动验证中 512Mi 不稳定），对应 requests 为 `20m` CPU 和 `102Mi` 内存。扩容步骤：
+
+1. 打开当前部署的 Canvas。
+2. 点击 Lobe Chat 的 Deployment 资源卡片。
+3. 如果并发用户、长会话或插件使用需要更多容量，提高 CPU 或内存。
+4. 应用变更并等待滚动更新完成。
+
+## 故障排查
+
+### 常见问题
+
+**应用可以打开，但模型调用失败**
+- 原因：`OPENAI_API_KEY`、`OPENAI_PROXY_URL` 或提供商设置缺失或无效。
+- 解决：更新模板输入，或在 Lobe Chat UI 中配置提供商凭据。
+
+**页面要求输入访问密码**
+- 原因：部署时配置了 `ACCESS_CODE`。
+- 解决：输入已配置的访问码，或在 Sealos Canvas 中修改 Deployment 环境变量。
+
+**需要服务端登录或注册**
+- 原因：此轻量版模板主要使用浏览器存储。
+- 解决：部署 Lobe Chat 数据库版模板，以使用 PostgreSQL 支持的账号和 SSO。
+
+### 获取帮助
+
+- [官方文档](https://lobehub.com/docs)
+- [自托管文档](https://lobehub.com/docs/self-hosting/start)
+- [GitHub Issues](https://github.com/lobehub/lobe-chat/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [LobeHub 官网](https://lobehub.com)
+- [Lobe Chat GitHub](https://github.com/lobehub/lobe-chat)
+- [模型提供商环境变量](https://lobehub.com/docs/self-hosting/environment-variables/model-provider)
+- [访问码和基础变量](https://lobehub.com/docs/self-hosting/environment-variables/basic)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库许可证。Lobe Chat 本身使用 Apache-2.0 许可证。

--- a/template/lobe-chat/index.yaml
+++ b/template/lobe-chat/index.yaml
@@ -27,6 +27,9 @@ spec:
     app_host:
       type: string
       value: ${{ random(8) }}
+    auth_secret:
+      type: string
+      value: ${{ random(64) }}
   inputs:
     OPENAI_API_KEY:
       description: "This is the API key you apply on the OpenAI account page"
@@ -55,7 +58,8 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: lobehub/lobe-chat:1.143.2
+    originImageName: lobehub/lobe-chat:1.143.3
+    docker-to-sealos.resource-override-source: "README.md#Scaling: cold-start validation found 512Mi unstable; 1024Mi is the tested baseline"
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -80,7 +84,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: lobehub/lobe-chat:1.143.2
+          image: lobehub/lobe-chat:1.143.3
           env:
             - name: OPENAI_API_KEY
               value: ${{ inputs.OPENAI_API_KEY }}
@@ -90,17 +94,45 @@ spec:
               value: ${{ inputs.ACCESS_CODE }}
             - name: OPENAI_MODEL_LIST
               value: ${{ inputs.OPENAI_MODEL_LIST }}
+            - name: AUTH_SECRET
+              value: ${{ defaults.auth_secret }}
+            - name: NEXT_AUTH_SECRET
+              value: ${{ defaults.auth_secret }}
           resources:
             requests:
-              cpu: 50m
+              cpu: 20m
               memory: 102Mi
             limits:
-              cpu: 500m
+              cpu: 200m
               memory: 1024Mi
           command: []
           args: []
           ports:
             - containerPort: 3210
+          startupProbe:
+            httpGet:
+              path: /
+              port: 3210
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3210
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3210
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           imagePullPolicy: IfNotPresent
           volumeMounts: []
       volumes: []
@@ -112,9 +144,11 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 3210
+    - name: http
+      port: 3210
   selector:
     app: ${{ defaults.app_name }}
 
@@ -132,7 +166,7 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 64k;
       large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
@@ -159,3 +193,18 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
+
+---
+apiVersion: app.sealos.io/v1
+kind: App
+metadata:
+  name: ${{ defaults.app_name }}
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  data:
+    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+  displayType: normal
+  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/lobe-chat/logo.png"
+  name: "Lobe Chat"
+  type: link

--- a/template/logto/README.md
+++ b/template/logto/README.md
@@ -1,28 +1,46 @@
-# Logto
+# Deploy and Host Logto on Sealos
 
-## Overview
+[Logto](https://logto.io/) is an open-source identity platform for modern applications. It provides sign-in and sign-up experiences, user management, OIDC/OAuth 2.0, SAML, multi-tenancy, and authorization from a self-hosted control plane.
 
-Logto is an open-source Identity and Access Management (IAM) platform designed to streamline Customer Identity and Access Management (CIAM) and Workforce Identity Management.
+## What You Get
 
-This Sealos template deploys **Logto** as the `logto` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+- Logto `1.40.1` running from the fixed `svhd/logto:1.40.1` image.
+- A dedicated PostgreSQL database created and initialized by the template.
+- Two public HTTPS endpoints: one for application authentication traffic and one for the Admin Console.
+- Automatic database creation, seed, and alteration deployment during first startup.
+
+## Requirements
+
+- A [Sealos](https://sealos.io/) account.
+- No external database is required; this template provisions PostgreSQL for you.
 
 ## Deploy on Sealos
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+1. Open the [Logto template on Sealos](https://sealos.io/products/app-store/logto).
+2. Click **Deploy Now** and keep the generated app name and domain, or customize them before deployment.
+3. Wait until the Logto app and PostgreSQL database are both running.
+4. Open the Admin Console URL shown in the Sealos app details.
 
-## Access
+## First Registration and Login
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+Logto exposes two URLs:
 
-## Configuration
+- **Admin Console**: `https://${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}`
+- **Core/Auth endpoint**: `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`
 
-The following user-facing inputs are available during deployment:
+On the first launch, open the **Admin Console** URL. The welcome page lets you click **Create account** to create the initial administrator account with a username and password. The open-source edition allows this initial account creation only once. After the administrator account is created, return to the Admin Console and use **Sign in**.
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+Use the **Core/Auth endpoint** as the issuer and redirect target base when connecting your own applications to Logto through OIDC/OAuth.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Post-Deployment Checklist
 
-## Official Links
+- Create the first administrator account from the Admin Console.
+- Configure your application redirect URIs in Logto.
+- Keep both the Core/Auth endpoint and Admin Console endpoint on HTTPS.
+- Review Logto's official documentation before enabling production identity flows.
 
-- Official website: https://logto.io/
-- Source repository: https://github.com/logto-io/logto
+## References
+
+- [Logto documentation](https://docs.logto.io/)
+- [Logto GitHub repository](https://github.com/logto-io/logto)
+- [Sealos documentation](https://sealos.io/docs/)

--- a/template/logto/README_zh.md
+++ b/template/logto/README_zh.md
@@ -1,28 +1,46 @@
-# Logto
+# 在 Sealos 上部署和托管 Logto
 
-## 应用概览
+[Logto](https://logto.io/) 是一个开源身份平台，适合为现代应用构建登录注册、用户管理、OIDC/OAuth 2.0、SAML、多租户和授权能力。
 
-Logto 是一个开源的 身份与访问管理（IAM）平台，是 Auth0 的开源替代方案，旨在帮助开发者快速构建安全、可扩展的登录注册系统和用户身份体系。
+## 模板内容
 
-此 Sealos 模板会将 **Logto** 部署为 `logto` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+- 使用固定镜像 `svhd/logto:1.40.1` 部署 Logto `1.40.1`。
+- 自动创建并初始化专用 PostgreSQL 数据库。
+- 提供两个公开 HTTPS 地址：一个用于应用认证流量，一个用于 Admin Console。
+- 首次启动时自动创建数据库、写入种子数据并执行数据库变更。
+
+## 使用要求
+
+- 一个 [Sealos](https://sealos.io/) 账号。
+- 不需要外部数据库；模板会自动创建 PostgreSQL。
 
 ## 在 Sealos 上部署
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+1. 打开 [Sealos Logto 模板](https://sealos.io/products/app-store/logto)。
+2. 点击 **Deploy Now**，可以使用自动生成的应用名和域名，也可以在部署前自定义。
+3. 等待 Logto 应用和 PostgreSQL 数据库都进入运行状态。
+4. 在 Sealos 应用详情中打开 Admin Console 地址。
 
-## 访问方式
+## 首次注册与登录
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+Logto 会提供两个地址：
 
-## 配置说明
+- **Admin Console**：`https://${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}`
+- **Core/Auth 端点**：`https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`
 
-部署时可以配置以下用户可见输入项：
+首次启动后，请打开 **Admin Console** 地址。欢迎页会显示 **Create account** 入口，可用用户名和密码创建初始管理员账号。开源版只允许创建一次初始管理员账号；创建完成后，再回到 Admin Console 使用 **Sign in** 登录。
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+将 **Core/Auth 端点** 作为连接业务应用时的 issuer 和重定向地址基础域名，用于 OIDC/OAuth 登录流程。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+## 部署后检查
 
-## 官方链接
+- 在 Admin Console 创建第一个管理员账号。
+- 在 Logto 中配置业务应用的 redirect URI。
+- 确认 Core/Auth 端点和 Admin Console 端点都使用 HTTPS。
+- 在启用生产身份流程前，先阅读 Logto 官方文档。
 
-- 官方网站: https://logto.io/
-- 源码仓库: https://github.com/logto-io/logto
+## 参考链接
+
+- [Logto 文档](https://docs.logto.io/)
+- [Logto GitHub 仓库](https://github.com/logto-io/logto)
+- [Sealos 文档](https://sealos.io/docs/)

--- a/template/logto/index.yaml
+++ b/template/logto/index.yaml
@@ -7,24 +7,21 @@ spec:
   url: 'https://logto.io/'
   gitRepo: 'https://github.com/logto-io/logto'
   author: 'Sealos'
-  description: 'Logto is an open-source Identity and Access Management (IAM) platform designed to streamline Customer Identity and Access Management (CIAM) and Workforce Identity Management.'
+  description: 'Logto is an open-source identity platform for building sign-in, user management, OIDC/OAuth, SAML, multi-tenancy, and authorization into modern applications.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/logo.png'
   screenshots:
     - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/website-screenshot.webp'
-
   templateType: inline
   locale: en
   i18n:
     zh:
-      title: 'Logto'
-      description: 'Logto 是一个开源的 身份与访问管理（IAM）平台，是 Auth0 的开源替代方案，旨在帮助开发者快速构建安全、可扩展的登录注册系统和用户身份体系。'
+      description: 'Logto 是一个开源身份平台，可为现代应用构建登录注册、用户管理、OIDC/OAuth、SAML、多租户和授权能力。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/README_zh.md'
   categories:
     - tool
   defaults:
     app_host:
-      # number or string..
       type: string
       value: logto-${{ random(8) }}
     app_name:
@@ -39,54 +36,6 @@ metadata:
     app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
     app.kubernetes.io/managed-by: kbcli
   name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: Cluster
-metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
-spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -103,7 +52,6 @@ rules:
       - '*'
     verbs:
       - '*'
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -120,7 +68,49 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ${{ defaults.app_name }}-pg
-
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-16.4.0
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
+      replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 51Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
 ---
 apiVersion: batch/v1
 kind: Job
@@ -128,41 +118,70 @@ metadata:
   name: ${{ defaults.app_name }}-pg-init
 spec:
   completions: 1
+  backoffLimit: 5
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
-        - name: pgsql-init
-          image: senzing/postgresql-client:2.2.4
+        - name: pg-init
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_DATABASE
+              value: logto
+            - name: PGPASSWORD
+              value: $(PG_PASSWORD)
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE logto;' &>/dev/null; do sleep 1; done
-              until psql ${DATABASE_URL}/logto -c 'UPDATE sign_in_experiences SET password_policy='\''{"rejects": {"pwned": false}}'\'' WHERE tenant_id='\''admin'\'';' &>/dev/null; do sleep 1; done
+              until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; do
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='logto'" | grep -q 1; then
+                psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "logto";'
+              fi
       restartPolicy: Never
-  backoffLimit: 0
   ttlSecondsAfterFinished: 300
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: svhd/logto:1.24
+    originImageName: svhd/logto:1.40.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -180,58 +199,138 @@ spec:
         app: ${{ defaults.app_name }}
     spec:
       automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}
-          image: svhd/logto:1.24
-          command: ["sh", "-c", "npm run cli db seed -- --swe && npm start"]
+      initContainers:
+        - name: db-seed
+          image: svhd/logto:1.40.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              for i in $(seq 1 90); do
+                if npm run cli db seed -- --swe; then
+                  npm run alteration deploy latest
+                  exit 0
+                fi
+                sleep 2
+              done
+              npm run cli db seed -- --swe
+              npm run alteration deploy latest
           env:
-            - name: TRUST_PROXY_HEADER
-              value: "1"
-            - name: DATABASE_PORT
+            - name: CI
+              value: 'true'
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: port
-            - name: DATABASE_USER
+            - name: PG_USER
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: username
-            - name: DATABASE_PASSWORD
+            - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
             - name: DB_URL
-              value: "postgres://$(DATABASE_USER):$(DATABASE_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:$(DATABASE_PORT)/logto"
+              value: postgres://$(PG_USER):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/logto
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      containers:
+        - name: ${{ defaults.app_name }}
+          image: svhd/logto:1.40.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              npm start
+          env:
+            - name: CI
+              value: 'true'
+            - name: TRUST_PROXY_HEADER
+              value: '1'
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: DB_URL
+              value: postgres://$(PG_USER):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/logto
             - name: ENDPOINT
               value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
             - name: ADMIN_ENDPOINT
               value: https://${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 25Mi
-            limits:
-              cpu: 1000m
-              memory: 256Mi
-          readinessProbe:
-            failureThreshold: 30
+          ports:
+            - name: http
+              containerPort: 3001
+            - name: admin
+              containerPort: 3002
+          startupProbe:
             httpGet:
-              path: /
+              path: /status
               port: 3001
               scheme: HTTP
+            failureThreshold: 36
+            periodSeconds: 5
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 3001
+              scheme: HTTP
+            failureThreshold: 6
             periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          imagePullPolicy: IfNotPresent
-
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 3001
+              scheme: HTTP
+            failureThreshold: 6
+            periodSeconds: 30
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
@@ -243,13 +342,13 @@ spec:
       port: 3002
   selector:
     app: ${{ defaults.app_name }}
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
@@ -281,38 +380,6 @@ spec:
                 name: ${{ defaults.app_name }}
                 port:
                   number: 3001
-  tls:
-    - hosts:
-        - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
-      secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ${{ defaults.app_name }}-admin
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}-admin
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/proxy-body-size: 32m
-    nginx.ingress.kubernetes.io/server-snippet: |
-      client_header_buffer_size 64k;
-      large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
-    nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
-    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
-    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
-        expires 30d;
-        add_header Cache-Control "public";
-      }
-spec:
-  rules:
     - host: ${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
       http:
         paths:
@@ -325,9 +392,9 @@ spec:
                   number: 3002
   tls:
     - hosts:
+        - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
         - ${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -339,6 +406,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/logo.png"
-  name: "Logto"
+  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/logto/logo.png'
+  name: 'Logto'
   type: link

--- a/template/loki/README.md
+++ b/template/loki/README.md
@@ -1,28 +1,134 @@
-# Loki
+# Deploy and Host Loki on Sealos
 
-## Overview
+Loki is Grafana's open source log aggregation system designed to store and query logs with Prometheus-style labels. This template deploys a single-node Loki instance with persistent storage and a public HTTPS endpoint on Sealos Cloud.
 
-Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus.
+## About Hosting Loki
 
-This Sealos template deploys **Loki** as the `loki` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Loki stores compressed log streams and indexes metadata labels instead of full log text, which keeps ingestion lightweight for application and infrastructure logs. The Sealos template runs Loki as a StatefulSet, persists `/loki` data on a 1 GiB volume, and exposes the HTTP API on port `3100`.
 
-## Deploy on Sealos
+This deployment is suitable for development, testing, small observability stacks, and lightweight log collection. It does not include Grafana or a log shipper, so you can connect Grafana, Promtail, Grafana Alloy, or compatible clients after deployment.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Application Log Collection**: Store logs from apps, workers, and services using Loki's push API.
+- **Grafana Log Exploration**: Add the Loki endpoint as a Grafana data source and query logs with LogQL.
+- **Lightweight DevOps Monitoring**: Keep a small persistent log backend for development and staging environments.
+- **Troubleshooting Pipelines**: Send CI, job, or batch logs into a searchable backend.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for Loki Hosting
+
+The Sealos template includes all runtime dependencies required to start Loki: the official Loki container image, a Kubernetes StatefulSet, a ClusterIP Service, an Ingress, and persistent storage.
+
+### Deployment Dependencies
+
+- [Loki Documentation](https://grafana.com/docs/loki/latest/) - Official Loki documentation
+- [Loki HTTP API](https://grafana.com/docs/loki/latest/reference/loki-http-api/) - API reference for readiness, ingestion, and queries
+- [LogQL Documentation](https://grafana.com/docs/loki/latest/query/) - Query language reference
+- [Grafana Loki GitHub](https://github.com/grafana/loki) - Source code and releases
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Loki StatefulSet**: Runs `docker.io/grafana/loki:3.7.2` with the built-in local filesystem configuration.
+- **Persistent Volume**: Mounts `/loki` for chunks, indexes, and rule data.
+- **Service**: Exposes Loki internally on port `3100`.
+- **Ingress and App Entry**: Provides an HTTPS endpoint for the Loki HTTP API.
+
+**Configuration:**
+
+Loki starts with its default single-binary local configuration. Authentication is disabled by the upstream local config, so protect the endpoint according to your workspace and network policy before sending sensitive logs. The template does not create users, passwords, or an initialization flow.
+
+**License Information:**
+
+Loki is licensed under the GNU Affero General Public License v3.0. This Sealos template is provided under the license terms of the templates repository.
+
+## Why Deploy Loki on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, networking, storage, and operations. By deploying Loki on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Loki from the App Store without writing Kubernetes YAML.
+- **Persistent Storage Included**: Keep log data across restarts with a managed persistent volume.
+- **Instant Public Access**: Use the generated HTTPS endpoint for API clients and Grafana data source configuration.
+- **Resource Controls**: Adjust CPU, memory, and storage from the Sealos Canvas when your log volume grows.
+- **Kubernetes-Based Operations**: Run Loki on a managed Kubernetes foundation without managing cluster primitives directly.
+
+## Deployment Guide
+
+1. Open the [Loki template](https://sealos.io/products/app-store/loki) and click **Deploy Now**.
+2. Keep the default parameters or adjust the generated app name and host in the popup dialog.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the StatefulSet, Service, Ingress, or storage resource cards to modify settings.
+4. Access Loki through the generated URL:
+   - **Readiness Check**: `https://[your-loki-url]/ready`
+   - **Build Info**: `https://[your-loki-url]/loki/api/v1/status/buildinfo`
+   - **Push API**: `https://[your-loki-url]/loki/api/v1/push`
+   - **Query API**: `https://[your-loki-url]/loki/api/v1/query_range`
+
+## API Access
+
+Loki does not provide a standalone web UI in this template. Use its HTTP API or connect the generated URL to Grafana as a Loki data source.
+
+Example API checks:
+
+```bash
+curl https://[your-loki-url]/ready
+curl https://[your-loki-url]/loki/api/v1/status/buildinfo
+```
+
+Example log ingestion:
+
+```bash
+NOW=$(date +%s)000000000
+curl -X POST "https://[your-loki-url]/loki/api/v1/push" \
+  -H 'Content-Type: application/json' \
+  --data "{\"streams\":[{\"stream\":{\"job\":\"demo\"},\"values\":[[\"$NOW\",\"hello from Sealos Loki\"]]}]}"
+```
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Loki through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AI Dialog**: Describe resource or runtime changes and let Sealos apply updates.
+- **Resource Cards**: Click the StatefulSet, Service, Ingress, or storage cards in Canvas.
+- **Client Configuration**: Point Grafana, Promtail, Grafana Alloy, or compatible clients to the generated HTTPS endpoint.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+This template is a single-node Loki deployment intended for lightweight workloads. To scale resources:
 
-- Official website: https://grafana.com/oss/loki/
-- Source repository: https://github.com/grafana/loki
+1. Open the Canvas for your deployment.
+2. Click the Loki StatefulSet resource card.
+3. Adjust CPU, memory, or storage according to ingestion volume.
+4. Apply the changes and wait for the pod to become ready.
+
+For high-volume or highly available production logging, use Loki's distributed deployment mode and object storage architecture instead of this single-node template.
+
+## Troubleshooting
+
+### Loki endpoint returns no log results
+
+- Cause: Loki has no ingested streams matching your LogQL query, or the query time range is too narrow.
+- Solution: Push a test log through `/loki/api/v1/push`, then query with `/loki/api/v1/query_range` and a label selector such as `{job="demo"}`.
+
+### Grafana cannot connect
+
+- Cause: The data source URL may be wrong or the Loki pod may still be starting.
+- Solution: Confirm `https://[your-loki-url]/ready` returns `ready`, then use the generated HTTPS URL as the Grafana Loki data source URL.
+
+### Pod restarts during heavy ingestion
+
+- Cause: The default template resources target a lightweight deployment.
+- Solution: Increase CPU and memory from the StatefulSet resource card, then retry ingestion.
+
+## Additional Resources
+
+- [Loki Documentation](https://grafana.com/docs/loki/latest/)
+- [Loki HTTP API](https://grafana.com/docs/loki/latest/reference/loki-http-api/)
+- [LogQL Query Reference](https://grafana.com/docs/loki/latest/query/)
+- [Grafana Data Source Setup](https://grafana.com/docs/grafana/latest/datasources/loki/)
+
+## License
+
+This Sealos template is provided under the license terms of the templates repository. Loki is licensed under the GNU Affero General Public License v3.0.

--- a/template/loki/README_zh.md
+++ b/template/loki/README_zh.md
@@ -1,28 +1,134 @@
-# Loki
+# 在 Sealos 上部署和托管 Loki
 
-## 应用概览
+Loki 是 Grafana 开源的日志聚合系统，用 Prometheus 风格的标签存储和查询日志。此模板会在 Sealos Cloud 上部署一个带持久化存储和公网 HTTPS 入口的单节点 Loki 实例。
 
-Loki 是一个水平可扩展、高可用、多租户的日志聚合系统，灵感来自 Prometheus。
+## 关于 Loki 托管
 
-此 Sealos 模板会将 **Loki** 部署为 `loki` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Loki 存储压缩后的日志流，并只索引元数据标签，而不是索引完整日志文本，因此适合轻量级应用和基础设施日志采集。Sealos 模板会以 StatefulSet 运行 Loki，将 `/loki` 数据持久化到 1 GiB 存储卷，并通过 `3100` 端口暴露 HTTP API。
 
-## 在 Sealos 上部署
+此部署适用于开发、测试、小型可观测性栈和轻量日志采集场景。模板不包含 Grafana 或日志采集器，部署后可以自行连接 Grafana、Promtail、Grafana Alloy 或其他兼容客户端。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **应用日志采集**：通过 Loki push API 存储应用、Worker 和服务日志。
+- **Grafana 日志检索**：将 Loki 入口添加为 Grafana 数据源，并使用 LogQL 查询日志。
+- **轻量 DevOps 监控**：为开发和预发环境保留一个小型持久化日志后端。
+- **排障流水线**：将 CI、Job 或批处理日志发送到可搜索的后端。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## Loki 托管依赖
+
+Sealos 模板包含启动 Loki 所需的运行时依赖：官方 Loki 容器镜像、Kubernetes StatefulSet、ClusterIP Service、Ingress 和持久化存储。
+
+### 部署依赖
+
+- [Loki 文档](https://grafana.com/docs/loki/latest/) - 官方 Loki 文档
+- [Loki HTTP API](https://grafana.com/docs/loki/latest/reference/loki-http-api/) - readiness、写入和查询 API 参考
+- [LogQL 文档](https://grafana.com/docs/loki/latest/query/) - 查询语言参考
+- [Grafana Loki GitHub](https://github.com/grafana/loki) - 源代码和版本发布
+
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下资源：
+
+- **Loki StatefulSet**：运行 `docker.io/grafana/loki:3.7.2`，使用内置本地文件系统配置。
+- **持久化存储卷**：挂载 `/loki`，用于保存 chunks、索引和规则数据。
+- **Service**：在集群内通过 `3100` 端口暴露 Loki。
+- **Ingress 与应用入口**：提供 Loki HTTP API 的 HTTPS 访问地址。
+
+**配置说明：**
+
+Loki 使用默认 single-binary 本地配置启动。上游本地配置默认关闭认证，因此在发送敏感日志前，应根据你的工作区和网络策略保护入口。模板不会创建用户、密码或初始化流程。
+
+**许可证信息：**
+
+Loki 使用 GNU Affero General Public License v3.0 许可证。此 Sealos 模板遵循模板仓库的许可证条款。
+
+## 为什么在 Sealos 上部署 Loki？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用部署、网络、存储和运维能力。在 Sealos 上部署 Loki，你可以获得：
+
+- **一键部署**：从应用商店部署 Loki，无需手写 Kubernetes YAML。
+- **内置持久化存储**：通过托管持久卷在重启后保留日志数据。
+- **即时公网访问**：使用自动生成的 HTTPS 入口配置 API 客户端和 Grafana 数据源。
+- **资源可控**：当日志量增长时，可在 Sealos Canvas 中调整 CPU、内存和存储。
+- **Kubernetes 运维基础**：无需直接管理集群底层资源，也能运行在托管 Kubernetes 基础之上。
+
+## 部署指南
+
+1. 打开 [Loki 模板](https://sealos.io/products/app-store/loki)，点击 **Deploy Now**。
+2. 保留默认参数，或在弹窗中调整生成的应用名称和访问域名。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas。后续如需修改，可在 AI 对话框中描述需求，或点击 StatefulSet、Service、Ingress、存储等资源卡片调整配置。
+4. 通过生成的 URL 访问 Loki：
+   - **就绪检查**：`https://[your-loki-url]/ready`
+   - **构建信息**：`https://[your-loki-url]/loki/api/v1/status/buildinfo`
+   - **写入 API**：`https://[your-loki-url]/loki/api/v1/push`
+   - **查询 API**：`https://[your-loki-url]/loki/api/v1/query_range`
+
+## API 访问方式
+
+此模板中的 Loki 不提供独立 Web UI。请使用 HTTP API，或将生成的 URL 连接到 Grafana 作为 Loki 数据源。
+
+API 检查示例：
+
+```bash
+curl https://[your-loki-url]/ready
+curl https://[your-loki-url]/loki/api/v1/status/buildinfo
+```
+
+日志写入示例：
+
+```bash
+NOW=$(date +%s)000000000
+curl -X POST "https://[your-loki-url]/loki/api/v1/push" \
+  -H 'Content-Type: application/json' \
+  --data "{\"streams\":[{\"stream\":{\"job\":\"demo\"},\"values\":[[\"$NOW\",\"hello from Sealos Loki\"]]}]}"
+```
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+部署后，你可以通过以下方式配置 Loki：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- **AI 对话框**：描述资源或运行时配置调整，让 Sealos 应用变更。
+- **资源卡片**：在 Canvas 中点击 StatefulSet、Service、Ingress 或存储资源卡片。
+- **客户端配置**：将 Grafana、Promtail、Grafana Alloy 或兼容客户端指向生成的 HTTPS 入口。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+## 扩缩容
 
-## 官方链接
+此模板是面向轻量负载的单节点 Loki 部署。调整资源时：
 
-- 官方网站: https://grafana.com/oss/loki/
-- 源码仓库: https://github.com/grafana/loki
+1. 打开当前部署的 Canvas。
+2. 点击 Loki StatefulSet 资源卡片。
+3. 根据日志写入量调整 CPU、内存或存储。
+4. 应用变更并等待 Pod 重新就绪。
+
+如果需要高吞吐或高可用生产日志系统，请使用 Loki 分布式部署模式和对象存储架构，而不是此单节点模板。
+
+## 故障排查
+
+### Loki 查询没有返回日志
+
+- 原因：Loki 中没有匹配 LogQL 查询的日志流，或查询时间范围过窄。
+- 解决：先通过 `/loki/api/v1/push` 写入测试日志，再用 `/loki/api/v1/query_range` 和 `{job="demo"}` 这类标签选择器查询。
+
+### Grafana 无法连接
+
+- 原因：数据源 URL 配置错误，或 Loki Pod 仍在启动。
+- 解决：确认 `https://[your-loki-url]/ready` 返回 `ready`，然后将生成的 HTTPS URL 填入 Grafana Loki 数据源。
+
+### 高写入量时 Pod 重启
+
+- 原因：默认模板资源面向轻量部署。
+- 解决：在 StatefulSet 资源卡片中提高 CPU 和内存后，再重试日志写入。
+
+## 其他资源
+
+- [Loki 文档](https://grafana.com/docs/loki/latest/)
+- [Loki HTTP API](https://grafana.com/docs/loki/latest/reference/loki-http-api/)
+- [LogQL 查询参考](https://grafana.com/docs/loki/latest/query/)
+- [Grafana 数据源配置](https://grafana.com/docs/grafana/latest/datasources/loki/)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库的许可证条款。Loki 使用 GNU Affero General Public License v3.0 许可证。

--- a/template/loki/index.yaml
+++ b/template/loki/index.yaml
@@ -16,7 +16,6 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Loki'
       description: 'Loki 是一个水平可扩展、高可用、多租户的日志聚合系统，灵感来自 Prometheus。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/loki/README_zh.md'
   categories:
@@ -34,7 +33,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: grafana/loki:main-515ebea
+    originImageName: docker.io/grafana/loki:3.7.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -54,36 +53,64 @@ spec:
     spec:
       automountServiceAccountToken: false
       initContainers:
-        - name: init-chmod
-          image: busybox:latest
+        - name: init-loki-data
+          image: busybox:1.37.0
           imagePullPolicy: IfNotPresent
           command:
             - sh
-            - -c
+            - -ec
             - |
+              mkdir -p /loki/chunks /loki/rules
               chown -R 10001:10001 /loki
-              chmod -R 755 /loki
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
           volumeMounts:
             - name: vn-loki
               mountPath: /loki
       containers:
         - name: ${{ defaults.app_name }}
-          image: grafana/loki:main-515ebea
+          image: docker.io/grafana/loki:3.7.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3100
               name: http-metrics
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            failureThreshold: 24
+            periodSeconds: 5
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            failureThreshold: 6
+            periodSeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: vn-loki
               mountPath: /loki
           resources:
             requests:
-              cpu: 10m
-              memory: 12Mi
+              cpu: 20m
+              memory: 25Mi
             limits:
-              cpu: 100m
-              memory: 128Mi
+              cpu: 200m
+              memory: 256Mi
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -104,6 +131,7 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
   ports:
@@ -163,6 +191,7 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}

--- a/template/mage-ai/README.md
+++ b/template/mage-ai/README.md
@@ -6,7 +6,7 @@ Mage AI is an open-source data pipeline tool for building and running data workf
 
 Mage AI provides a notebook-style environment to build, schedule, and monitor data pipelines. The template provisions a dedicated PostgreSQL cluster for metadata and a persistent volume for project files at `/home/src`.
 
-The deployment includes a public HTTPS endpoint via Ingress, automatic SSL certificates, and managed networking on Sealos. You can manage resources and environment variables through the App Launchpad without touching YAML.
+The deployment includes a public HTTPS endpoint via Ingress, automatic SSL certificates, and managed networking on Sealos. You can manage resources and environment variables through the Canvas without touching YAML.
 
 ## Common Use Cases
 
@@ -25,7 +25,7 @@ The Sealos template includes all required dependencies: Mage AI runtime, Postgre
 - [Mage AI Documentation](https://docs.mage.ai/) - Official documentation and guides
 - [Mage AI GitHub Repository](https://github.com/mage-ai/mage-ai) - Source code and releases
 - [Mage AI GitHub Issues](https://github.com/mage-ai/mage-ai/issues) - Community support and issue tracking
-- [Sealos Cloud](https://sealos.io) - Deployment platform and App Launchpad
+- [Sealos Cloud](https://sealos.io) - Deployment platform and Canvas
 
 ### Implementation Details
 
@@ -43,11 +43,11 @@ This template deploys the following services:
 
 - **Admin Credentials**: Set `DEFAULT_OWNER_EMAIL` and `DEFAULT_OWNER_PASSWORD` during deployment
 - **Database**: Connection details are injected automatically; database name is `mage`
-- **Connection URL**: `MAGE_DATABASE_CONNECTION_URL` is assembled from the PostgreSQL credentials
+- **Connection URL**: Mage builds its PostgreSQL URL from `DB_USER`, `DB_PASS`, `DB_HOST`, `DB_PORT`, and `DB_NAME`
 
 **License Information:**
 
-Mage AI is licensed under its upstream open-source license. See the Mage AI GitHub repository for details.
+Mage AI is licensed under the Apache License 2.0. See the Mage AI GitHub repository for details.
 
 ## Why Deploy Mage AI on Sealos?
 
@@ -55,7 +55,7 @@ Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies
 
 - **One-Click Deployment**: Launch Mage AI with PostgreSQL and storage in minutes
 - **Auto-Scaling Built-In**: Adjust resources as workload grows without manual orchestration
-- **Easy Customization**: Configure environment variables and storage in the App Launchpad
+- **Easy Customization**: Configure environment variables and storage in the Canvas
 - **Zero Kubernetes Expertise Required**: Managed Kubernetes benefits without the complexity
 - **Persistent Storage Included**: Data and projects survive restarts with built-in volumes
 - **Instant Public Access**: Automatic HTTPS endpoint with SSL certificates
@@ -70,9 +70,9 @@ Deploy Mage AI on Sealos and focus on building data workflows instead of managin
 3. Configure the parameters in the popup dialog:
    - **Default Owner Email**: Admin login email
    - **Default Owner Password**: Admin login password
-4. Wait for deployment to complete (typically 0-1 minutes). After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Wait for deployment to complete (typically 2-4 minutes). After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
 5. Access your Mage AI instance via the provided URLs:
-   - **Mage AI Web UI**: Log in with your default owner credentials
+   - **Mage AI Web UI**: open the provided URL or `/sign-in`, then log in with your default owner credentials. Mage AI creates this owner account automatically during the first startup; no separate registration step is required.
 
 ## Configuration
 
@@ -80,14 +80,14 @@ After deployment, you can configure Mage AI through:
 
 - **AI Dialog**: Describe the changes you want and let AI apply updates directly
 - **Resource Cards**: Click the relevant resource cards to modify settings
-- **Web UI**: Log in at the provided URL using the default owner credentials
+- **Web UI**: Log in at the provided URL or `/sign-in` using the default owner credentials. Self-registration is not required for the initial owner account.
 - **Storage**: Projects are stored in `/home/src` on a persistent volume
 
 ## Scaling
 
 This template runs a single Mage AI replica by default. To scale resources:
 
-1. Open App Launchpad in Sealos
+1. Open Canvas in Sealos
 2. Select your Mage AI deployment
 3. Adjust CPU/Memory limits and click "Update"
 
@@ -97,7 +97,7 @@ This template runs a single Mage AI replica by default. To scale resources:
 
 **Issue: Cannot log in to Mage AI**
 - Cause: Incorrect default owner email or password
-- Solution: Verify credentials in the deployment configuration and update in App Launchpad if needed
+- Solution: Verify credentials in the deployment configuration and update in Canvas if needed
 
 **Issue: Database connection failed**
 - Cause: PostgreSQL is still initializing or the init job has not completed
@@ -119,4 +119,4 @@ This template runs a single Mage AI replica by default. To scale resources:
 
 ## License
 
-This Sealos template follows the repository licensing terms. Mage AI itself is licensed under its upstream license; see the Mage AI GitHub repository for details.
+This Sealos template follows the repository licensing terms. Mage AI itself is licensed under the Apache License 2.0; see the Mage AI GitHub repository for details.

--- a/template/mage-ai/README_zh.md
+++ b/template/mage-ai/README_zh.md
@@ -6,7 +6,7 @@ Mage AI 是一个开源的数据管道工具，用于构建和运行数据工作
 
 Mage AI 提供类似笔记本的交互环境，用于构建、调度和监控数据管道。该模板自动配置专用的 PostgreSQL 集群用于存储元数据，并为 `/home/src` 路径提供持久化卷来存放项目文件。
 
-部署完成后，系统会自动配置公网 HTTPS 入口、SSL 证书自动签发以及网络管理，无需触碰任何 YAML 配置。你可以直接在 App Launchpad 中管理资源和环境变量。
+部署完成后，系统会自动配置公网 HTTPS 入口、SSL 证书自动签发以及网络管理，无需触碰任何 YAML 配置。你可以直接在 Canvas 中管理资源和环境变量。
 
 ## 常见应用场景
 
@@ -25,7 +25,7 @@ Sealos 模板已包含所有必需的依赖：Mage AI 运行时、PostgreSQL 数
 - [Mage AI 官方文档](https://docs.mage.ai/)——权威文档和使用指南
 - [Mage AI GitHub 仓库](https://github.com/mage-ai/mage-ai)——源代码和版本发布
 - [Mage AI GitHub 议题](https://github.com/mage-ai/mage-ai/issues)——社区支持和问题跟踪
-- [Sealos 云平台](https://sealos.run)——部署平台和应用启动器
+- [Sealos 云平台](https://sealos.io)——部署平台和应用启动器
 
 ### 实现细节
 
@@ -43,11 +43,11 @@ Sealos 模板已包含所有必需的依赖：Mage AI 运行时、PostgreSQL 数
 
 - **管理员凭据**——部署时设置 `DEFAULT_OWNER_EMAIL` 和 `DEFAULT_OWNER_PASSWORD`
 - **数据库**——连接详情自动注入，数据库名称为 `mage`
-- **连接字符串**——`MAGE_DATABASE_CONNECTION_URL` 会根据 PostgreSQL 凭据自动组装
+- **连接字符串**——Mage 会根据 `DB_USER`、`DB_PASS`、`DB_HOST`、`DB_PORT` 和 `DB_NAME` 组装 PostgreSQL 连接字符串
 
 **许可证信息：**
 
-Mage AI 遵循其上游开源许可证。详情请查看 Mage AI GitHub 仓库。
+Mage AI 使用 Apache License 2.0 许可。详情请查看 Mage AI GitHub 仓库。
 
 ## 为何选择在 Sealos 上部署 Mage AI？
 
@@ -55,7 +55,7 @@ Sealos 是一个基于 Kubernetes 的云操作系统，通过 AI 辅助实现了
 
 - **一键部署**——几分钟内即可启动包含 PostgreSQL 和存储的 Mage AI
 - **自动弹性伸缩**——根据工作负载自动调整资源，无需人工编排
-- **灵活定制**——在 App Launchpad 中轻松配置环境变量和存储
+- **灵活定制**——在 Canvas 中轻松配置环境变量和存储
 - **零 Kubernetes 门槛**——享受托管 Kubernetes 的优势，无需深入理解其复杂性
 - **内置持久化存储**——数据和配置随持久化卷保存，重启不丢失
 - **即刻公网访问**——自动配置 HTTPS 端点和 SSL 证书
@@ -66,13 +66,13 @@ Sealos 是一个基于 Kubernetes 的云操作系统，通过 AI 辅助实现了
 ## 部署指南
 
 1. 访问 [Mage AI 模板页面](https://sealos.io/products/app-store/mage-ai)
-2. 点击"立即部署"按钮
+2. 点击 **Deploy Now**（立即部署）按钮
 3. 在弹出对话框中配置参数：
    - **默认所有者邮箱**——管理员登录邮箱
    - **默认所有者密码**——管理员登录密码
-4. 等待部署完成（通常 0-1 分钟）。部署完成后会自动跳转到 Canvas。后续如需修改，可在对话框中描述需求让 AI 自动应用更新，或点击相关资源卡片手动调整设置。
+4. 等待部署完成（通常 2-4 分钟）。部署完成后会自动跳转到 Canvas。后续如需修改，可在对话框中描述需求让 AI 自动应用更新，或点击相关资源卡片手动调整设置。
 5. 通过提供的 URL 访问你的 Mage AI 实例：
-   - **Mage AI Web 界面**——使用默认所有者凭据登录
+   - **Mage AI Web 界面**——打开提供的 URL 或 `/sign-in`，使用默认所有者凭据登录。Mage AI 会在首次启动时自动创建该所有者账号，无需单独注册。
 
 ## 配置
 
@@ -80,14 +80,14 @@ Sealos 是一个基于 Kubernetes 的云操作系统，通过 AI 辅助实现了
 
 - **AI 对话**——描述你想要的变更，让 AI 直接应用更新
 - **资源卡片**——点击相关资源卡片修改设置
-- **Web 界面**——通过提供的 URL 使用默认所有者凭据登录
+- **Web 界面**——通过提供的 URL 或 `/sign-in` 使用默认所有者凭据登录。初始所有者账号无需自助注册。
 - **存储**——项目存储在持久化卷的 `/home/src` 路径
 
 ## 扩缩容
 
 本模板默认运行单个 Mage AI 副本。如需调整资源：
 
-1. 在 Sealos 中打开 App Launchpad
+1. 在 Sealos 中打开 Canvas
 2. 选择你的 Mage AI 部署
 3. 调整 CPU/内存限制并点击"更新"
 
@@ -97,7 +97,7 @@ Sealos 是一个基于 Kubernetes 的云操作系统，通过 AI 辅助实现了
 
 **问题：无法登录 Mage AI**
 - 原因：默认所有者邮箱或密码错误
-- 解决方案：在部署配置中验证凭据，如需要可在 App Launchpad 中更新
+- 解决方案：在部署配置中验证凭据，如需要可在 Canvas 中更新
 
 **问题：数据库连接失败**
 - 原因：PostgreSQL 仍在初始化，或初始化任务尚未完成
@@ -119,4 +119,4 @@ Sealos 是一个基于 Kubernetes 的云操作系统，通过 AI 辅助实现了
 
 ## 许可证
 
-本 Sealos 模板遵循代码仓库的许可条款。Mage AI 本身受其上游许可证约束；详情请查看 Mage AI GitHub 仓库。
+本 Sealos 模板遵循代码仓库的许可条款。Mage AI 本身使用 Apache License 2.0 许可；详情请查看 Mage AI GitHub 仓库。

--- a/template/mage-ai/index.yaml
+++ b/template/mage-ai/index.yaml
@@ -17,7 +17,6 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Mage AI'
       description: '开源数据流水线工具，用于构建与运行数据工作流。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mage-ai/README_zh.md'
   categories:
@@ -148,7 +147,7 @@ spec:
     spec:
       containers:
         - name: pgsql-init
-          image: postgres:16-alpine
+          image: postgres:16.4-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -171,22 +170,36 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://$(PG_USERNAME):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)
+            - name: PG_DATABASE
+              value: mage
           command:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE mage;' &>/dev/null; do sleep 1; done
+              set -eu
+              export PGPASSWORD="$PG_PASSWORD"
+              for i in $(seq 1 90); do
+                if pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                if [ "$i" -eq 90 ]; then
+                  echo "PostgreSQL is not ready" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              if ! psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='mage'" | grep -q 1; then
+                createdb -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USERNAME" "$PG_DATABASE"
+              fi
           resources:
             requests:
               cpu: 20m
-              memory: 32Mi
+              memory: 25Mi
             limits:
               cpu: 200m
               memory: 256Mi
-      restartPolicy: Never
-  backoffLimit: 0
+      restartPolicy: OnFailure
+  backoffLimit: 10
   ttlSecondsAfterFinished: 300
 ---
 # Mage AI StatefulSet
@@ -196,10 +209,12 @@ metadata:
   name: ${{ defaults.app_name }}
   annotations:
     originImageName: mageai/mageai:0.9.79
+    docker-to-sealos.resource-override-source: 'https://docs.mage.ai/getting-started/setup#docker runs mageai/mageai with /home/src persistent project storage and full data-pipeline runtime dependencies'
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   revisionHistoryLimit: 1
   replicas: 1
@@ -215,7 +230,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-postgres
-          image: postgres:16-alpine
+          image: mageai/mageai:0.9.79
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -245,12 +260,12 @@ spec:
             - -c
             - |
               echo "waiting for postgresql to be ready..."
-              until PGPASSWORD="${PGPASSWORD}" pg_isready -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USERNAME}; do
+              until PGPASSWORD="${PGPASSWORD}" pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}"; do
                 echo "postgresql not ready, rechecking in 2s"
                 sleep 2
               done
               echo "database ${DB_NAME} is ready"
-              until PGPASSWORD="${PGPASSWORD}" psql -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USERNAME} -d postgres \
+              until PGPASSWORD="${PGPASSWORD}" psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres \
                 -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}';" | grep -q 1; do
                 echo "database ${DB_NAME} not found, rechecking in 2s"
                 sleep 2
@@ -259,7 +274,7 @@ spec:
           resources:
             requests:
               cpu: 20m
-              memory: 32Mi
+              memory: 25Mi
             limits:
               cpu: 200m
               memory: 256Mi
@@ -268,52 +283,76 @@ spec:
           image: mageai/mageai:0.9.79
           imagePullPolicy: IfNotPresent
           command:
-            - mage
-            - start
-            - magic
+            - /app/run_app.sh
           ports:
-            - containerPort: 6789
+            - name: http
+              containerPort: 6789
+              protocol: TCP
           env:
             - name: ENV
               value: dev
+            - name: USER_CODE_PATH
+              value: magic
             - name: DEFAULT_OWNER_EMAIL
               value: ${{ inputs.default_owner_email }}
             - name: DEFAULT_OWNER_PASSWORD
               value: ${{ inputs.default_owner_password }}
-            - name: POSTGRES_DB
+            - name: DB_NAME
               value: mage
-            - name: POSTGRES_HOST
+            - name: DB_HOST
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: host
-            - name: POSTGRES_PORT
+            - name: DB_PORT
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: port
-            - name: POSTGRES_USER
+            - name: DB_USER
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: username
-            - name: POSTGRES_PASSWORD
+            - name: DB_PASS
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: MAGE_DATABASE_CONNECTION_URL
-              value: postgresql+psycopg2://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)
           volumeMounts:
             - name: vn-homevn-src
               mountPath: /home/src
+          startupProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 6
+            timeoutSeconds: 5
           resources:
             requests:
-              cpu: 200m
-              memory: 512Mi
+              cpu: 20m
+              memory: 102Mi
             limits:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: 200m
+              memory: 1024Mi
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -334,11 +373,14 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
   ports:
-    - port: 6789
-      targetPort: 6789
+    - name: http
+      port: 6789
+      targetPort: http
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
 ---

--- a/template/matomo/README.md
+++ b/template/matomo/README.md
@@ -1,28 +1,131 @@
-# Matomo
+# Deploy and Host Matomo on Sealos
 
-## Overview
+Matomo is an open source web analytics platform for tracking visitor behavior, conversions, campaigns, and site performance. This template deploys Matomo with the official Apache/PHP runtime, persistent application storage, and a Sealos-managed MySQL database on Sealos Cloud.
 
-Matomo is the leading open source web analytics platform that gives you valuable insights into your website visitors
+## About Hosting Matomo
 
-This Sealos template deploys **Matomo** as the `matomo` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Matomo runs as a single Apache/PHP application container, which avoids sidecar configuration drift during restarts and provides the public HTTP entry point directly. Sealos provisions a MySQL database through KubeBlocks and persistent storage for `/var/www/html`, so application files and generated configuration survive restarts.
 
-## Deploy on Sealos
+On first access, Matomo opens its installation wizard. The template preconfigures the database host, database username, password, database name, table prefix, and trusted host through Matomo-supported environment variables, so you can proceed through the wizard and create the first superuser account from the browser.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Privacy-focused web analytics**: Track website traffic while keeping analytics data under your control.
+- **Campaign and conversion tracking**: Measure marketing campaigns, goals, funnels, and ecommerce events.
+- **Product usage analytics**: Monitor how users navigate product documentation, portals, or SaaS dashboards.
+- **Self-hosted reporting**: Provide teams with analytics dashboards without relying on third-party hosted analytics.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for Matomo Hosting
+
+The Sealos template includes the required runtime services: Matomo Apache/PHP runtime, persistent storage, and a MySQL database.
+
+### Deployment Dependencies
+
+- [Matomo Official Website](https://matomo.org/) - Product overview and documentation
+- [Matomo Installation Guide](https://matomo.org/faq/on-premise/installing-matomo/) - First-run installation flow
+- [Matomo Docker Image](https://hub.docker.com/_/matomo) - Official container image
+- [Matomo GitHub Repository](https://github.com/matomo-org/matomo) - Source code and releases
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Matomo Application**: Runs Matomo 5.10.0 with the official Apache/PHP image and serves the web UI on port 80.
+- **MySQL**: A Sealos-managed KubeBlocks MySQL cluster stores analytics data and application settings.
+- **Persistent Storage**: A 1 GiB volume stores Matomo application files and generated configuration under `/var/www/html`.
+
+**Configuration:**
+
+- The public endpoint is exposed through Sealos Ingress with automatic HTTPS.
+- Database connection values use Matomo-supported `MATOMO_DATABASE_*` environment variables and are sourced from the Sealos-managed MySQL credential secret.
+- The first Matomo administrator is created in the browser during the installation wizard.
+- Keep the generated public URL stable after installation because Matomo records it as a trusted host.
+
+**License Information:**
+
+Matomo is licensed under GPL-3.0. This Sealos template is provided under the repository license.
+
+## Why Deploy Matomo on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, networking, storage, and operations. By deploying Matomo on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Matomo and MySQL from a ready-made template without writing Kubernetes YAML.
+- **Managed Public Access**: Sealos creates an HTTPS endpoint for the Matomo web UI.
+- **Persistent Data**: Application files and database data are stored on persistent volumes.
+- **Easy Operations**: Use the Canvas, AI dialog, and resource cards to adjust resources or inspect runtime state.
+- **Pay-as-you-go Resources**: Start with a small footprint and scale resources when analytics volume grows.
+
+## Deployment Guide
+
+1. Open the [Matomo template](https://sealos.io/products/app-store/matomo) and click **Deploy Now**.
+2. Keep the default parameters or adjust the generated app name and host in the popup dialog.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog, or click the relevant resource cards to modify settings.
+4. Open the provided Matomo URL.
+5. Complete the Matomo installation wizard:
+   - Confirm the system check.
+   - Use the prefilled database settings when shown.
+   - Create the first superuser account.
+   - Add your first website and copy the tracking code into the site you want to measure.
+   - On the final congratulations page, click **Continue to Matomo** to reach the sign-in page.
+6. Sign in with the superuser username and password you created in the wizard.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, configure Matomo through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **Installation Wizard**: Create the first administrator and website when you open the app for the first time.
+- **Matomo Admin Panel**: Manage users, websites, privacy settings, plugins, and tracking code after installation.
+- **AI Dialog**: Describe resource or configuration changes in the Sealos Canvas.
+- **Resource Cards**: Open the StatefulSet, MySQL, Ingress, or storage cards to inspect and adjust runtime settings.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+The template uses a validated 512 MiB memory limit so the installation wizard can finish without PHP/Apache being OOMKilled. As traffic grows:
 
-- Official website: https://matomo.org/
-- Source repository: https://github.com/matomo-org/matomo
+1. Open the Canvas for your deployment.
+2. Click the Matomo StatefulSet resource card.
+3. Increase CPU or memory using the allowed Sealos resource options if dashboards or archiving become slow.
+4. Apply the change and verify the Matomo dashboard remains available.
+
+For high-traffic installations, also configure Matomo archiving through cron according to the official Matomo documentation.
+
+## Troubleshooting
+
+### Installation wizard cannot connect to the database
+
+- Cause: MySQL may still be starting or credentials may not be ready yet.
+- Solution: Wait until the MySQL pod and the Matomo pod are running, then reload the wizard.
+
+### Browser shows a trusted host or HTTPS warning
+
+- Cause: Matomo validates the host it is accessed through.
+- Solution: Use the Sealos-provided public URL and avoid changing the app host after completing installation.
+
+### Setup stops midway or the pod restarts
+
+- Cause: Matomo can exceed a 256 MiB container limit while creating tables, plugins, and the first admin account.
+- Solution: Keep the template memory limit at 512 MiB or higher during setup. The current template already uses this validated limit.
+
+### Analytics reports are slow on larger sites
+
+- Cause: Browser-triggered archiving can become slow with more traffic.
+- Solution: Follow Matomo's cron archiving guide and increase application resources if needed.
+
+### Getting Help
+
+- [Matomo Documentation](https://matomo.org/help/)
+- [Matomo Community Forum](https://forum.matomo.org/)
+- [Matomo GitHub Issues](https://github.com/matomo-org/matomo/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Tracking Code Guide](https://matomo.org/faq/new-to-piwik/how-to-install-the-javascript-tracking-code/)
+- [Privacy Features](https://matomo.org/privacy/)
+- [Developer Documentation](https://developer.matomo.org/)
+
+## License
+
+This Sealos template is provided under the repository license. Matomo itself is licensed under GPL-3.0.

--- a/template/matomo/README_zh.md
+++ b/template/matomo/README_zh.md
@@ -1,28 +1,131 @@
-# Matomo
+# 在 Sealos 上部署和托管 Matomo
 
-## 应用概览
+Matomo 是一款开源网站分析平台，可用于跟踪访客行为、转化、营销活动和网站性能。此模板会在 Sealos Cloud 上部署 Matomo，包含官方 Apache/PHP 运行时、持久化应用存储，以及由 Sealos 管理的 MySQL 数据库。
 
-Matomo 是领先的开源网站分析平台，为您提供关于网站访客的宝贵洞察
+## 关于 Matomo 托管
 
-此 Sealos 模板会将 **Matomo** 部署为 `matomo` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Matomo 以单个 Apache/PHP 应用容器运行，直接提供公网 HTTP 入口，并避免重启时出现 sidecar 配置漂移。Sealos 会通过 KubeBlocks 创建 MySQL 数据库，并为 `/var/www/html` 提供持久化存储，因此应用文件和生成的配置在重启后仍会保留。
 
-## 在 Sealos 上部署
+首次访问时，Matomo 会打开安装向导。模板已经通过 Matomo 支持的环境变量预配置数据库主机、数据库用户名、密码、数据库名、表前缀和可信主机，因此可以直接在浏览器中继续向导并创建第一个超级用户账号。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **注重隐私的网站分析**：在保留数据控制权的同时跟踪网站流量。
+- **营销活动和转化跟踪**：衡量推广活动、目标、漏斗和电商事件。
+- **产品使用分析**：观察用户如何浏览产品文档、门户或 SaaS 控制台。
+- **自托管报表**：为团队提供分析仪表盘，同时避免依赖第三方托管分析服务。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## Matomo 托管依赖
+
+此 Sealos 模板包含所需运行服务：Matomo Apache/PHP 运行时、持久化存储和 MySQL 数据库。
+
+### 部署依赖
+
+- [Matomo 官方网站](https://matomo.org/) - 产品概览和文档
+- [Matomo 安装指南](https://matomo.org/faq/on-premise/installing-matomo/) - 首次安装流程
+- [Matomo Docker 镜像](https://hub.docker.com/_/matomo) - 官方容器镜像
+- [Matomo GitHub 仓库](https://github.com/matomo-org/matomo) - 源码和版本发布
+
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Matomo 应用**：使用官方 Apache/PHP 镜像运行 Matomo 5.10.0，并在 80 端口提供 Web UI。
+- **MySQL**：由 Sealos 管理的 KubeBlocks MySQL 集群，用于存储分析数据和应用设置。
+- **持久化存储**：1 GiB 卷用于保存 `/var/www/html` 下的 Matomo 应用文件和生成配置。
+
+**配置：**
+
+- 公网入口通过 Sealos Ingress 暴露，并自动启用 HTTPS。
+- 数据库连接值使用 Matomo 支持的 `MATOMO_DATABASE_*` 环境变量，并来自 Sealos 管理的 MySQL 凭据 Secret。
+- 第一个 Matomo 管理员需要在安装向导中创建。
+- 安装完成后请保持生成的公网 URL 稳定，因为 Matomo 会将其记录为可信主机。
+
+**许可证信息：**
+
+Matomo 使用 GPL-3.0 许可证。此 Sealos 模板使用仓库许可证发布。
+
+## 为什么在 Sealos 上部署 Matomo？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用部署、网络、存储和运维。在 Sealos 上部署 Matomo 可以获得：
+
+- **一键部署**：通过现成模板部署 Matomo 和 MySQL，无需手写 Kubernetes YAML。
+- **托管公网访问**：Sealos 会为 Matomo Web UI 创建 HTTPS 访问入口。
+- **持久化数据**：应用文件和数据库数据都保存在持久化卷中。
+- **便捷运维**：通过 Canvas、AI 对话和资源卡片调整资源或查看运行状态。
+- **按量使用资源**：从较小资源配置开始，后续根据分析流量增长再扩容。
+
+## 部署指南
+
+1. 打开 [Matomo 模板](https://sealos.io/products/app-store/matomo)，点击 **Deploy Now**。
+2. 在弹窗中保留默认参数，或调整生成的应用名称和访问域名前缀。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会进入 Canvas。后续如需修改，可在 AI 对话中描述需求，或点击相关资源卡片调整设置。
+4. 打开生成的 Matomo 访问 URL。
+5. 完成 Matomo 安装向导：
+   - 确认系统检查结果。
+   - 数据库配置页使用模板预填的数据库设置。
+   - 创建第一个超级用户账号。
+   - 添加第一个网站，并将跟踪代码复制到需要统计的网站中。
+   - 在最后的 Congratulations 页面点击 **Continue to Matomo**，进入登录页。
+6. 使用安装向导中创建的超级用户账号和密码登录。
 
 ## 配置说明
 
-部署时可以配置以下用户可见输入项：
+部署后，可以通过以下方式配置 Matomo：
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- **安装向导**：首次打开应用时创建第一个管理员和网站。
+- **Matomo 管理后台**：安装完成后管理用户、网站、隐私设置、插件和跟踪代码。
+- **AI 对话**：在 Sealos Canvas 中描述资源或配置变更需求。
+- **资源卡片**：打开 StatefulSet、MySQL、Ingress 或存储卡片，查看并调整运行配置。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+## 扩展
 
-## 官方链接
+模板使用经过验证的 512 MiB 内存限制，可避免安装向导创建表、插件和管理员账号时因内存不足被 OOMKilled。随着访问量增长，可以按以下步骤扩展：
 
-- 官方网站: https://matomo.org/
-- 源码仓库: https://github.com/matomo-org/matomo
+1. 打开当前部署的 Canvas。
+2. 点击 Matomo StatefulSet 资源卡片。
+3. 如果仪表盘或归档变慢，可按 Sealos 允许的资源选项增加 CPU 或内存。
+4. 应用变更，并确认 Matomo 仪表盘仍可访问。
+
+对于高流量场景，还应根据 Matomo 官方文档配置 cron 归档任务。
+
+## 故障排查
+
+### 安装向导无法连接数据库
+
+- 原因：MySQL 可能仍在启动，或凭据尚未就绪。
+- 解决：等待 MySQL Pod 和 Matomo Pod 都进入运行状态后刷新安装向导。
+
+### 浏览器显示可信主机或 HTTPS 警告
+
+- 原因：Matomo 会校验访问所使用的主机名。
+- 解决：使用 Sealos 提供的公网 URL，安装完成后避免更改应用访问域名。
+
+### 安装向导中途停止或 Pod 重启
+
+- 原因：Matomo 在创建表、插件和管理员账号时可能超过 256 MiB 容器内存限制。
+- 解决：安装期间保持模板的内存限制为 512 MiB 或更高。当前模板已经使用经过验证的 512 MiB 限制。
+
+### 大型网站的分析报表较慢
+
+- 原因：流量增大后，由浏览器触发的归档可能变慢。
+- 解决：根据 Matomo 的 cron 归档指南配置定时归档，并按需提升应用资源。
+
+### 获取帮助
+
+- [Matomo 文档](https://matomo.org/help/)
+- [Matomo 社区论坛](https://forum.matomo.org/)
+- [Matomo GitHub Issues](https://github.com/matomo-org/matomo/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [跟踪代码指南](https://matomo.org/faq/new-to-piwik/how-to-install-the-javascript-tracking-code/)
+- [隐私功能](https://matomo.org/privacy/)
+- [开发者文档](https://developer.matomo.org/)
+
+## 许可证
+
+此 Sealos 模板使用仓库许可证发布。Matomo 本身使用 GPL-3.0 许可证。

--- a/template/matomo/index.yaml
+++ b/template/matomo/index.yaml
@@ -16,7 +16,6 @@ spec:
   locale: en
   i18n:
     zh:
-      title: 'Matomo'
       description: 'Matomo 是领先的开源网站分析平台，为您提供关于网站访客的宝贵洞察'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/matomo/README_zh.md'
   categories:
@@ -82,7 +81,7 @@ metadata:
     - cluster.kubeblocks.io/finalizer
   labels:
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
+    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30-1
     sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
   annotations: {}
   name: ${{ defaults.app_name }}-mysql
@@ -91,12 +90,14 @@ spec:
     nodeLabels: {}
     podAntiAffinity: Preferred
     tenancy: SharedNode
-    topologyKeys: []
+    topologyKeys:
+      - kubernetes.io/hostname
   clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterVersionRef: ac-mysql-8.0.30-1
   componentSpecs:
     - componentDefRef: mysql
       monitor: true
+      noCreatePDB: false
       name: mysql
       replicas: 1
       resources:
@@ -131,7 +132,15 @@ spec:
     spec:
       containers:
         - name: mysql-init
-          image: mysql:8.0
+          image: mysql:8.0.44
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
           env:
             - name: MYSQL_PASSWORD
               valueFrom:
@@ -147,116 +156,28 @@ spec:
             - /bin/sh
             - -c
             - |
-              until mysql -h${MYSQL_HOST} -uroot -p${MYSQL_PASSWORD} -e 'CREATE DATABASE IF NOT EXISTS matomo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;' &>/dev/null; do sleep 1; done
+              set -eu
+              for i in $(seq 1 60); do
+                if mysqladmin ping -h"${MYSQL_HOST}" -uroot -p"${MYSQL_PASSWORD}" --silent; then
+                  break
+                fi
+                sleep 2
+              done
+              mysqladmin ping -h"${MYSQL_HOST}" -uroot -p"${MYSQL_PASSWORD}" --silent
+              mysql -h"${MYSQL_HOST}" -uroot -p"${MYSQL_PASSWORD}" -e "CREATE DATABASE IF NOT EXISTS matomo CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
       restartPolicy: Never
-  backoffLimit: 0
+  backoffLimit: 3
   ttlSecondsAfterFinished: 300
 
 ---
-# ConfigMap with vn- naming
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ${{ defaults.app_name }}
-  labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-data:
-  vn-etcvn-nginxvn-nginxvn-conf: |
-    events {
-      worker_connections 768;
-    }
-
-    http {
-      upstream backend {
-        server localhost:9000;
-      }
-
-      include /etc/nginx/mime.types;
-      default_type application/octet-stream;
-      gzip on;
-      gzip_disable "msie6";
-
-      map $http_x_forwarded_proto $proxy_x_forwarded_proto {
-        default $http_x_forwarded_proto;
-        ''      $scheme;
-      }
-      map $http_x_forwarded_port $proxy_x_forwarded_port {
-        default $http_x_forwarded_port;
-        ''      $server_port;
-      }
-      map $http_upgrade $proxy_connection {
-        default upgrade;
-        '' close;
-      }
-      map $scheme $proxy_x_forwarded_ssl {
-        default off;
-        https on;
-      }
-      proxy_http_version 1.1;
-      proxy_buffering off;
-      proxy_set_header Host $http_host;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $proxy_connection;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
-      proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
-      proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
-      proxy_set_header Proxy "";
-
-      server {
-        listen 80;
-
-        root /var/www/html/;
-        index index.php index.html index.htm;
-
-        location / {
-          try_files $uri $uri/ =404;
-        }
-
-        error_page 404 /404.html;
-        error_page 500 502 503 504 /50x.html;
-        location = /50x.html {
-          root /usr/share/nginx/html;
-        }
-
-        location = /favicon.ico {
-          log_not_found off;
-          access_log off;
-        }
-
-        location ~ \.php$ {
-          fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
-          fastcgi_param  SERVER_SOFTWARE    nginx;
-          fastcgi_param  QUERY_STRING       $query_string;
-          fastcgi_param  REQUEST_METHOD     $request_method;
-          fastcgi_param  CONTENT_TYPE       $content_type;
-          fastcgi_param  CONTENT_LENGTH     $content_length;
-          fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
-          fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
-          fastcgi_param  REQUEST_URI        $request_uri;
-          fastcgi_param  DOCUMENT_URI       $document_uri;
-          fastcgi_param  DOCUMENT_ROOT      $document_root;
-          fastcgi_param  SERVER_PROTOCOL    $server_protocol;
-          fastcgi_param  REMOTE_ADDR        $remote_addr;
-          fastcgi_param  REMOTE_PORT        $remote_port;
-          fastcgi_param  SERVER_ADDR        $server_addr;
-          fastcgi_param  SERVER_PORT        $server_port;
-          fastcgi_param  SERVER_NAME        $server_name;
-          fastcgi_intercept_errors on;
-          fastcgi_pass backend;
-        }
-      }
-    }
-
----
-# StatefulSet (converted from Deployment)
+# StatefulSet
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: matomo:5.3.2-fpm
+    originImageName: matomo:5.10.0-apache
+    docker-to-sealos.resource-override-source: 'Sealos validation on 2026-06-03: Matomo setup exceeded a 256Mi container limit and was OOMKilled; 512Mi is required to complete the installation wizard reliably.'
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -277,20 +198,37 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: matomo:5.3.2-fpm
+          image: matomo:5.10.0-apache
           imagePullPolicy: IfNotPresent
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
           env:
             - name: MATOMO_DATABASE_HOST
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: host
-            - name: MATOMO_DATABASE_ADAPTER
-              value: "MYSQL"
-            - name: MATOMO_DATABASE_TABLES_PREFIX
-              value: "matomo_"
             - name: MATOMO_DATABASE_USERNAME
-              value: "root"
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
             - name: MATOMO_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -298,51 +236,28 @@ spec:
                   key: password
             - name: MATOMO_DATABASE_DBNAME
               value: "matomo"
+            - name: MATOMO_DATABASE_ADAPTER
+              value: "mysql"
+            - name: MATOMO_DATABASE_TABLES_PREFIX
+              value: "matomo_"
             - name: MATOMO_GENERAL_TRUSTED_HOST
               value: "${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}"
-          ports:
-            - name: php-fpm
-              containerPort: 9000
-              protocol: TCP
-          volumeMounts:
-            - name: vn-varvn-wwwvn-html
-              mountPath: /var/www/html
-          resources:
-            requests:
-              cpu: 20m
-              memory: 25Mi
-            limits:
-              cpu: 200m
-              memory: 256Mi
-        - name: ${{ defaults.app_name }}-nginx
-          image: nginx:alpine
-          imagePullPolicy: IfNotPresent
-          command: ["nginx", "-g", "daemon off;", "-c", "/etc/nginx/nginx.conf"]
+            - name: PHP_MEMORY_LIMIT
+              value: "256M"
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
           volumeMounts:
-            - name: vn-etcvn-nginxvn-nginxvn-conf
-              mountPath: /etc/nginx/nginx.conf
-              subPath: ./etc/nginx/nginx.conf
             - name: vn-varvn-wwwvn-html
               mountPath: /var/www/html
           resources:
             requests:
-              cpu: 20m
-              memory: 25Mi
+              cpu: 50m
+              memory: 51Mi
             limits:
-              cpu: 200m
-              memory: 256Mi
-      volumes:
-        - name: vn-etcvn-nginxvn-nginxvn-conf
-          configMap:
-            name: ${{ defaults.app_name }}
-            items:
-              - key: vn-etcvn-nginxvn-nginxvn-conf
-                path: ./etc/nginx/nginx.conf
-            defaultMode: 420
+              cpu: 500m
+              memory: 512Mi
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -363,6 +278,7 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   type: ClusterIP
@@ -381,6 +297,7 @@ kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:

--- a/template/meilisearch/README.md
+++ b/template/meilisearch/README.md
@@ -1,31 +1,150 @@
-# Meilisearch
+# Deploy and Host Meilisearch on Sealos
 
-## Overview
+Meilisearch is a fast, open-source search engine API for building typo-tolerant search experiences. This template deploys Meilisearch v1.45.1 with persistent storage and a lightweight Meilisearch UI dashboard on Sealos Cloud.
 
-A lightning-fast search API that fits effortlessly into your apps, websites, and workflow.
+![Meilisearch Screenshot](website-screenshot.webp)
 
-This Sealos template deploys **Meilisearch** as the `meilisearch` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Meilisearch
 
-## Deploy on Sealos
+Meilisearch runs as a single-node StatefulSet and stores indexes, tasks, and runtime data in a persistent volume mounted at `/meili_data`. The API is exposed through a Sealos-managed HTTPS endpoint on port `7700`, so applications and SDK clients can connect from outside the cluster.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+The template also deploys a separate Meilisearch UI service using `eyeix/meilisearch-ui:v0.15.1-lite`. The UI provides a browser-based dashboard for managing indexes, documents, search, and settings. It does not create a user account system; instead, you connect it to your Meilisearch API endpoint with the generated `MEILI_MASTER_KEY`.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **Application Search**: Add typo-tolerant search to SaaS products, dashboards, and content apps.
+- **E-commerce Search**: Index products and enable fast keyword search with filtering and ranking.
+- **Documentation Search**: Power search experiences for docs, knowledge bases, and help centers.
+- **Internal Tools**: Use the bundled dashboard to inspect indexes and test search behavior.
+- **API Prototyping**: Create indexes, add documents, and validate queries before integrating SDKs.
+
+## Dependencies for Meilisearch Hosting
+
+The Sealos template includes the Meilisearch API container, Meilisearch UI container, persistent storage for `/meili_data`, Kubernetes Services, HTTPS Ingress resources, and a Sealos App link.
+
+### Deployment Dependencies
+
+- [Meilisearch Documentation](https://www.meilisearch.com/docs) - Official product and API documentation
+- [Meilisearch REST API Reference](https://www.meilisearch.com/docs/reference/api/overview) - API endpoint details
+- [Meilisearch GitHub Repository](https://github.com/meilisearch/meilisearch) - Source code and releases
+- [Meilisearch UI Repository](https://github.com/eyeix/meilisearch-ui) - Web dashboard used by this template
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following resources:
+
+- **Meilisearch StatefulSet**: Runs `getmeili/meilisearch:v1.45.1` with persistent `/meili_data` storage.
+- **Meilisearch UI Deployment**: Runs `eyeix/meilisearch-ui:v0.15.1-lite` on port `24900` for browser-based administration.
+- **Persistent Volume Claim**: Stores indexes, tasks, and runtime data across pod restarts.
+- **API Service and Ingress**: Expose the Meilisearch HTTP API over an automatically generated HTTPS URL.
+- **UI Service and Ingress**: Expose the dashboard through a separate HTTPS URL.
+- **Sealos App**: Opens the Meilisearch UI from the Sealos Canvas.
+
+**Configuration:**
+
+- `MEILI_ENV` is set to `production`.
+- `MEILI_MASTER_KEY` is generated automatically as `defaults.master_key` and protects all API routes except `GET /health`.
+- The UI stores connection information in your browser. Enter the Meilisearch API URL and generated master key when connecting.
+- The UI is intentionally not preloaded with the master key, because browser-delivered singleton configuration would expose the key in the frontend bundle.
+- API resources use the lightweight validated profile: `100m` CPU and `128Mi` memory. The UI uses the standard Sealos baseline: `200m` CPU and `256Mi` memory.
+
+**License Information:**
+
+Meilisearch is distributed under the MIT License. This Sealos template is provided under the repository license for Sealos templates. Review the Meilisearch UI upstream repository for dashboard licensing details.
+
+## Why Deploy Meilisearch on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, operations, and management. By deploying Meilisearch on Sealos, you get:
+
+- **One-Click Deployment**: Launch Meilisearch and its dashboard from the App Store template without writing Kubernetes manifests.
+- **Persistent Storage Included**: Keep search indexes and task data across restarts.
+- **Instant Public Access**: Receive HTTPS endpoints for both the API and Web UI after deployment.
+- **Easy Customization**: Adjust resources, environment variables, and storage from the Canvas or AI dialog.
+- **Zero Kubernetes Expertise Required**: Use Kubernetes-backed workloads without manually managing Services, Ingress, or StatefulSets.
+- **Pay-as-You-Go Resources**: Start with a small search node and scale resources when indexing or query traffic grows.
+
+Deploy Meilisearch on Sealos and focus on search quality instead of infrastructure setup.
+
+## Deployment Guide
+
+1. Open the [Meilisearch template](https://sealos.io/products/app-store/meilisearch) and click **Deploy Now**.
+2. Review the generated application name, API host, UI host, and master key values in the popup dialog.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog, or click the relevant resource cards to modify settings.
+4. Open the Meilisearch UI from the Sealos App link. The UI does not require registration or a user login. Connect to your instance with:
+   - **Host**: the generated Meilisearch API URL, for example `https://<your-meilisearch-api-url>`
+   - **API Key**: the generated `MEILI_MASTER_KEY`
+5. Use the API endpoint directly for SDKs or REST clients. Protected endpoints require `Authorization: Bearer <MEILI_MASTER_KEY>` or `X-Meili-API-Key: <MEILI_MASTER_KEY>`.
+
+Example health check:
+
+```bash
+curl https://<your-meilisearch-api-url>/health
+```
+
+Example authenticated API call:
+
+```bash
+curl   -H "Authorization: Bearer <MEILI_MASTER_KEY>"   https://<your-meilisearch-api-url>/version
+```
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Meilisearch through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `MEILI_ENV` | Configures the instance's environment. Value must be either production or development. | `false` | `development` |
-| `MEILI_MASTER_KEY` | Sets the instance's master key, automatically protecting all routes except GET /health. | `false` | `` |
+- **Meilisearch UI**: Connect with the generated API URL and master key to manage indexes, documents, and settings.
+- **AI Dialog**: Describe resource or environment changes and let Sealos apply updates.
+- **Resource Cards**: Open the StatefulSet, Deployment, Service, Ingress, PVC, or App cards to inspect and modify deployment settings.
+- **API Clients**: Use the generated public URL and `MEILI_MASTER_KEY` with Meilisearch SDKs or REST requests.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+To scale the deployment vertically:
 
-- Official website: https://www.meilisearch.com/
-- Source repository: https://github.com/meilisearch/meilisearch
+1. Open the Canvas for your deployment.
+2. Click the Meilisearch StatefulSet resource card.
+3. Adjust CPU and memory resources based on your indexing and query workload.
+4. Apply the changes and wait for the pod to roll out.
+
+The bundled UI is stateless and can be redeployed independently. Meilisearch in this template is a single-node deployment; for larger production search workloads, review the official Meilisearch guidance before increasing traffic or index size.
+
+## Troubleshooting
+
+### The UI asks for a host and API key
+
+- Cause: The lightweight UI stores connection information in your browser and is not preconfigured with the master key.
+- Solution: Use the generated Meilisearch API URL as the host and the generated `MEILI_MASTER_KEY` as the API key.
+
+### API requests return unauthorized errors
+
+- Cause: Meilisearch runs in production mode with a generated master key.
+- Solution: Include `Authorization: Bearer <MEILI_MASTER_KEY>` or `X-Meili-API-Key: <MEILI_MASTER_KEY>` in protected API requests.
+
+### The UI cannot connect to the API
+
+- Cause: The UI runs in the browser and must reach the public Meilisearch API URL.
+- Solution: Use the HTTPS API URL generated by this template, not the internal Kubernetes Service name.
+
+### Indexing uses too much memory
+
+- Cause: Large document batches or complex indexing tasks can require more memory than the lightweight default.
+- Solution: Increase the StatefulSet memory limit from the Canvas before running large imports.
+
+### Getting Help
+
+- [Official Documentation](https://www.meilisearch.com/docs)
+- [GitHub Issues](https://github.com/meilisearch/meilisearch/issues)
+- [Meilisearch UI Issues](https://github.com/eyeix/meilisearch-ui/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Meilisearch Quick Start](https://www.meilisearch.com/docs/learn/getting_started/quick_start)
+- [API Keys](https://www.meilisearch.com/docs/learn/security/master_api_keys)
+- [Indexing Documents](https://www.meilisearch.com/docs/learn/getting_started/indexing)
+- [Search API](https://www.meilisearch.com/docs/reference/api/search)
+
+## License
+
+This Sealos template is provided under the repository license for Sealos templates. Meilisearch itself is licensed under the MIT License.

--- a/template/meilisearch/README_zh.md
+++ b/template/meilisearch/README_zh.md
@@ -1,31 +1,150 @@
-# Meilisearch
+# 在 Sealos 上部署和托管 Meilisearch
 
-## 应用概览
+Meilisearch 是一个快速、开源的搜索引擎 API，可用于构建容错搜索体验。此模板会在 Sealos Cloud 上部署 Meilisearch v1.45.1、持久化存储和轻量 Meilisearch UI 管理界面。
 
-Meilisearch 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+![Meilisearch 截图](website-screenshot.webp)
 
-此 Sealos 模板会将 **Meilisearch** 部署为 `meilisearch` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于 Meilisearch 托管
 
-## 在 Sealos 上部署
+Meilisearch 以单节点 StatefulSet 运行，并将索引、任务和运行时数据保存在挂载到 `/meili_data` 的持久卷中。API 会通过 Sealos 管理的 HTTPS 入口暴露 `7700` 端口，应用和 SDK 客户端可以从集群外访问。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+模板还会使用 `eyeix/meilisearch-ui:v0.15.1-lite` 部署独立的 Meilisearch UI 服务。这个 UI 提供浏览器管理界面，可管理索引、文档、搜索和设置。它不创建用户账户系统；连接时需要填写 Meilisearch API 地址和生成的 `MEILI_MASTER_KEY`。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **应用内搜索**：为 SaaS 产品、仪表盘和内容应用增加容错搜索能力。
+- **电商搜索**：索引商品数据，支持快速关键词搜索、过滤和排序。
+- **文档搜索**：为文档站、知识库和帮助中心提供搜索体验。
+- **内部工具**：使用内置管理界面查看索引并测试搜索效果。
+- **API 原型验证**：在接入 SDK 前创建索引、添加文档并验证查询。
 
-## 配置说明
+## Meilisearch 托管依赖
 
-部署时可以配置以下用户可见输入项：
+Sealos 模板包含 Meilisearch API 容器、Meilisearch UI 容器、用于 `/meili_data` 的持久化存储、Kubernetes Service、HTTPS Ingress 和 Sealos App 链接。
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `MEILI_ENV` | `MEILI_ENV` 部署参数。 | `否` | `development` |
-| `MEILI_MASTER_KEY` | `MEILI_MASTER_KEY` 部署参数。 | `否` | `` |
+### 部署依赖
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+- [Meilisearch 文档](https://www.meilisearch.com/docs) - 官方产品和 API 文档
+- [Meilisearch REST API 参考](https://www.meilisearch.com/docs/reference/api/overview) - API 端点说明
+- [Meilisearch GitHub 仓库](https://github.com/meilisearch/meilisearch) - 源码和版本发布
+- [Meilisearch UI 仓库](https://github.com/eyeix/meilisearch-ui) - 此模板使用的 Web 管理界面
 
-## 官方链接
+### 实现细节
 
-- 官方网站: https://www.meilisearch.com/
-- 源码仓库: https://github.com/meilisearch/meilisearch
+**架构组件：**
+
+此模板会部署以下资源：
+
+- **Meilisearch StatefulSet**：运行 `getmeili/meilisearch:v1.45.1`，并挂载持久化 `/meili_data` 存储。
+- **Meilisearch UI Deployment**：运行 `eyeix/meilisearch-ui:v0.15.1-lite`，通过 `24900` 端口提供浏览器管理界面。
+- **持久卷声明**：保存索引、任务和运行时数据，避免 Pod 重启后丢失。
+- **API Service 和 Ingress**：通过自动生成的 HTTPS URL 暴露 Meilisearch HTTP API。
+- **UI Service 和 Ingress**：通过独立 HTTPS URL 暴露管理界面。
+- **Sealos App**：在 Sealos Canvas 中打开 Meilisearch UI。
+
+**配置：**
+
+- `MEILI_ENV` 固定为 `production`。
+- `MEILI_MASTER_KEY` 会作为 `defaults.master_key` 自动生成，并保护除 `GET /health` 以外的所有 API 路由。
+- UI 会将连接信息保存在浏览器中。连接时输入 Meilisearch API URL 和生成的 master key。
+- 模板不会把 master key 预置到 UI 中，因为浏览器端 singleton 配置会把 key 暴露在前端包里。
+- API 资源使用经过验证的轻量规格：`100m` CPU 和 `128Mi` 内存。UI 使用 Sealos 基线规格：`200m` CPU 和 `256Mi` 内存。
+
+**许可证信息：**
+
+Meilisearch 使用 MIT License。此 Sealos 模板遵循 Sealos templates 仓库的许可证。Meilisearch UI 的许可证请以其上游仓库为准。
+
+## 为什么在 Sealos 上部署 Meilisearch？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用部署、运维和管理。将 Meilisearch 部署到 Sealos 后，你可以获得：
+
+- **一键部署**：从应用商店模板启动 Meilisearch 和管理界面，无需手写 Kubernetes 配置。
+- **内置持久化存储**：在重启后保留搜索索引和任务数据。
+- **即时公网访问**：部署完成后获得 API 和 Web UI 的 HTTPS 端点。
+- **易于自定义**：通过 Canvas 或 AI 对话调整资源、环境变量和存储。
+- **无需 Kubernetes 专业知识**：使用 Kubernetes 支撑的工作负载，而无需手动管理 Service、Ingress 或 StatefulSet。
+- **按量使用资源**：先使用小规格搜索节点，后续按索引或查询负载扩容。
+
+在 Sealos 上部署 Meilisearch，把精力放在搜索体验上，而不是基础设施配置上。
+
+## 部署指南
+
+1. 打开 [Meilisearch 模板](https://sealos.io/products/app-store/meilisearch)，点击 **Deploy Now**。
+2. 在弹窗中检查生成的应用名称、API 域名、UI 域名和 master key。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会进入 Canvas。后续如需调整，可在 AI 对话中描述需求，或点击相关资源卡片修改配置。
+4. 从 Sealos App 链接打开 Meilisearch UI。UI 不需要注册，也没有用户登录流程。连接实例时填写：
+   - **Host**：生成的 Meilisearch API URL，例如 `https://<your-meilisearch-api-url>`
+   - **API Key**：生成的 `MEILI_MASTER_KEY`
+5. 如果通过 SDK 或 REST 客户端直接访问 API，受保护接口需要携带 `Authorization: Bearer <MEILI_MASTER_KEY>` 或 `X-Meili-API-Key: <MEILI_MASTER_KEY>`。
+
+健康检查示例：
+
+```bash
+curl https://<your-meilisearch-api-url>/health
+```
+
+认证 API 调用示例：
+
+```bash
+curl   -H "Authorization: Bearer <MEILI_MASTER_KEY>"   https://<your-meilisearch-api-url>/version
+```
+
+## 配置
+
+部署完成后，你可以通过以下方式配置 Meilisearch：
+
+- **Meilisearch UI**：使用生成的 API URL 和 master key 连接，管理索引、文档和设置。
+- **AI 对话**：描述资源或环境变量调整需求，由 Sealos 应用变更。
+- **资源卡片**：打开 StatefulSet、Deployment、Service、Ingress、PVC 或 App 卡片，查看和修改部署设置。
+- **API 客户端**：结合生成的公网 URL 和 `MEILI_MASTER_KEY` 使用 Meilisearch SDK 或 REST 请求。
+
+## 扩容
+
+如需纵向扩容：
+
+1. 打开当前部署的 Canvas。
+2. 点击 Meilisearch StatefulSet 资源卡片。
+3. 根据索引和查询负载调整 CPU 与内存资源。
+4. 应用变更并等待 Pod 滚动更新完成。
+
+内置 UI 是无状态服务，可独立重新部署。此模板中的 Meilisearch 是单节点部署；对于更大的生产搜索负载，在提升流量或索引规模前，请先参考 Meilisearch 官方建议。
+
+## 故障排查
+
+### UI 要求填写 host 和 API key
+
+- 原因：轻量 UI 会把连接信息保存在浏览器中，不会预置 master key。
+- 解决方法：使用生成的 Meilisearch API URL 作为 host，使用生成的 `MEILI_MASTER_KEY` 作为 API key。
+
+### API 请求返回未授权错误
+
+- 原因：Meilisearch 以 production 模式运行，并使用生成的 master key。
+- 解决方法：在受保护 API 请求中加入 `Authorization: Bearer <MEILI_MASTER_KEY>` 或 `X-Meili-API-Key: <MEILI_MASTER_KEY>`。
+
+### UI 无法连接 API
+
+- 原因：UI 在浏览器中运行，必须访问公网 Meilisearch API URL。
+- 解决方法：使用此模板生成的 HTTPS API URL，不要使用内部 Kubernetes Service 名称。
+
+### 索引任务占用过多内存
+
+- 原因：大批量文档或复杂索引任务可能需要超过轻量默认值的内存。
+- 解决方法：在 Canvas 中提高 StatefulSet 内存限制后再执行大批量导入。
+
+### 获取帮助
+
+- [官方文档](https://www.meilisearch.com/docs)
+- [GitHub Issues](https://github.com/meilisearch/meilisearch/issues)
+- [Meilisearch UI Issues](https://github.com/eyeix/meilisearch-ui/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Meilisearch 快速开始](https://www.meilisearch.com/docs/learn/getting_started/quick_start)
+- [API Keys](https://www.meilisearch.com/docs/learn/security/master_api_keys)
+- [索引文档](https://www.meilisearch.com/docs/learn/getting_started/indexing)
+- [搜索 API](https://www.meilisearch.com/docs/reference/api/search)
+
+## 许可证
+
+此 Sealos 模板遵循 Sealos templates 仓库的许可证。Meilisearch 本身使用 MIT License。

--- a/template/meilisearch/index.yaml
+++ b/template/meilisearch/index.yaml
@@ -7,7 +7,8 @@ spec:
   url: 'https://www.meilisearch.com/'
   gitRepo: 'https://github.com/meilisearch/meilisearch'
   author: 'Sealos'
-  description: 'A lightning-fast search API that fits effortlessly into your apps, websites, and workflow.'
+  description: 'A fast, open-source search engine API with a lightweight web dashboard for managing indexes, documents, and search settings.'
+  locale: en
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/meilisearch/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/meilisearch/logo.png'
   screenshots:
@@ -23,19 +24,15 @@ spec:
     app_name:
       type: string
       value: meilisearch-${{ random(8) }}
-  inputs:
-    MEILI_ENV:
-      description: "Configures the instance's environment. Value must be either production or development."
+    master_key:
       type: string
-      default: "development"
-      required: false
-    MEILI_MASTER_KEY:
-      description: "Sets the instance's master key, automatically protecting all routes except GET /health."
+      value: ${{ random(32) }}
+    ui_host:
       type: string
-      default: ""
-      required: false
+      value: meilisearch-ui-${{ random(8) }}
   i18n:
     zh:
+      description: '快速、开源的搜索引擎 API，并带有轻量 Web 管理界面，可管理索引、文档和搜索设置。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/meilisearch/README_zh.md'
 
 ---
@@ -44,9 +41,10 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: getmeili/meilisearch:v1.8
+    originImageName: getmeili/meilisearch:v1.45.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
+    docker-to-sealos.resource-override-source: 'Live validation on Sealos usw-1 (2026-05-29): Meilisearch v1.45.1 cold-started, served /health, /version, index creation, document ingestion, and search with 100m CPU / 128Mi memory; observed usage 3-4m CPU and 10Mi memory, restartCount=0.'
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
@@ -67,12 +65,12 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: getmeili/meilisearch:v1.8
+          image: getmeili/meilisearch:v1.45.1
           env:
             - name: MEILI_ENV
-              value: ${{ inputs.MEILI_ENV }}
+              value: production
             - name: MEILI_MASTER_KEY
-              value: ${{ inputs.MEILI_MASTER_KEY }}
+              value: ${{ defaults.master_key }}
           resources:
             requests:
               cpu: 10m
@@ -88,20 +86,31 @@ spec:
           volumeMounts:
             - name: vn-meili-data
               mountPath: /meili_data
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl -sf http://localhost:7700/health | grep 'available'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 24
           livenessProbe:
             exec:
               command:
-              - /bin/sh
-              - -c
-              - curl -sf http://localhost:7700/health | grep 'available'
+                - /bin/sh
+                - -c
+                - curl -sf http://localhost:7700/health | grep 'available'
             initialDelaySeconds: 20
+            periodSeconds: 10
           readinessProbe:
             exec:
               command:
-              - /bin/sh
-              - -c
-              - curl -sf http://localhost:7700/health | grep 'available'
+                - /bin/sh
+                - -c
+                - curl -sf http://localhost:7700/health | grep 'available'
             initialDelaySeconds: 20
+            periodSeconds: 10
   volumeClaimTemplates:
     - metadata:
         annotations:
@@ -116,17 +125,95 @@ spec:
             storage: 1Gi
 
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-ui
+  annotations:
+    originImageName: eyeix/meilisearch-ui:v0.15.1-lite
+    deploy.cloud.sealos.io/minReplicas: '1'
+    deploy.cloud.sealos.io/maxReplicas: '1'
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-ui
+    app: ${{ defaults.app_name }}-ui
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-ui
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-ui
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: ${{ defaults.app_name }}-ui
+          image: eyeix/meilisearch-ui:v0.15.1-lite
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 24900
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 7700
+    - name: http
+      port: 7700
+      targetPort: 7700
   selector:
     app: ${{ defaults.app_name }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}-ui
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-ui
+    app: ${{ defaults.app_name }}-ui
+spec:
+  ports:
+    - name: http
+      port: 24900
+      targetPort: 24900
+  selector:
+    app: ${{ defaults.app_name }}-ui
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -147,15 +234,11 @@ metadata:
       large_client_header_buffers 4 128k;
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; img-src * data: blob: resource: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.${{ SEALOS_CLOUD_DOMAIN }} ${{ SEALOS_CLOUD_DOMAIN }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://${{ SEALOS_CLOUD_DOMAIN }} https://*.${{ SEALOS_CLOUD_DOMAIN }}";
-      more_set_headers "X-Xss-Protection: 1; mode=block";
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
         add_header Cache-Control "public";
@@ -166,7 +249,7 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /()(.*)
+            path: /
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -178,6 +261,48 @@ spec:
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
 
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${{ defaults.app_name }}-ui
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-ui
+    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.ui_host }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 64k;
+      large_client_header_buffers 4 128k;
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
+        expires 30d;
+        add_header Cache-Control "public";
+      }
+spec:
+  rules:
+    - host: ${{ defaults.ui_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: ${{ defaults.app_name }}-ui
+                port:
+                  number: 24900
+  tls:
+    - hosts:
+        - ${{ defaults.ui_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+      secretName: ${{ SEALOS_CERT_SECRET_NAME }}
+
+---
 apiVersion: app.sealos.io/v1
 kind: App
 metadata:
@@ -186,8 +311,8 @@ metadata:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   data:
-    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+    url: https://${{ defaults.ui_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
   icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/meilisearch/logo.png"
   name: "Meilisearch"
-  type: iframe
+  type: link

--- a/template/metabase/README.md
+++ b/template/metabase/README.md
@@ -1,28 +1,141 @@
-# metabase
+# Deploy and Host Metabase on Sealos
 
-## Overview
+Metabase is an open source business intelligence platform for dashboards, SQL exploration, and self-service analytics. This template deploys Metabase 0.61.3 with PostgreSQL, persistent plugin storage, and a public HTTPS endpoint on Sealos Cloud.
 
-The simplest, fastest way to get business intelligence and analytics to everyone in your company 😋
+![Metabase Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/website-screenshot.webp)
 
-This Sealos template deploys **metabase** as the `metabase` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+## About Hosting Metabase
 
-## Deploy on Sealos
+Metabase helps teams connect to databases, ask questions, build dashboards, and share analytics without requiring every user to write SQL. It works well for internal reporting, product analytics, operational metrics, and lightweight embedded BI workflows.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+This Sealos template runs Metabase as a StatefulSet and provisions a Kubeblocks PostgreSQL database for the Metabase application database. A persistent volume is mounted at `/plugins` so custom database drivers and plugin files can survive restarts.
 
-## Access
+Sealos also configures the Kubernetes Service, HTTPS Ingress, generated public URL, and App entry automatically. On first access, Metabase shows its setup flow so you can create the first administrator account and finish the workspace configuration.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Common Use Cases
+
+- **Self-service BI**: Let business users explore data, save questions, and build dashboards.
+- **Operational dashboards**: Track revenue, product usage, support queues, or infrastructure data from connected databases.
+- **SQL exploration**: Provide analysts with a browser-based SQL editor and shared result sets.
+- **Embedded reporting**: Share dashboards or questions with teammates and stakeholders.
+- **Internal analytics portal**: Centralize metrics across teams without running a large BI stack.
+
+## Dependencies for Metabase Hosting
+
+The Sealos template includes the required runtime components: the Metabase container image, a PostgreSQL `postgresql-16.4.0` database, a database initialization job for `metabaseappdb`, persistent plugin storage, a Kubernetes Service, an Ingress, and a Sealos App entry.
+
+### Deployment Dependencies
+
+- [Metabase Website](https://www.metabase.com/) - Product overview and commercial options
+- [Metabase Documentation](https://www.metabase.com/docs/latest/) - Administration, setup, and user documentation
+- [Metabase GitHub Repository](https://github.com/metabase/metabase) - Source code and releases
+- [Metabase Docker Image](https://hub.docker.com/r/metabase/metabase) - Official container image tags
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **Metabase Web Service**: Runs `metabase/metabase:v0.61.3` on port `3000` and serves the web UI, API, and background application tasks.
+- **PostgreSQL**: Kubeblocks-managed PostgreSQL `postgresql-16.4.0` stores Metabase users, permissions, dashboard metadata, questions, and saved settings.
+- **PostgreSQL Init Job**: Creates the `metabaseappdb` database idempotently after PostgreSQL is ready.
+- **Persistent Plugin Storage**: A `1Gi` volume mounted at `/plugins` keeps custom drivers and plugin files across restarts.
+- **Ingress and App Entry**: Sealos exposes Metabase through an HTTPS domain and creates a dashboard entry for direct access.
+
+**Configuration:**
+
+The template configures Metabase with PostgreSQL environment variables from the Kubeblocks connection Secret:
+
+- `MB_DB_TYPE=postgres`
+- `MB_DB_DBNAME=metabaseappdb`
+- `MB_DB_HOST`, `MB_DB_PORT`, `MB_DB_USER`, and `MB_DB_PASS` from `${{ defaults.app_name }}-pg-conn-credential`
+- `JAVA_OPTS=-XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=25` for stable JVM sizing inside the container limit
+
+No required user inputs are needed during deployment. After the first administrator is created, database connections, users, SSO, email, and embedding settings are managed inside the Metabase admin interface.
+
+**License Information:**
+
+Metabase Open Source Edition is distributed under the AGPLv3 License. This Sealos template is provided as deployment configuration for Metabase and does not change the upstream application license.
+
+## Why Deploy Metabase on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the entire application lifecycle, from development in cloud IDEs to production deployment and management. By deploying Metabase on Sealos, you get:
+
+- **One-Click Deployment**: Deploy Metabase, PostgreSQL, storage, networking, and the App entry from one template.
+- **Zero Kubernetes Expertise Required**: Use Kubernetes-backed reliability without writing manifests manually.
+- **Persistent Storage Included**: Keep Metabase metadata in PostgreSQL and plugin files on persistent storage.
+- **Instant Public Access**: Each deployment receives an HTTPS URL for setup, login, and dashboard sharing.
+- **Easy Customization**: Adjust resources, environment variables, and storage through the Sealos Canvas and AI dialog.
+- **Pay-As-You-Go Resources**: Start with a validated resource profile and scale when usage grows.
+
+Deploy Metabase on Sealos and focus on analytics instead of infrastructure management.
+
+## Deployment Guide
+
+1. Open the [Metabase template](https://sealos.io/products/app-store/metabase) and click **Deploy Now**.
+2. Keep the default parameters unless you need a custom generated name or host.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog or click the relevant resource cards to modify settings.
+4. Open the generated Metabase URL from the App entry.
+5. Complete the first-run setup wizard:
+   - Enter the first administrator's name, email address, and password.
+   - Set the organization or site name.
+   - Choose whether to connect your first analytics database immediately or skip and add it later.
+   - Review usage data preferences and finish setup.
+6. After setup, use the same administrator email and password on the login page for future access.
+
+Metabase does not create a public self-registration flow in this template. The first user created during setup becomes the administrator.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Metabase through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **Initial Setup Wizard**: Creates the first administrator account and baseline site settings.
+- **Metabase Admin Settings**: Add data sources, users, groups, permissions, email, SSO, embedding, and localization settings.
+- **Sealos AI Dialog**: Describe environment, resource, or storage changes and let AI apply updates.
+- **Resource Cards**: Click the StatefulSet, PostgreSQL, Ingress, or storage cards in Canvas to inspect and adjust settings.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+If you add custom database drivers, upload the driver JAR to `/plugins` and restart the Metabase workload. Keep database credentials inside Metabase or Sealos-managed settings instead of committing them to the template repository.
 
-## Official Links
+## Scaling
 
-- Official website: metabase.com
-- Source repository: https://github.com/metabase/metabase
+To scale Metabase on Sealos:
+
+1. Open the Canvas for your Metabase deployment.
+2. Click the Metabase StatefulSet resource card.
+3. Increase CPU or memory when startup, migrations, dashboard rendering, or concurrent query activity requires more capacity.
+4. Increase PostgreSQL or storage resources if metadata or plugin usage grows.
+5. Apply the change and wait for the pod to become ready again.
+
+The default application profile is `1` CPU and `2G` memory. Live validation showed `1024Mi` can fail during cold start or restart for Metabase 0.61.3, while `2G` completed cold start, first-run setup, restart, and login checks.
+
+## Troubleshooting
+
+### The app opens the setup wizard
+
+This is expected on a fresh deployment. Complete the wizard to create the first administrator account. After setup, unauthenticated visitors will see the login page.
+
+### The app is slow or restarts during startup
+
+Metabase performs JVM startup and database migrations on cold start. Wait a few minutes during first deployment. If the workload restarts or dashboards are slow, increase memory first and then CPU from the StatefulSet resource card.
+
+### Cannot connect an analytics database
+
+Verify the target database host, port, username, password, network access, and TLS requirements in Metabase Admin Settings. For databases that require custom JDBC drivers, place the driver file in `/plugins` and restart the workload.
+
+### Getting Help
+
+- [Metabase Documentation](https://www.metabase.com/docs/latest/)
+- [Metabase Troubleshooting Guide](https://www.metabase.com/docs/latest/troubleshooting-guide/)
+- [Metabase GitHub Issues](https://github.com/metabase/metabase/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [Metabase Setup Guide](https://www.metabase.com/docs/latest/configuring-metabase/setting-up-metabase)
+- [Metabase Administration Guide](https://www.metabase.com/docs/latest/configuring-metabase/)
+- [Running Metabase on Docker](https://www.metabase.com/docs/latest/installation-and-operation/running-metabase-on-docker)
+
+## License
+
+This Sealos template is provided under the repository's template license. Metabase Open Source Edition itself is licensed under AGPLv3.

--- a/template/metabase/README_zh.md
+++ b/template/metabase/README_zh.md
@@ -1,28 +1,141 @@
-# metabase
+# 在 Sealos 上部署和托管 Metabase
 
-## 应用概览
+Metabase 是一个开源商业智能平台，适用于仪表盘、SQL 探索和自助式数据分析。本模板会在 Sealos Cloud 上部署 Metabase 0.61.3，并配套 PostgreSQL、持久化插件存储和公开 HTTPS 访问入口。
 
-metabase 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+![Metabase 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/website-screenshot.webp)
 
-此 Sealos 模板会将 **metabase** 部署为 `metabase` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+## 关于托管 Metabase
 
-## 在 Sealos 上部署
+Metabase 可以帮助团队连接数据库、提出数据问题、创建仪表盘并共享分析结果，不要求每个用户都编写 SQL。它适合内部报表、产品分析、运营指标和轻量级嵌入式 BI 场景。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+此 Sealos 模板会将 Metabase 作为 StatefulSet 运行，并创建一个 Kubeblocks PostgreSQL 数据库存储 Metabase 应用数据。模板还会把持久化卷挂载到 `/plugins`，用于保留自定义数据库驱动和插件文件。
 
-## 访问方式
+Sealos 会自动配置 Kubernetes Service、HTTPS Ingress、生成的公网 URL 和 App 入口。首次访问时，Metabase 会显示初始化流程，用于创建第一个管理员账号并完成工作区配置。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## 常见使用场景
 
-## 配置说明
+- **自助式 BI**：让业务用户探索数据、保存问题并创建仪表盘。
+- **运营仪表盘**：跟踪收入、产品使用、支持队列或基础设施数据。
+- **SQL 探索**：为分析师提供浏览器中的 SQL 编辑器和可共享结果集。
+- **嵌入式报表**：向团队成员和相关方共享仪表盘或问题。
+- **内部分析门户**：在不运行大型 BI 技术栈的情况下集中管理团队指标。
 
-部署时可以配置以下用户可见输入项：
+## Metabase 托管依赖
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+此 Sealos 模板包含运行所需的组件：Metabase 容器镜像、PostgreSQL `postgresql-16.4.0` 数据库、用于创建 `metabaseappdb` 的数据库初始化 Job、持久化插件存储、Kubernetes Service、Ingress 和 Sealos App 入口。
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 部署依赖
 
-## 官方链接
+- [Metabase 官网](https://www.metabase.com/) - 产品概览和商业版本说明
+- [Metabase 文档](https://www.metabase.com/docs/latest/) - 管理、初始化和用户文档
+- [Metabase GitHub 仓库](https://github.com/metabase/metabase) - 源码与版本发布
+- [Metabase Docker 镜像](https://hub.docker.com/r/metabase/metabase) - 官方容器镜像标签
 
-- 官方网站: metabase.com
-- 源码仓库: https://github.com/metabase/metabase
+### 实现细节
+
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **Metabase Web 服务**：运行 `metabase/metabase:v0.61.3`，监听 `3000` 端口，提供 Web UI、API 和后台应用任务。
+- **PostgreSQL**：由 Kubeblocks 管理的 PostgreSQL `postgresql-16.4.0`，用于存储 Metabase 用户、权限、仪表盘元数据、问题和已保存设置。
+- **PostgreSQL 初始化 Job**：在 PostgreSQL 就绪后，以幂等方式创建 `metabaseappdb` 数据库。
+- **持久化插件存储**：挂载到 `/plugins` 的 `1Gi` 卷，用于在重启后保留自定义驱动和插件文件。
+- **Ingress 与 App 入口**：Sealos 通过 HTTPS 域名暴露 Metabase，并在仪表盘中创建应用入口。
+
+**配置：**
+
+模板会从 Kubeblocks 连接 Secret 中读取 PostgreSQL 环境变量并配置 Metabase：
+
+- `MB_DB_TYPE=postgres`
+- `MB_DB_DBNAME=metabaseappdb`
+- `MB_DB_HOST`、`MB_DB_PORT`、`MB_DB_USER` 和 `MB_DB_PASS` 来自 `${{ defaults.app_name }}-pg-conn-credential`
+- `JAVA_OPTS=-XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=25`，用于在容器限制内稳定设置 JVM 大小
+
+部署时不需要填写必填参数。第一个管理员创建完成后，可以在 Metabase 管理界面中配置数据库连接、用户、SSO、邮件和嵌入式分析设置。
+
+**许可证信息：**
+
+Metabase 开源版使用 AGPLv3 License。此 Sealos 模板只是 Metabase 的部署配置，不改变上游应用许可证。
+
+## 为什么在 Sealos 上部署 Metabase？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，覆盖从云端开发到生产部署和运维管理的完整应用生命周期。在 Sealos 上部署 Metabase 可以获得：
+
+- **一键部署**：通过一个模板同时部署 Metabase、PostgreSQL、存储、网络和 App 入口。
+- **无需 Kubernetes 经验**：不用手写清单，也能获得 Kubernetes 的可靠性。
+- **内置持久化存储**：Metabase 元数据保存在 PostgreSQL 中，插件文件保存在持久化存储中。
+- **即时公网访问**：每次部署都会获得 HTTPS URL，可用于初始化、登录和仪表盘共享。
+- **易于自定义**：可通过 Sealos Canvas 和 AI 对话调整资源、环境变量和存储。
+- **按量使用资源**：从经过验证的资源规格起步，并在使用量增长时扩容。
+
+在 Sealos 上部署 Metabase，可以把精力放在数据分析本身，而不是基础设施维护上。
+
+## 部署指南
+
+1. 打开 [Metabase 模板](https://sealos.io/products/app-store/metabase)，点击 **Deploy Now**。
+2. 除非需要自定义生成名称或访问域名，否则保留默认参数即可。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会跳转到 Canvas。后续如需修改，可在 AI 对话框中描述需求，或点击对应资源卡片调整配置。
+4. 从 App 入口打开生成的 Metabase URL。
+5. 完成首次初始化向导：
+   - 输入首个管理员的姓名、邮箱地址和密码。
+   - 设置组织或站点名称。
+   - 选择是否立即连接第一个分析数据库，也可以跳过后续再添加。
+   - 检查使用数据偏好并完成初始化。
+6. 初始化完成后，后续可在登录页使用同一个管理员邮箱和密码登录。
+
+本模板不会创建公开自助注册流程。初始化过程中创建的第一个用户会成为管理员。
+
+## 配置
+
+部署后，你可以通过以下方式配置 Metabase：
+
+- **初始化向导**：创建首个管理员账号和基础站点设置。
+- **Metabase 管理设置**：添加数据源、用户、用户组、权限、邮件、SSO、嵌入式分析和本地化设置。
+- **Sealos AI 对话**：描述环境变量、资源或存储调整需求，让 AI 协助修改。
+- **资源卡片**：在 Canvas 中点击 StatefulSet、PostgreSQL、Ingress 或存储卡片，查看并调整配置。
+
+如果需要添加自定义数据库驱动，请将驱动 JAR 上传到 `/plugins` 并重启 Metabase 工作负载。数据库凭据应保存在 Metabase 或 Sealos 管理的配置中，不要提交到模板仓库。
+
+## 扩展
+
+在 Sealos 上扩展 Metabase：
+
+1. 打开 Metabase 部署对应的 Canvas。
+2. 点击 Metabase StatefulSet 资源卡片。
+3. 当启动、迁移、仪表盘渲染或并发查询需要更多容量时，提高 CPU 或内存资源。
+4. 如果元数据或插件使用量增长，可提高 PostgreSQL 或存储资源。
+5. 应用变更并等待 Pod 重新就绪。
+
+默认应用规格为 `1` CPU 和 `2G` 内存。实际验证显示，Metabase 0.61.3 使用 `1024Mi` 时可能在冷启动或重启过程中失败；`2G` 已通过冷启动、首次初始化、重启和登录检查。
+
+## 故障排查
+
+### 应用打开后进入初始化向导
+
+这是新部署的正常行为。请完成向导并创建首个管理员账号。初始化完成后，未登录访问会显示登录页。
+
+### 应用启动慢或启动期间重启
+
+Metabase 冷启动时会执行 JVM 启动和数据库迁移。首次部署时请等待几分钟。如果工作负载重启或仪表盘运行缓慢，请先在 StatefulSet 资源卡片中提高内存，再按需提高 CPU。
+
+### 无法连接分析数据库
+
+请在 Metabase 管理设置中检查目标数据库的主机、端口、用户名、密码、网络访问和 TLS 要求。若数据库需要自定义 JDBC 驱动，请将驱动文件放入 `/plugins` 并重启工作负载。
+
+### 获取帮助
+
+- [Metabase 文档](https://www.metabase.com/docs/latest/)
+- [Metabase 故障排查指南](https://www.metabase.com/docs/latest/troubleshooting-guide/)
+- [Metabase GitHub Issues](https://github.com/metabase/metabase/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 更多资源
+
+- [Metabase 初始化指南](https://www.metabase.com/docs/latest/configuring-metabase/setting-up-metabase)
+- [Metabase 管理指南](https://www.metabase.com/docs/latest/configuring-metabase/)
+- [使用 Docker 运行 Metabase](https://www.metabase.com/docs/latest/installation-and-operation/running-metabase-on-docker)
+
+## 许可证
+
+此 Sealos 模板遵循仓库中的模板许可证。Metabase 开源版本身使用 AGPLv3。

--- a/template/metabase/index.yaml
+++ b/template/metabase/index.yaml
@@ -3,44 +3,178 @@ kind: Template
 metadata:
   name: metabase
 spec:
-  title: 'metabase'
-  url: 'https://metabase.com'
-  gitRepo: 'https://github.com/metabase/metabase'
-  author: 'Sealos'
-  description: 'The simplest, fastest way to get business intelligence and analytics to everyone in your company 😋'
-  readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/README.md'
-  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/logo.png'
+  title: Metabase
+  url: https://www.metabase.com/
+  gitRepo: https://github.com/metabase/metabase
+  author: Sealos
+  description: Open source business intelligence and analytics platform for dashboards, SQL exploration, and self-service reporting.
+  readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/README.md
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/logo.png
   screenshots:
-    - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/website-screenshot.webp'
+    - https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/website-screenshot.webp
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: 开源商业智能与数据分析平台，适用于仪表盘、SQL 探索和自助式报表。
+      readme: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/README_zh.md
   categories:
     - database
     - low-code
   defaults:
     app_host:
-      # number or string..
       type: string
-      value: ${{ random(8) }}
+      value: metabase-${{ random(8) }}
     app_name:
       type: string
       value: metabase-${{ random(8) }}
-  inputs:
-
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/README_zh.md'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
+    app.kubernetes.io/managed-by: kbcli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ defaults.app_name }}-pg
+subjects:
+  - kind: ServiceAccount
+    name: ${{ defaults.app_name }}-pg
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${{ defaults.app_name }}-pg
+  labels:
+    kb.io/database: postgresql-16.4.0
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
+    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-16.4.0
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: postgresql
+      componentDefRef: postgresql
+      disableExporter: true
+      enabledLogs:
+        - running
+      replicas: 1
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      switchPolicy:
+        type: Noop
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 51Mi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-pg-init
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: pgsql-init
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          env:
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PG_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: endpoint
+            - name: PG_DATABASE
+              value: metabaseappdb
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              for i in $(seq 1 60); do
+                if pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1; then
+                  break
+                fi
+                sleep 2
+              done
+              pg_isready -h "${PG_ENDPOINT%:*}" -p "${PG_ENDPOINT##*:}" -U postgres -d postgres >/dev/null 2>&1
+              if ! psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='metabaseappdb'" | grep -q 1; then
+                psql "postgresql://postgres:$(PG_PASSWORD)@$(PG_ENDPOINT)/postgres" -v ON_ERROR_STOP=1 -c 'CREATE DATABASE "metabaseappdb";'
+              fi
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: metabase/metabase:v0.50.17
+    originImageName: metabase/metabase:v0.61.3
+    docker-to-sealos.resource-override-source: 'Live Sealos validation on 2026-05-30: Metabase v0.61.3 live setup/login validated at 1 CPU/2G; the workload may restart once while PostgreSQL finishes accepting connections; smaller memory tiers need fresh cold-start validation before use.'
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -54,11 +188,11 @@ spec:
       labels:
         app: ${{ defaults.app_name }}
     spec:
-      terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: metabase/metabase:v0.50.17
+          image: metabase/metabase:v0.61.3
+          imagePullPolicy: IfNotPresent
           env:
             - name: MB_DB_TYPE
               value: postgres
@@ -84,60 +218,97 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: host
+            - name: JAVA_OPTS
+              value: -XX:MaxRAMPercentage=75 -XX:InitialRAMPercentage=25
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            failureThreshold: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            failureThreshold: 6
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+            timeoutSeconds: 5
           resources:
             limits:
-              cpu: 2
-              memory: 2Gi
+              cpu: 1
+              memory: 2048Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
-          ports:
-            - containerPort: 3000
-          imagePullPolicy: IfNotPresent
+              cpu: 100m
+              memory: 204Mi
           volumeMounts:
             - name: vn-plugins
               mountPath: /plugins
-      securityContext:
-        runAsUser: 2000
-        runAsGroup: 2000
-        fsGroup: 2000
-        fsGroupChangePolicy: "OnRootMismatch"
   volumeClaimTemplates:
     - metadata:
+        name: vn-plugins
         annotations:
           path: /plugins
-          value: '0.3'
-        name: vn-plugins
+          value: '1'
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 300Mi
-
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 3000
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP
   selector:
     app: ${{ defaults.app_name }}
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
+    nginx.ingress.kubernetes.io/server-snippet: |
+      client_header_buffer_size 64k;
+      large_client_header_buffers 4 128k;
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
+        expires 30d;
+        add_header Cache-Control "public";
+      }
 spec:
   rules:
     - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
@@ -154,126 +325,6 @@ spec:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: Cluster
-metadata:
-  finalizers:
-    - cluster.kubeblocks.io/finalizer
-  labels:
-    clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
-  name: ${{ defaults.app_name }}-pg
-spec:
-  affinity:
-    nodeLabels: {}
-    podAntiAffinity: Preferred
-    tenancy: SharedNode
-    topologyKeys: []
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
-  componentSpecs:
-    - componentDefRef: postgresql
-      monitor: true
-      name: postgresql
-      replicas: 1
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 51Mi
-      serviceAccountName: ${{ defaults.app_name }}-pg
-      switchPolicy:
-        type: Noop
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-
-  terminationPolicy: Delete
-  tolerations: []
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/instance: ${{ defaults.app_name }}-pg
-    app.kubernetes.io/managed-by: kbcli
-  name: ${{ defaults.app_name }}-pg
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ${{ defaults.app_name }}-pg
-subjects:
-  - kind: ServiceAccount
-    name: ${{ defaults.app_name }}-pg
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ${{ defaults.app_name }}-init
-spec:
-  completions: 1
-  template:
-    spec:
-      containers:
-        - name: pgsql-init
-          image: senzing/postgresql-client:2.2.4
-          env:
-            - name: PG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE metabaseappdb;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
 ---
 apiVersion: app.sealos.io/v1
 kind: App
@@ -285,6 +336,6 @@ spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
-  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/logo.png"
-  name: metabase
+  icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/metabase/logo.png
+  name: Metabase
   type: link

--- a/template/mlflow/README.md
+++ b/template/mlflow/README.md
@@ -1,28 +1,117 @@
-# MLflow
+# Deploy and Host MLflow on Sealos
 
-## Overview
+MLflow is an open-source platform for tracking machine learning experiments, organizing model metadata, and storing model artifacts. This template deploys MLflow with PostgreSQL metadata storage and S3-compatible artifact storage on Sealos Cloud.
 
-MLflow is an open-source developer platform to build AI/LLM applications and models with confidence.
+## About Hosting MLflow
 
-This Sealos template deploys **MLflow** as the `mlflow` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+MLflow runs as a web service that exposes the experiment tracking UI and REST API on port 5000. The Sealos template provisions PostgreSQL for the backend store and an Object Storage bucket for artifacts, so experiment metadata and uploaded files remain persistent across restarts.
 
-## Deploy on Sealos
+MLflow does not include built-in login or user authentication in this deployment. Treat the generated Sealos URL as an application endpoint for your workspace, and add an external authentication layer or network access control if you need multi-user or public access protection.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Experiment Tracking**: Record parameters, metrics, tags, and artifacts for model training runs.
+- **Model Registry Workflows**: Organize model versions and metadata for review and promotion workflows.
+- **Artifact Storage**: Store training outputs, plots, model files, and evaluation reports in S3-compatible storage.
+- **Team ML Operations**: Share a central tracking server across notebooks, scripts, and CI jobs.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for MLflow Hosting
+
+The Sealos template includes all required runtime dependencies: the MLflow server container, a KubeBlocks PostgreSQL 16.4 cluster for metadata, and a private Object Storage bucket for artifacts.
+
+### Deployment Dependencies
+
+- [MLflow Documentation](https://mlflow.org/docs/latest/) - Official documentation
+- [MLflow Tracking](https://mlflow.org/docs/latest/ml/tracking/) - Tracking UI and API guide
+- [MLflow GitHub Repository](https://github.com/mlflow/mlflow) - Source code and issues
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **MLflow Server**: Serves the web UI and REST API at port 5000.
+- **PostgreSQL**: Stores experiment, run, parameter, metric, and model metadata.
+- **Object Storage**: Stores MLflow artifacts through the S3 API.
+- **Ingress and App Link**: Provides the public HTTPS endpoint managed by Sealos.
+
+**Configuration:**
+
+The server starts with `--backend-store-uri` pointing to PostgreSQL and `--default-artifact-root` pointing to the generated S3 bucket. Sealos injects database credentials and object storage credentials through managed secrets, so no manual credential entry is required during deployment.
+
+**Access and Authentication:**
+
+MLflow is available immediately after deployment at the generated HTTPS URL. This template does not configure username/password login because upstream MLflow tracking server does not provide a built-in login screen for this mode. Use Sealos workspace controls, private sharing practices, or an external proxy/authentication layer when the endpoint should not be publicly reachable.
+
+**License Information:**
+
+MLflow is licensed under the Apache License 2.0. This Sealos template is provided under the repository license for the Sealos templates project.
+
+## Why Deploy MLflow on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies application deployment, networking, storage, and day-2 operations. By deploying MLflow on Sealos, you get:
+
+- **One-Click Deployment**: Deploy MLflow, PostgreSQL, object storage, service, ingress, and app link from one template.
+- **Persistent Metadata and Artifacts**: Keep MLflow metadata in PostgreSQL and artifacts in managed S3-compatible storage.
+- **Instant Public Access**: Get an HTTPS endpoint after deployment without manually configuring ingress or certificates.
+- **Easy Customization**: Adjust CPU, memory, environment variables, and storage from the Sealos Canvas after deployment.
+- **Kubernetes Foundation**: Run MLflow on Kubernetes without managing raw manifests yourself.
+- **Pay-as-You-Go Resources**: Start with the template defaults and scale resources when workloads grow.
+
+## Deployment Guide
+
+1. Open the [MLflow template](https://sealos.io/products/app-store/mlflow) and click **Deploy Now**.
+2. Keep the default parameters unless you need a custom app name or hostname.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the AI dialog, or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **MLflow UI**: Open the generated HTTPS app URL. No default username or password is created.
+   - **Tracking API**: Use the same generated URL as `MLFLOW_TRACKING_URI` in MLflow clients.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure MLflow through:
 
-This template does not define extra user inputs; the default settings are enough to deploy it.
+- **AI Dialog**: Describe the changes you want and let Sealos apply updates.
+- **Resource Cards**: Open the Deployment, PostgreSQL, Object Storage, or Ingress cards to adjust resources and settings.
+- **MLflow Clients**: Set `MLFLOW_TRACKING_URI` to the generated app URL in notebooks, training scripts, or CI jobs.
+- **External Access Control**: Add an authentication proxy or restrict access if your tracking server contains sensitive experiment data.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+To scale MLflow resources:
 
-- Official website: https://mlflow.org/
-- Source repository: https://github.com/mlflow/mlflow
+1. Open the Canvas for your deployment.
+2. Click the MLflow Deployment resource card.
+3. Adjust CPU and memory based on request volume, artifact activity, and UI usage.
+4. Apply the changes in the dialog and wait for the new pod to become ready.
+
+## Troubleshooting
+
+### The MLflow URL opens without a login page
+
+MLflow tracking server does not provide built-in login in this deployment mode. This is expected. Protect the endpoint with workspace access rules, private sharing, or an external authentication proxy if needed.
+
+### Clients cannot log runs
+
+Confirm that `MLFLOW_TRACKING_URI` uses the generated HTTPS URL. If your run uploads artifacts, also confirm that the deployment is healthy and the Object Storage bucket exists in the Canvas.
+
+### Deployment takes longer than expected
+
+PostgreSQL and the MLflow container need time to initialize. If the app is not ready after several minutes, inspect the Deployment and PostgreSQL resource cards in Canvas.
+
+### Getting Help
+
+- [MLflow Documentation](https://mlflow.org/docs/latest/)
+- [MLflow GitHub Issues](https://github.com/mlflow/mlflow/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [MLflow Tracking API](https://mlflow.org/docs/latest/api_reference/rest-api.html)
+- [MLflow Python API](https://mlflow.org/docs/latest/python_api/)
+- [Sealos App Store](https://sealos.io/products/app-store)
+
+## License
+
+This Sealos template is provided under the repository license for Sealos templates. MLflow itself is licensed under the Apache License 2.0.

--- a/template/mlflow/README_zh.md
+++ b/template/mlflow/README_zh.md
@@ -1,28 +1,117 @@
-# MLflow
+# 在 Sealos 上部署和托管 MLflow
 
-## 应用概览
+MLflow 是一个开源平台，用于跟踪机器学习实验、整理模型元数据并存储模型产物。此模板会在 Sealos Cloud 上部署 MLflow，并配置 PostgreSQL 元数据存储和 S3 兼容产物存储。
 
-开源机器学习生命周期平台 - 跟踪实验、打包代码为可重现运行、共享和部署模型
+## 关于托管 MLflow
 
-此 Sealos 模板会将 **MLflow** 部署为 `mlflow` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+MLflow 以 Web 服务形式运行，在 5000 端口提供实验跟踪界面和 REST API。Sealos 模板会自动创建 PostgreSQL 作为 backend store，并创建 Object Storage 存储桶保存 artifacts，因此实验元数据和上传文件在重启后仍会保留。
 
-## 在 Sealos 上部署
+此部署模式下，MLflow 默认不包含内置登录或用户认证。请将生成的 Sealos URL 视为工作区内的应用入口；如果需要多人或公网访问保护，请额外添加认证代理或网络访问控制。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **实验跟踪**：记录模型训练运行的参数、指标、标签和产物。
+- **模型注册流程**：整理模型版本和元数据，用于评审和发布流程。
+- **产物存储**：保存训练输出、图表、模型文件和评估报告。
+- **团队机器学习运维**：为 notebooks、脚本和 CI 任务共享一个中心化 tracking server。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## MLflow 托管依赖
 
-## 配置说明
+Sealos 模板包含所需运行依赖：MLflow server 容器、用于元数据的 KubeBlocks PostgreSQL 16.4 集群，以及用于 artifacts 的私有 Object Storage 存储桶。
 
-部署时可以配置以下用户可见输入项：
+### 部署依赖
 
-此模板没有额外的用户输入项；保留默认配置即可完成部署。
+- [MLflow 文档](https://mlflow.org/docs/latest/) - 官方文档
+- [MLflow Tracking](https://mlflow.org/docs/latest/ml/tracking/) - Tracking UI 和 API 指南
+- [MLflow GitHub 仓库](https://github.com/mlflow/mlflow) - 源代码和问题反馈
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 实现细节
 
-## 官方链接
+**架构组件：**
 
-- 官方网站: https://mlflow.org/
-- 源码仓库: https://github.com/mlflow/mlflow
+此模板会部署以下服务：
+
+- **MLflow Server**：在 5000 端口提供 Web UI 和 REST API。
+- **PostgreSQL**：保存实验、运行记录、参数、指标和模型元数据。
+- **Object Storage**：通过 S3 API 保存 MLflow artifacts。
+- **Ingress 和 App Link**：提供由 Sealos 管理的公网 HTTPS 入口。
+
+**配置：**
+
+服务启动时会将 `--backend-store-uri` 指向 PostgreSQL，并将 `--default-artifact-root` 指向生成的 S3 存储桶。Sealos 通过托管 Secret 注入数据库和对象存储凭据，部署时无需手动填写私有凭据。
+
+**访问与认证：**
+
+部署完成后，可以通过生成的 HTTPS URL 直接访问 MLflow。此模板不会创建用户名或密码，因为上游 MLflow tracking server 在该模式下没有内置登录页。如果 tracking server 不应公开访问，请使用 Sealos 工作区控制、私有分享策略或外部认证代理。
+
+**许可证信息：**
+
+MLflow 使用 Apache License 2.0。此 Sealos 模板遵循 Sealos templates 仓库的许可证。
+
+## 为什么在 Sealos 上部署 MLflow？
+
+Sealos 是基于 Kubernetes 的 AI 辅助云操作系统，统一管理应用部署、网络、存储和后续运维。在 Sealos 上部署 MLflow，你可以获得：
+
+- **一键部署**：通过一个模板部署 MLflow、PostgreSQL、对象存储、Service、Ingress 和 App 入口。
+- **持久化元数据与产物**：使用 PostgreSQL 保存 MLflow 元数据，并使用托管 S3 兼容存储保存 artifacts。
+- **即时公网访问**：部署后获得 HTTPS 入口，无需手动配置 Ingress 或证书。
+- **易于调整**：部署后可在 Sealos Canvas 中调整 CPU、内存、环境变量和存储配置。
+- **Kubernetes 基础能力**：无需直接维护原始 Kubernetes YAML，也能运行在 Kubernetes 之上。
+- **按量资源使用**：先使用模板默认资源，之后再按工作负载增长进行扩容。
+
+## 部署指南
+
+1. 打开 [MLflow 模板](https://sealos.io/products/app-store/mlflow)，点击 **Deploy Now**。
+2. 除非需要自定义应用名称或域名前缀，否则保留默认参数。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会进入 Canvas。后续如需修改，可在 AI 对话框描述需求，或点击对应资源卡片调整设置。
+4. 通过生成的 URL 访问应用：
+   - **MLflow UI**：打开生成的 HTTPS 应用地址。系统不会创建默认用户名或密码。
+   - **Tracking API**：在 MLflow 客户端中将同一个生成地址设置为 `MLFLOW_TRACKING_URI`。
+
+## 配置
+
+部署后，可以通过以下方式配置 MLflow：
+
+- **AI 对话框**：描述需要修改的内容，让 Sealos 应用变更。
+- **资源卡片**：打开 Deployment、PostgreSQL、Object Storage 或 Ingress 卡片调整资源和设置。
+- **MLflow 客户端**：在 notebooks、训练脚本或 CI 任务中将 `MLFLOW_TRACKING_URI` 设置为生成的应用地址。
+- **外部访问控制**：如果 tracking server 包含敏感实验数据，请添加认证代理或限制访问范围。
+
+## 扩容
+
+如需扩展 MLflow 资源：
+
+1. 打开该部署对应的 Canvas。
+2. 点击 MLflow Deployment 资源卡片。
+3. 根据请求量、artifact 活动和 UI 使用情况调整 CPU 与内存。
+4. 在对话框中应用变更，并等待新 Pod 进入 ready 状态。
+
+## 故障排查
+
+### MLflow URL 打开后没有登录页
+
+MLflow tracking server 在此部署模式下没有内置登录功能。这是预期行为。如需保护入口，请使用工作区访问规则、私有分享或外部认证代理。
+
+### 客户端无法写入运行记录
+
+确认 `MLFLOW_TRACKING_URI` 使用生成的 HTTPS URL。如果运行记录需要上传 artifacts，也请确认部署状态健康，并且 Canvas 中存在 Object Storage 存储桶。
+
+### 部署耗时超过预期
+
+PostgreSQL 和 MLflow 容器初始化需要一定时间。如果几分钟后应用仍未 ready，请在 Canvas 中检查 Deployment 和 PostgreSQL 资源卡片。
+
+### 获取帮助
+
+- [MLflow 文档](https://mlflow.org/docs/latest/)
+- [MLflow GitHub Issues](https://github.com/mlflow/mlflow/issues)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [MLflow Tracking API](https://mlflow.org/docs/latest/api_reference/rest-api.html)
+- [MLflow Python API](https://mlflow.org/docs/latest/python_api/)
+- [Sealos 应用商店](https://sealos.io/products/app-store)
+
+## 许可证
+
+此 Sealos 模板遵循 Sealos templates 仓库的许可证。MLflow 本身使用 Apache License 2.0。

--- a/template/mlflow/index.yaml
+++ b/template/mlflow/index.yaml
@@ -7,7 +7,7 @@ spec:
   url: 'https://mlflow.org/'
   gitRepo: 'https://github.com/mlflow/mlflow'
   author: 'Sealos'
-  description: 'MLflow is an open-source developer platform to build AI/LLM applications and models with confidence.'
+  description: 'MLflow is an open-source platform for tracking machine learning experiments, packaging projects, and managing model artifacts.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mlflow/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mlflow/logo.png'
   screenshots:
@@ -20,7 +20,7 @@ spec:
   locale: en
   i18n:
     zh:
-      description: '开源机器学习生命周期平台 - 跟踪实验、打包代码为可重现运行、共享和部署模型'
+      description: '开源机器学习生命周期平台，用于跟踪实验、管理模型和存储训练产物。'
       readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mlflow/README_zh.md'
   defaults:
     app_name:
@@ -90,10 +90,10 @@ metadata:
   finalizers:
     - cluster.kubeblocks.io/finalizer
   labels:
+    kb.io/database: postgresql-16.4.0
     clusterdefinition.kubeblocks.io/name: postgresql
-    clusterversion.kubeblocks.io/name: postgresql-14.8.0
+    clusterversion.kubeblocks.io/name: postgresql-16.4.0
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
   name: ${{ defaults.app_name }}-pg
 spec:
   affinity:
@@ -102,10 +102,12 @@ spec:
     tenancy: SharedNode
     topologyKeys: []
   clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-14.8.0
+  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
     - componentDefRef: postgresql
-      monitor: true
+      disableExporter: true
+      enabledLogs:
+        - running
       name: postgresql
       replicas: 1
       resources:
@@ -138,29 +140,57 @@ metadata:
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  completions: 1
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 120
   template:
     spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
       containers:
         - name: pgsql-init
-          image: postgres:14-alpine
+          image: senzing/postgresql-client:2.2.4
+          imagePullPolicy: IfNotPresent
           env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
-            - name: DATABASE_URL
-              value: postgresql://postgres:$(PG_PASSWORD)@${{ defaults.app_name }}-pg-postgresql.${{ SEALOS_NAMESPACE }}.svc:5432
+            - name: PG_DATABASE
+              value: mlflow
           command:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE mlflow;' &>/dev/null; do sleep 1; done
-      restartPolicy: Never
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 300
-
+              set -eu
+              until PGPASSWORD="$PG_PASSWORD" pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; do
+                sleep 5
+              done
+              if ! PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='mlflow'" | grep -q 1; then
+                PGPASSWORD="$PG_PASSWORD" createdb -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" mlflow
+              fi
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
 
 ---
 apiVersion: apps/v1
@@ -168,9 +198,10 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/mlflow/mlflow:v2.22.2
+    originImageName: ghcr.io/mlflow/mlflow:v3.12.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
+    docker-to-sealos.resource-override-source: 'Empirical Sealos deployment test for MLflow 3.12.0: 256Mi, 512Mi and 1024Mi memory failed cold-start readiness; 2 CPU / 2G with two Uvicorn workers reached Ready and served UI plus REST API with PostgreSQL 16.4 and S3 artifact storage. MLflow 3 security middleware also requires --allowed-hosts and --cors-allowed-origins for the generated public host.'
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     app: ${{ defaults.app_name }}
@@ -188,7 +219,8 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-postgres
-          image: busybox:latest
+          image: senzing/postgresql-client:2.2.4
+          imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
               valueFrom:
@@ -200,19 +232,42 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PG_DATABASE
+              value: mlflow
           command:
             - /bin/sh
             - -c
             - |
-              echo "Waiting for PostgreSQL..."
-              until nc -z $(PG_HOST) $(PG_PORT); do
-                echo "PostgreSQL is not ready..."
-                sleep 5
+              set -eu
+              until PGPASSWORD="$PG_PASSWORD" pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; do
+                sleep 2
               done
-              echo "PostgreSQL is ready!"
+              until PGPASSWORD="$PG_PASSWORD" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='mlflow'" | grep -q 1; do
+                sleep 2
+              done
+              until PGPASSWORD="$PG_PASSWORD" pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DATABASE" >/dev/null 2>&1; do
+                sleep 2
+              done
+          resources:
+            requests:
+              cpu: 20m
+              memory: 25Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/mlflow/mlflow:v2.22.2
+          image: ghcr.io/mlflow/mlflow:v3.12.0
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -237,16 +292,20 @@ spec:
                   key: password
             - name: MLFLOW_BACKEND_STORE_URI
               value: postgresql://$(PG_USER):$(PG_PASSWORD)@$(PG_HOST):$(PG_PORT)/mlflow
-            - name: AWS_ACCESS_KEY_ID
+            - name: S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key
                   key: accessKey
-            - name: AWS_SECRET_ACCESS_KEY
+            - name: S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key
                   key: secretKey
+            - name: AWS_ACCESS_KEY_ID
+              value: $(S3_ACCESS_KEY_ID)
+            - name: AWS_SECRET_ACCESS_KEY
+              value: $(S3_SECRET_ACCESS_KEY)
             - name: MLFLOW_S3_BUCKET
               valueFrom:
                 secretKeyRef:
@@ -260,7 +319,7 @@ spec:
             - name: MLFLOW_S3_ENDPOINT_URL
               value: "https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)"
             - name: MLFLOW_DEFAULT_ARTIFACT_ROOT
-              value: s3://$(MLFLOW_S3_BUCKET)/
+              value: s3://$(MLFLOW_S3_BUCKET)/mlflow
             - name: AWS_DEFAULT_REGION
               value: us-east-1
             - name: MLFLOW_S3_IGNORE_TLS
@@ -269,16 +328,25 @@ spec:
               value: 0.0.0.0
             - name: MLFLOW_PORT
               value: "5000"
+            - name: MLFLOW_ALLOWED_HOSTS
+              value: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: MLFLOW_CORS_ALLOWED_ORIGINS
+              value: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+            - name: MLFLOW_UVICORN_OPTS
+              value: "--workers 2"
           command:
             - /bin/bash
             - -c
             - |
-              pip install --no-cache-dir mlflow[extras] boto3 psycopg2-binary
+              pip install --no-cache-dir boto3==1.43.17 psycopg2-binary==2.9.12
               mlflow server \
                 --backend-store-uri ${MLFLOW_BACKEND_STORE_URI} \
                 --default-artifact-root ${MLFLOW_DEFAULT_ARTIFACT_ROOT} \
                 --host ${MLFLOW_HOST} \
-                --port ${MLFLOW_PORT}
+                --port ${MLFLOW_PORT} \
+                --allowed-hosts ${MLFLOW_ALLOWED_HOSTS} \
+                --cors-allowed-origins ${MLFLOW_CORS_ALLOWED_ORIGINS} \
+                --uvicorn-opts "${MLFLOW_UVICORN_OPTS}"
           ports:
             - containerPort: 5000
               name: http
@@ -296,13 +364,11 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: 100m
-              memory: 102Mi
-              ephemeral-storage: 300Mi
+              cpu: 200m
+              memory: 200Mi
             limits:
-              cpu: 1000m
-              memory: 1024Mi
-              ephemeral-storage: 300Mi
+              cpu: 2
+              memory: 2G
 
 ---
 apiVersion: v1
@@ -311,6 +377,7 @@ metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    app: ${{ defaults.app_name }}
 spec:
   ports:
     - name: http

--- a/template/mongo-express/README.md
+++ b/template/mongo-express/README.md
@@ -1,32 +1,131 @@
-# mongo-express
+# Deploy and Host mongo-express on Sealos
 
-## Overview
+mongo-express is a web-based MongoDB administration interface built with Node.js, Express, and Bootstrap 3. This template deploys mongo-express with a Sealos-managed MongoDB instance, public HTTPS access, and Basic Authentication enabled by default.
 
-A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap3
+## About Hosting mongo-express
 
-This Sealos template deploys **mongo-express** as the `mongo-express` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+mongo-express provides a browser-based interface for browsing databases, collections, documents, indexes, and server metadata in MongoDB. It is useful for development, testing, internal administration, and lightweight database inspection when you need a visual UI instead of a command-line client.
 
-## Deploy on Sealos
+This Sealos template provisions a dedicated MongoDB KubeBlocks cluster and a mongo-express Deployment. Sealos also creates the Service, Ingress, SSL-enabled public URL, and dashboard entry so you can open the admin UI directly after deployment.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+Basic Authentication is enabled on the web UI. The default username is `admin`, and the password is generated automatically for each deployment. The MongoDB DSN is built from the managed MongoDB service and the KubeBlocks root password, so no external MongoDB connection string is required for the default template.
 
-## Access
+## Common Use Cases
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+- **MongoDB Administration**: Browse databases, collections, indexes, and documents from a web interface.
+- **Development Debugging**: Inspect application data while building or testing MongoDB-backed services.
+- **Internal Operations**: Give trusted team members a simple UI for database maintenance.
+- **Schema Exploration**: Review document structure and sample records without installing local tools.
+
+## Dependencies for mongo-express Hosting
+
+The Sealos template includes all required runtime dependencies: mongo-express, a managed MongoDB database, a Kubernetes Service, an Ingress, and a Sealos App entry.
+
+### Deployment Dependencies
+
+- [mongo-express GitHub Repository](https://github.com/mongo-express/mongo-express) - Source code and project documentation
+- [mongo-express Docker Image](https://hub.docker.com/_/mongo-express) - Official container image
+- [MongoDB Documentation](https://www.mongodb.com/docs/) - MongoDB usage and administration reference
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys the following services:
+
+- **mongo-express**: Web UI running `mongo-express:1.0.2-20-alpine3.19` on port `8081`.
+- **MongoDB**: Sealos-managed KubeBlocks MongoDB `8.0.4` cluster with persistent storage.
+- **Ingress and App Entry**: Public HTTPS route and Sealos dashboard link for the UI.
+
+**Configuration:**
+
+- `ME_CONFIG_MONGODB_URL` is composed as `mongodb://root:<managed-password>@<managed-mongodb-service>:27017/admin?authSource=admin`.
+- The managed MongoDB password comes from the KubeBlocks root account secret.
+- Basic Authentication uses `ME_CONFIG_BASICAUTH_USERNAME` and `ME_CONFIG_BASICAUTH_PASSWORD`.
+- Health checks use the `/status` endpoint exposed by mongo-express.
+- The validated minimum app resource tier is `100m` CPU and `128Mi` memory, with requests derived as `10m` CPU and `12Mi` memory.
+
+**Login Information:**
+
+After deployment, open the application URL from the Sealos App details. Sign in with:
+
+- **Username**: `admin`
+- **Password**: the generated `ME_CONFIG_BASICAUTH_PASSWORD` value in the mongo-express Deployment environment
+
+Keep this password private. Anyone with the web login can administer the MongoDB instance through mongo-express.
+
+**MongoDB DSN:**
+
+The default deployment does not ask for an external MongoDB DSN. It creates a managed MongoDB cluster and injects the internal DSN automatically through `ME_CONFIG_MONGODB_URL`. To connect mongo-express to another MongoDB server, edit the Deployment environment after deployment and replace `ME_CONFIG_MONGODB_URL` with your own MongoDB connection string.
+
+**License Information:**
+
+mongo-express is licensed under the MIT License. This Sealos template is provided under the repository license for Sealos templates.
+
+## Why Deploy mongo-express on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies the application lifecycle from deployment to operations. By deploying mongo-express on Sealos, you get:
+
+- **One-Click Deployment**: Open the template page, configure the deployment, and let Sealos create the database and web UI resources.
+- **Managed Kubernetes Runtime**: Run mongo-express on a Kubernetes-based platform without writing manifests manually.
+- **Persistent MongoDB Storage**: The managed MongoDB cluster stores data on persistent storage.
+- **Instant Public Access**: Sealos provisions an HTTPS URL and dashboard App entry automatically.
+- **Simple Operations**: Use Canvas, AI dialog, and resource cards for later configuration or resource changes.
+- **Resource Efficiency**: Start with a small validated resource profile and scale from the Sealos UI when needed.
+
+## Deployment Guide
+
+1. Open the [mongo-express template](https://sealos.io/products/app-store/mongo-express) and click **Deploy Now**.
+2. Review the generated defaults. Keep the generated `ME_CONFIG_BASICAUTH_PASSWORD` value safe because it is used for the web login.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Access your application via the provided URL:
+   - **mongo-express UI**: Log in with username `admin` and the generated `ME_CONFIG_BASICAUTH_PASSWORD` value from the Deployment environment.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure mongo-express through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `custom_express_password` | User-defined mongo express login account password (non-database). The default is `sealos`. | `false` | `<redacted>` |
-| `custom_express_user` | User-defined mongo express login account user (non-database). The default is `admin`. | `false` | `admin` |
-| `mongodb_conn_credential` | mongodb conn credential, ex. mongodb://user:password@host:port/dbname | `true` | `<redacted>` |
+- **AI Dialog**: Describe changes such as increasing CPU or memory and let AI apply updates.
+- **Resource Cards**: Click the Deployment, MongoDB, Service, or Ingress cards to review and modify settings.
+- **Environment Variables**: Advanced users can adjust `ME_CONFIG_MONGODB_URL`, Basic Auth credentials, read-only mode, or editor options from the Deployment resource card.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+To scale resources for heavier database inspection workloads:
 
-- Official website: https://github.com/mongo-express/mongo-express
-- Source repository: https://github.com/mongo-express/mongo-express
+1. Open the Canvas for your deployment.
+2. Click the mongo-express Deployment resource card.
+3. Adjust CPU and memory resources, then apply the change in the dialog.
+4. Click the MongoDB resource card if database capacity also needs to be increased.
+
+## Troubleshooting
+
+### Common Issues
+
+**Login prompt appears immediately**
+- Cause: Basic Authentication is enabled by design.
+- Solution: Use username `admin` and the generated `ME_CONFIG_BASICAUTH_PASSWORD` value from the Deployment environment.
+
+**The UI cannot connect to MongoDB**
+- Cause: The MongoDB cluster may still be starting, the DSN was changed, or credentials were changed manually.
+- Solution: Wait for the MongoDB resource to become ready in Canvas. If credentials or DSN values were changed, redeploy or update `ME_CONFIG_MONGODB_URL` and the related password environment value.
+
+**The UI is reachable but shows limited data**
+- Cause: mongo-express displays the data available to the configured MongoDB account.
+- Solution: This template uses the managed root account for administration. Confirm that your target data exists in this deployed MongoDB instance.
+
+### Getting Help
+
+- [mongo-express GitHub Issues](https://github.com/mongo-express/mongo-express/issues)
+- [MongoDB Documentation](https://www.mongodb.com/docs/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## Additional Resources
+
+- [mongo-express Configuration](https://github.com/mongo-express/mongo-express#usage-docker)
+- [MongoDB Connection Strings](https://www.mongodb.com/docs/manual/reference/connection-string/)
+- [Sealos App Store](https://sealos.io/products/app-store)
+
+## License
+
+This Sealos template is provided under the repository license. mongo-express itself is licensed under the MIT License.

--- a/template/mongo-express/README_zh.md
+++ b/template/mongo-express/README_zh.md
@@ -1,32 +1,131 @@
-# mongo-express
+# 在 Sealos 上部署和托管 mongo-express
 
-## 应用概览
+mongo-express 是一个基于 Node.js、Express 和 Bootstrap 3 的 MongoDB Web 管理界面。此模板会在 Sealos 上部署 mongo-express，并自动创建 Sealos 托管的 MongoDB、公开 HTTPS 访问入口和默认启用的 Basic Authentication。
 
-mongo-express 是一个可在 Sealos 上一键部署的应用，模板会创建所需资源并提供应用访问入口。
+## 关于托管 mongo-express
 
-此 Sealos 模板会将 **mongo-express** 部署为 `mongo-express` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+mongo-express 提供浏览器界面，可用于查看 MongoDB 数据库、集合、文档、索引和服务器元数据。它适合开发、测试、内部管理，以及需要图形界面而不是命令行客户端的轻量数据库检查场景。
 
-## 在 Sealos 上部署
+此 Sealos 模板会创建专用的 MongoDB KubeBlocks 集群和 mongo-express Deployment。Sealos 还会创建 Service、Ingress、SSL 公网 URL 和仪表盘 App 入口，部署完成后即可直接打开管理界面。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+Web UI 默认启用 Basic Authentication。默认用户名为 `admin`，密码会在每次部署时自动生成。MongoDB DSN 会由托管 MongoDB 服务和 KubeBlocks root 密码自动组合，默认模板不需要外部 MongoDB 连接字符串。
 
-## 访问方式
+## 常见使用场景
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+- **MongoDB 管理**：通过 Web 界面浏览数据库、集合、索引和文档。
+- **开发调试**：在构建或测试 MongoDB 应用时检查应用数据。
+- **内部运维**：为可信团队成员提供简单的数据库维护界面。
+- **结构探索**：无需安装本地工具即可查看文档结构和样例记录。
 
-## 配置说明
+## mongo-express 托管依赖
 
-部署时可以配置以下用户可见输入项：
+此 Sealos 模板包含所有必需运行依赖：mongo-express、托管 MongoDB 数据库、Kubernetes Service、Ingress 和 Sealos App 入口。
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `custom_express_password` | `custom_express_password` 部署参数。 | `否` | `<已隐藏>` |
-| `custom_express_user` | `custom_express_user` 部署参数。 | `否` | `admin` |
-| `mongodb_conn_credential` | `mongodb_conn_credential` 部署参数。 | `是` | `<已隐藏>` |
+### 部署依赖
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+- [mongo-express GitHub 仓库](https://github.com/mongo-express/mongo-express) - 源代码和项目文档
+- [mongo-express Docker 镜像](https://hub.docker.com/_/mongo-express) - 官方容器镜像
+- [MongoDB 文档](https://www.mongodb.com/docs/) - MongoDB 使用和管理参考
 
-## 官方链接
+### 实现细节
 
-- 官方网站: https://github.com/mongo-express/mongo-express
-- 源码仓库: https://github.com/mongo-express/mongo-express
+**架构组件：**
+
+此模板会部署以下服务：
+
+- **mongo-express**：运行 `mongo-express:1.0.2-20-alpine3.19` 的 Web UI，监听端口 `8081`。
+- **MongoDB**：由 Sealos 托管的 KubeBlocks MongoDB `8.0.4` 集群，带持久化存储。
+- **Ingress 和 App 入口**：用于访问 UI 的公开 HTTPS 路由和 Sealos 仪表盘入口。
+
+**配置：**
+
+- `ME_CONFIG_MONGODB_URL` 会组合为 `mongodb://root:<托管密码>@<托管-mongodb-service>:27017/admin?authSource=admin`。
+- 托管 MongoDB 密码来自 KubeBlocks root 账号 Secret。
+- Basic Authentication 使用 `ME_CONFIG_BASICAUTH_USERNAME` 和 `ME_CONFIG_BASICAUTH_PASSWORD`。
+- 健康检查使用 mongo-express 暴露的 `/status` 端点。
+- 已验证的最小应用资源档位为 `100m` CPU 和 `128Mi` 内存，对应 requests 为 `10m` CPU 和 `12Mi` 内存。
+
+**登录信息：**
+
+部署完成后，从 Sealos App 详情中打开应用 URL。使用以下信息登录：
+
+- **用户名**：`admin`
+- **密码**：mongo-express Deployment 环境变量中的 `ME_CONFIG_BASICAUTH_PASSWORD`
+
+请妥善保管此密码。任何拥有 Web 登录信息的人都可以通过 mongo-express 管理 MongoDB 实例。
+
+**MongoDB DSN：**
+
+默认部署不要求外部 MongoDB DSN。模板会创建托管 MongoDB 集群，并通过 `ME_CONFIG_MONGODB_URL` 自动注入内部 DSN。如需连接到其他 MongoDB 服务器，请在部署后编辑 Deployment 环境变量，将 `ME_CONFIG_MONGODB_URL` 替换为你自己的 MongoDB 连接字符串。
+
+**许可证信息：**
+
+mongo-express 使用 MIT License。此 Sealos 模板遵循 Sealos templates 仓库许可证。
+
+## 为什么在 Sealos 上部署 mongo-express？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一应用从部署到运维的生命周期。在 Sealos 上部署 mongo-express 可以获得：
+
+- **一键部署**：打开模板页面，配置部署参数，由 Sealos 自动创建数据库和 Web UI 资源。
+- **托管 Kubernetes 运行时**：无需手写 Kubernetes YAML 即可运行 mongo-express。
+- **持久化 MongoDB 存储**：托管 MongoDB 集群使用持久化存储保存数据。
+- **即时公网访问**：Sealos 会自动创建 HTTPS URL 和仪表盘 App 入口。
+- **简单运维**：后续可通过 Canvas、AI 对话和资源卡片调整配置或资源。
+- **资源高效**：从已验证的小资源配置开始，需要时可在 Sealos UI 中扩容。
+
+## 部署指南
+
+1. 打开 [mongo-express 模板](https://sealos.io/products/app-store/mongo-express)，点击 **Deploy Now**。
+2. 检查生成的默认值。请保存生成的 `ME_CONFIG_BASICAUTH_PASSWORD`，它用于 Web 登录。
+3. 等待部署完成，通常需要 2-3 分钟。部署完成后会跳转到 Canvas。后续如需调整，可在对话框中描述需求让 AI 修改，或点击对应资源卡片修改设置。
+4. 通过提供的 URL 访问应用：
+   - **mongo-express UI**：使用用户名 `admin` 和 Deployment 环境变量中的 `ME_CONFIG_BASICAUTH_PASSWORD` 登录。
+
+## 配置
+
+部署后，可以通过以下方式配置 mongo-express：
+
+- **AI 对话**：描述需要的调整，例如增加 CPU 或内存，让 AI 应用修改。
+- **资源卡片**：点击 Deployment、MongoDB、Service 或 Ingress 资源卡片查看并修改设置。
+- **环境变量**：高级用户可在 Deployment 资源卡片中调整 `ME_CONFIG_MONGODB_URL`、Basic Auth 凭据、只读模式或编辑器选项。
+
+## 扩容
+
+如需支持更重的数据库检查工作负载，可按以下步骤扩容资源：
+
+1. 打开当前部署的 Canvas。
+2. 点击 mongo-express Deployment 资源卡片。
+3. 调整 CPU 和内存资源，并在对话框中应用更改。
+4. 如果数据库容量也需要提升，点击 MongoDB 资源卡片调整。
+
+## 故障排查
+
+### 常见问题
+
+**打开后立即出现登录弹窗**
+- 原因：Basic Authentication 默认启用。
+- 解决方案：使用用户名 `admin` 和 Deployment 环境变量中的 `ME_CONFIG_BASICAUTH_PASSWORD` 登录。
+
+**UI 无法连接 MongoDB**
+- 原因：MongoDB 集群可能仍在启动，DSN 被修改，或凭据被手动修改。
+- 解决方案：在 Canvas 中等待 MongoDB 资源就绪。如果凭据或 DSN 值已修改，请重新部署或更新 `ME_CONFIG_MONGODB_URL` 及相关密码环境变量。
+
+**UI 可访问但数据较少**
+- 原因：mongo-express 只显示当前 MongoDB 账号可访问的数据。
+- 解决方案：此模板使用托管 root 账号进行管理。请确认目标数据存在于本次部署的 MongoDB 实例中。
+
+### 获取帮助
+
+- [mongo-express GitHub Issues](https://github.com/mongo-express/mongo-express/issues)
+- [MongoDB 文档](https://www.mongodb.com/docs/)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 其他资源
+
+- [mongo-express 配置](https://github.com/mongo-express/mongo-express#usage-docker)
+- [MongoDB 连接字符串](https://www.mongodb.com/docs/manual/reference/connection-string/)
+- [Sealos 应用商店](https://sealos.io/products/app-store)
+
+## 许可证
+
+此 Sealos 模板遵循仓库许可证。mongo-express 本身使用 MIT License。

--- a/template/mongo-express/index.yaml
+++ b/template/mongo-express/index.yaml
@@ -7,13 +7,17 @@ spec:
   url: 'https://github.com/mongo-express/mongo-express'
   gitRepo: 'https://github.com/mongo-express/mongo-express'
   author: 'Sealos'
-  description: 'A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap3'
+  description: 'A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap 3.'
   readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/README.md'
   icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/logo.svg'
   screenshots:
     - 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/website-screenshot.webp'
-
   templateType: inline
+  locale: en
+  i18n:
+    zh:
+      description: '一个基于 Node.js、Express 和 Bootstrap 3 的 MongoDB Web 管理界面。'
+      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/README_zh.md'
   categories:
     - database
   defaults:
@@ -23,32 +27,104 @@ spec:
     app_host:
       type: string
       value: ${{ random(8) }}
-  inputs:
-    mongodb_conn_credential:
-      description: 'mongodb conn credential, ex. mongodb://user:password@host:port/dbname'
+    express_user:
       type: string
-      default: ''
-      required: true
-    custom_express_user:
-      description: 'User-defined mongo express login account user (non-database). The default is `admin`.'
+      value: admin
+    express_password:
       type: string
-      default: 'admin'
-      required: false
-    custom_express_password:
-        description: 'User-defined mongo express login account password (non-database). The default is `sealos`.'
-        type: string
-        default: 'sealos'
-        required: false
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/README_zh.md'
+      value: ${{ random(16) }}
+    site_cookie_secret:
+      type: string
+      value: ${{ random(32) }}
+    site_session_secret:
+      type: string
+      value: ${{ random(32) }}
+
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: ${{ defaults.app_name }}-mongo
+  labels:
+    kb.io/database: mongodb-8.0.4
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mongo
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+    topologyKeys:
+      - kubernetes.io/hostname
+  componentSpecs:
+    - componentDef: mongodb
+      name: mongodb
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 51Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      serviceAccountName: ${{ defaults.app_name }}-mongo
+      serviceVersion: 8.0.4
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: openebs-backup
+  terminationPolicy: Delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${{ defaults.app_name }}-mongo
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/managed-by: kbcli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${{ defaults.app_name }}-mongo
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/managed-by: kbcli
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${{ defaults.app_name }}-mongo
+  labels:
+    sealos-db-provider-cr: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/instance: ${{ defaults.app_name }}-mongo
+    app.kubernetes.io/managed-by: kbcli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ${{ defaults.app_name }}-mongo
+subjects:
+  - kind: ServiceAccount
+    name: ${{ defaults.app_name }}-mongo
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: mongo-express:1.0.2-20
+    originImageName: mongo-express:1.0.2-20-alpine3.19
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -68,30 +144,83 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: mongo-express:1.0.2-20
+          image: mongo-express:1.0.2-20-alpine3.19
+          imagePullPolicy: IfNotPresent
           env:
+            - name: ME_CONFIG_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mongo-mongodb-account-root
+                  key: password
             - name: ME_CONFIG_MONGODB_URL
-              value: ${{ inputs.mongodb_conn_credential }}
+              value: mongodb://root:$(ME_CONFIG_MONGODB_PASSWORD)@${{ defaults.app_name }}-mongo-mongodb.${{ SEALOS_NAMESPACE }}.svc:27017/admin?authSource=admin
+            - name: ME_CONFIG_MONGODB_ENABLE_ADMIN
+              value: 'true'
             - name: ME_CONFIG_BASICAUTH
               value: 'true'
             - name: ME_CONFIG_BASICAUTH_USERNAME
-              value: ${{ inputs.custom_express_user }}
+              value: ${{ defaults.express_user }}
             - name: ME_CONFIG_BASICAUTH_PASSWORD
-              value: ${{ inputs.custom_express_password }}
+              value: ${{ defaults.express_password }}
+            - name: ME_CONFIG_SITE_COOKIESECRET
+              value: ${{ defaults.site_cookie_secret }}
+            - name: ME_CONFIG_SITE_SESSIONSECRET
+              value: ${{ defaults.site_session_secret }}
+            - name: ME_CONFIG_HEALTH_CHECK_PATH
+              value: /status
             - name: ME_CONFIG_OPTIONS_EDITORTHEME
               value: ambiance
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             requests:
-              cpu: 50m
-              memory: 51Mi
+              cpu: 20m
+              memory: 25Mi
             limits:
-              cpu: 500m
-              memory: 512Mi
-          ports:
-            - containerPort: 8081
-          imagePullPolicy: IfNotPresent
-          volumeMounts: []
-      volumes: []
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}
+  labels:
+    app: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: ${{ defaults.app_name }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -106,11 +235,12 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       client_header_buffer_size 64k;
       large_client_header_buffers 4 128k;
-    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/client-body-buffer-size: 64k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '300'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '300'
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {
         expires 30d;
@@ -122,7 +252,7 @@ spec:
       http:
         paths:
           - pathType: Prefix
-            path: /()(.*)
+            path: /
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -133,14 +263,16 @@ spec:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
 ---
-apiVersion: v1
-kind: Service
+apiVersion: app.sealos.io/v1
+kind: App
 metadata:
   name: ${{ defaults.app_name }}
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
-  ports:
-    - port: 8081
-  selector:
-    app: ${{ defaults.app_name }}
+  data:
+    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+  displayType: normal
+  icon: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/mongo-express/logo.svg'
+  name: mongo-express
+  type: link

--- a/template/nacos/README.md
+++ b/template/nacos/README.md
@@ -1,30 +1,106 @@
-# Nacos
+# Deploy and Host Nacos on Sealos
 
-## Overview
+Nacos is a dynamic service discovery, configuration, and service management platform. This template deploys Nacos 3.2.2 with tuned Nacos JVM memory, a separate console, a standalone Nacos server, persistent storage, and a Sealos-managed MySQL database on Sealos Cloud.
 
-Dynamic Naming and Configuration Service - an easy-to-use platform designed for dynamic service discovery and configuration and service management
+## About Hosting Nacos
 
-This Sealos template deploys **Nacos** as the `nacos` application. It uses the repository-maintained Sealos manifest and keeps deployment, networking, and storage configuration inside the template.
+Nacos provides naming, service discovery, configuration management, namespace isolation, and console-based operations for microservice platforms. The Sealos template provisions the Nacos console and server as separate StatefulSets so that the web console can be exposed publicly while the service endpoint remains available inside the cluster.
 
-## Deploy on Sealos
+The deployment also provisions a KubeBlocks MySQL 8.0 cluster and runs the Nacos schema initialization job before the application starts using the external database. Persistent volumes store Nacos logs and runtime data across restarts.
 
-Open this template in the Sealos App Store, review the configuration values, and click **Deploy**. Sealos renders the template variables, creates the required Kubernetes resources, and manages the public endpoint for the application.
+## Common Use Cases
 
-## Access
+- **Microservice service discovery**: Register services and discover healthy instances from applications running in Kubernetes or other environments.
+- **Centralized configuration management**: Manage shared configuration, publish changes, and track configuration history.
+- **Environment isolation**: Use namespaces to separate development, staging, and production service metadata.
+- **AI and plugin registry experiments**: Use Nacos 3.x registry capabilities for newer plugin, prompt, and agent metadata workflows.
 
-After deployment, open `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`. The concrete hostname is generated from `defaults.app_host` and your Sealos Cloud domain.
+## Dependencies for Nacos Hosting
+
+The Sealos template includes all required runtime dependencies: two Nacos application components, a MySQL database, schema initialization, persistent volumes, internal Services, an HTTPS Ingress for the console, and a Sealos App link.
+
+### Deployment Dependencies
+
+- [Nacos Documentation](https://nacos.io/en/docs/latest/overview/) - Official Nacos documentation
+- [Nacos Docker Repository](https://github.com/nacos-group/nacos-docker) - Official Docker image and compose examples
+- [Nacos GitHub Repository](https://github.com/alibaba/nacos) - Source code and release notes
+
+### Implementation Details
+
+**Architecture Components:**
+
+This template deploys four main components:
+
+- **Nacos Console**: Public web console on port 8080, exposed through Sealos Ingress.
+- **Nacos Server**: Internal Nacos server on ports 8848 and 9848 for service discovery and client RPC.
+- **MySQL**: KubeBlocks-managed MySQL 8.0 database for configuration, user, role, and metadata storage.
+- **Initialization Job**: Loads the Nacos MySQL schema into the `nacos_devtest` database before the application components finish startup.
+
+**Configuration:**
+
+- Authentication is enabled for the console and server APIs.
+- Console and server use `JVM_XMS=512m`, `JVM_XMX=512m`, and `JVM_XMN=256m`; each Nacos component is capped at 1024Mi memory for the validated single-node profile.
+- The first console visit initializes the fixed admin username `nacos`; set your own password on that screen, then log in with `nacos` and the password you created.
+- `auth_token` is generated automatically as the JWT signing secret used by Nacos authentication. If you change it later, keep the same value on both Nacos components.
+- Console access uses `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`.
+
+**License Information:**
+
+Nacos is licensed under the Apache License 2.0. This Sealos template is provided under the repository license for Sealos templates.
+
+## Why Deploy Nacos on Sealos?
+
+Sealos is an AI-assisted Cloud Operating System built on Kubernetes that unifies deployment, networking, storage, and application management. By deploying Nacos on Sealos, you get:
+
+- **One-Click Deployment**: Launch Nacos with MySQL, persistent storage, HTTPS routing, and application metadata from one template.
+- **Managed Kubernetes Runtime**: Run Nacos on Kubernetes without manually writing StatefulSets, Services, Ingresses, or database resources.
+- **Persistent Storage Included**: Keep Nacos logs and runtime data across pod restarts.
+- **Integrated Database Provisioning**: Use a Sealos-managed MySQL cluster instead of maintaining a separate database by hand.
+- **Public Console Access**: Open the Nacos console from a generated HTTPS URL after deployment.
+
+## Deployment Guide
+
+1. Open the [Nacos template](https://sealos.io/products/app-store/nacos) and click **Deploy Now**.
+2. Configure the deployment parameters in the popup dialog. The template automatically generates the Nacos authentication token.
+3. Wait for deployment to complete, typically 2-3 minutes. After deployment, you will be redirected to the Canvas. For later changes, describe your requirements in the dialog to let AI apply updates, or click the relevant resource cards to modify settings.
+4. Access the Nacos console via the generated public URL.
+5. On the first visit, set the admin password for the fixed username `nacos`.
+6. After initialization, log in with username `nacos` and the password you created.
 
 ## Configuration
 
-The following user-facing inputs are available during deployment:
+After deployment, you can configure Nacos through:
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `auth_token` | JWT secret key for authentication (Base64 encoded, must be at least 32 characters) | `false` | `<redacted>` |
+- **Nacos Console**: Manage namespaces, configurations, services, users, roles, and permissions.
+- **AI Dialog**: Describe resource or environment changes and let Sealos apply updates.
+- **Resource Cards**: Click the StatefulSet, database, or Ingress cards on the Canvas to adjust settings.
+- **Client Configuration**: Connect internal clients to the Nacos server Service on port 8848.
 
-Keep sensitive values in Sealos-managed inputs or generated defaults. Do not commit private credentials to the template repository.
+## Scaling
 
-## Official Links
+The template is tuned for a single-node Nacos deployment with persistent storage and MySQL. To increase resources, open the Canvas, select the relevant StatefulSet resource card, and adjust CPU or memory. For high-availability Nacos clusters, review the official Nacos clustering documentation before changing replica counts.
 
-- Official website: https://nacos.io/
-- Source repository: https://github.com/nacos-group/nacos-docker
+## Troubleshooting
+
+### First login redirects to the initialization page
+
+This is expected when no global admin user exists yet. Set the password for username `nacos`, submit the form, then return to the login page and sign in with that password.
+
+### Login fails after changing the JWT secret
+
+All Nacos components must use the same `auth_token` value. Update both application components consistently if you modify the generated token after deployment.
+
+### Nacos cannot connect to the database
+
+Check that the MySQL cluster is running and that the schema initialization Job completed successfully. If the Job failed, inspect its logs from the Canvas or with kubectl.
+
+## Additional Resources
+
+- [Nacos Quick Start](https://nacos.io/en/docs/latest/quickstart/quick-start-docker/)
+- [Nacos Authentication Guide](https://nacos.io/en/docs/latest/manual/admin/auth/)
+- [Sealos Documentation](https://sealos.io/docs)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## License
+
+This Sealos template is provided under the repository license. Nacos itself is licensed under the Apache License 2.0.

--- a/template/nacos/README_zh.md
+++ b/template/nacos/README_zh.md
@@ -1,30 +1,106 @@
-# Nacos
+# 在 Sealos 上部署和托管 Nacos
 
-## 应用概览
+Nacos 是用于动态服务发现、配置管理和服务管理的平台。此模板会在 Sealos Cloud 上部署 Nacos 3.2.2，并包含调优后的 Nacos JVM 内存、独立控制台、单节点 Nacos Server、持久化存储和 Sealos 托管的 MySQL 数据库。
 
-动态命名和配置服务 - 一个易于使用的平台，专为动态服务发现、配置和服务管理而设计
+## 关于 Nacos 托管
 
-此 Sealos 模板会将 **Nacos** 部署为 `nacos` 应用。部署、网络和存储配置都由仓库中的 Sealos 模板维护。
+Nacos 为微服务平台提供命名服务、服务发现、配置管理、命名空间隔离和控制台运维能力。此 Sealos 模板将 Nacos 控制台和服务端拆分为两个 StatefulSet：控制台通过公网 HTTPS 访问，Nacos 服务端通过集群内服务提供给客户端使用。
 
-## 在 Sealos 上部署
+模板还会创建 KubeBlocks MySQL 8.0 集群，并在应用启动前执行 Nacos 数据库表结构初始化任务。Nacos 日志和运行数据会写入持久化卷，避免 Pod 重启后丢失。
 
-在 Sealos 应用商店打开此模板，检查配置项后点击 **部署**。Sealos 会渲染模板变量，创建所需的 Kubernetes 资源，并为应用管理公网访问入口。
+## 常见使用场景
 
-## 访问方式
+- **微服务服务发现**：注册服务实例，并让应用发现健康实例。
+- **集中式配置管理**：维护共享配置、发布变更并追踪配置历史。
+- **环境隔离**：使用命名空间区分开发、测试和生产环境的服务元数据。
+- **AI 与插件注册实验**：使用 Nacos 3.x 的注册能力管理插件、提示词和 Agent 相关元数据。
 
-部署完成后，打开 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。实际域名由 `defaults.app_host` 和当前 Sealos Cloud 域名生成。
+## Nacos 托管依赖
 
-## 配置说明
+此 Sealos 模板包含所需运行依赖：两个 Nacos 应用组件、MySQL 数据库、表结构初始化、持久化卷、内部 Service、控制台 HTTPS Ingress 以及 Sealos App 入口。
 
-部署时可以配置以下用户可见输入项：
+### 部署依赖
 
-| 名称 | 说明 | 必填 | 默认值 |
-|------|------|------|--------|
-| `auth_token` | `auth_token` 部署参数。 | `否` | `<已隐藏>` |
+- [Nacos 文档](https://nacos.io/docs/latest/overview/) - Nacos 官方文档
+- [Nacos Docker 仓库](https://github.com/nacos-group/nacos-docker) - 官方镜像与 Compose 示例
+- [Nacos GitHub 仓库](https://github.com/alibaba/nacos) - 源代码与版本发布说明
 
-请将敏感信息保存在 Sealos 管理的输入项或生成默认值中，不要把私有凭据提交到模板仓库。
+### 实现细节
 
-## 官方链接
+**架构组件：**
 
-- 官方网站: https://nacos.io/
-- 源码仓库: https://github.com/nacos-group/nacos-docker
+此模板部署四个主要组件：
+
+- **Nacos Console**：运行在 8080 端口的 Web 控制台，通过 Sealos Ingress 对外暴露。
+- **Nacos Server**：运行在 8848 和 9848 端口的集群内 Nacos 服务端，用于服务发现和客户端 RPC。
+- **MySQL**：由 KubeBlocks 管理的 MySQL 8.0 数据库，用于保存配置、用户、角色和元数据。
+- **初始化 Job**：在应用组件完成启动前，将 Nacos MySQL 表结构写入 `nacos_devtest` 数据库。
+
+**配置说明：**
+
+- 控制台和服务端 API 均启用认证。
+- 控制台和服务端使用 `JVM_XMS=512m`、`JVM_XMX=512m` 和 `JVM_XMN=256m`；经过验证的单节点配置中，每个 Nacos 组件内存上限为 1024Mi。
+- 首次访问控制台时会初始化固定管理员用户名 `nacos`；在页面中设置密码后，再使用 `nacos` 和该密码登录。
+- `auth_token` 会自动生成为 Nacos 认证使用的 JWT 签名密钥。如部署后修改该值，请确保两个 Nacos 组件保持一致。
+- 控制台访问地址为 `https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}`。
+
+**许可信息：**
+
+Nacos 使用 Apache License 2.0。此 Sealos 模板遵循 Sealos 模板仓库的许可证。
+
+## 为什么在 Sealos 上部署 Nacos？
+
+Sealos 是基于 Kubernetes 的 AI 云操作系统，统一管理部署、网络、存储和应用生命周期。在 Sealos 上部署 Nacos 可以获得：
+
+- **一键部署**：通过一个模板创建 Nacos、MySQL、持久化存储、HTTPS 路由和应用入口。
+- **托管 Kubernetes 运行环境**：无需手写 StatefulSet、Service、Ingress 或数据库资源。
+- **内置持久化存储**：Pod 重启后仍保留 Nacos 日志和运行数据。
+- **集成数据库能力**：使用 Sealos 托管的 MySQL 集群，无需单独维护数据库。
+- **公网控制台访问**：部署完成后通过生成的 HTTPS 地址打开 Nacos 控制台。
+
+## 部署指南
+
+1. 打开 [Nacos 模板](https://sealos.io/products/app-store/nacos)，点击 **Deploy Now**。
+2. 在弹窗中配置部署参数。模板会自动生成 Nacos 认证令牌。
+3. 等待部署完成，通常需要 2-3 分钟。部署后会进入 Canvas。后续如需调整配置，可以在对话框描述需求让 AI 修改，也可以点击相关资源卡片进行设置。
+4. 通过生成的公网地址访问 Nacos 控制台。
+5. 首次访问时，为固定用户名 `nacos` 设置管理员密码。
+6. 初始化完成后，使用用户名 `nacos` 和刚设置的密码登录。
+
+## 配置
+
+部署后可以通过以下方式配置 Nacos：
+
+- **Nacos 控制台**：管理命名空间、配置、服务、用户、角色和权限。
+- **AI 对话框**：描述资源或环境变量调整需求，由 Sealos 执行修改。
+- **资源卡片**：在 Canvas 中点击 StatefulSet、数据库或 Ingress 卡片调整配置。
+- **客户端配置**：集群内客户端连接 Nacos Server Service 的 8848 端口。
+
+## 扩缩容
+
+此模板按单节点 Nacos 部署调优，并配套持久化存储与 MySQL。如需提升资源，在 Canvas 中打开对应 StatefulSet 资源卡片并调整 CPU 或内存。若要改为高可用 Nacos 集群，请先参考官方 Nacos 集群文档，再调整副本数。
+
+## 故障排查
+
+### 首次登录跳转到初始化页面
+
+这是没有全局管理员用户时的正常行为。请为用户名 `nacos` 设置密码并提交，然后回到登录页使用该密码登录。
+
+### 修改 JWT 密钥后无法登录
+
+所有 Nacos 组件必须使用相同的 `auth_token`。如果部署后修改自动生成的令牌，请确保两个应用组件保持一致。
+
+### Nacos 无法连接数据库
+
+检查 MySQL 集群是否运行正常，并确认表结构初始化 Job 已成功完成。如果 Job 失败，请在 Canvas 或 kubectl 中查看该 Job 的日志。
+
+## 其他资源
+
+- [Nacos 快速开始](https://nacos.io/docs/latest/quickstart/quick-start-docker/)
+- [Nacos 认证指南](https://nacos.io/docs/latest/manual/admin/auth/)
+- [Sealos 文档](https://sealos.io/docs)
+- [Sealos Discord](https://discord.gg/wdUn538zVP)
+
+## 许可证
+
+此 Sealos 模板遵循模板仓库许可证。Nacos 本身使用 Apache License 2.0。

--- a/template/nacos/index.yaml
+++ b/template/nacos/index.yaml
@@ -87,7 +87,7 @@ metadata:
     - cluster.kubeblocks.io/finalizer
   labels:
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
+    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30-1
     sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
   annotations: {}
   name: ${{ defaults.app_name }}-mysql
@@ -98,11 +98,12 @@ spec:
     tenancy: SharedNode
     topologyKeys: []
   clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterVersionRef: ac-mysql-8.0.30-1
   componentSpecs:
-    - componentDefRef: mysql
+    - name: mysql
+      componentDefRef: mysql
       monitor: true
-      name: mysql
+      noCreatePDB: false
       replicas: 1
       resources:
         limits:
@@ -112,6 +113,8 @@ spec:
           cpu: 50m
           memory: 51Mi
       serviceAccountName: ${{ defaults.app_name }}-mysql
+      switchPolicy:
+        type: Noop
       volumeClaimTemplates:
         - name: data
           spec:
@@ -130,6 +133,7 @@ kind: ConfigMap
 metadata:
   name: ${{ defaults.app_name }}-mysql-init
   labels:
+    app: ${{ defaults.app_name }}-mysql-init
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-mysql-init
 data:
   vn-tmpvn-nacosvn-mysqlvn-sql: |
@@ -316,9 +320,6 @@ data:
                                    UNIQUE INDEX `uk_role_permission` (`role`,`resource`,`action`) USING BTREE
     );
 
-    -- Insert default user
-    INSERT INTO users (username, password, enabled) VALUES ('nacos', '$2a$10$EuWPZHzz32dJN7jexM34MOeYirDdFAZm2kuWj7VEOJhhZkDrxfvUu', TRUE);
-    INSERT INTO roles (username, role) VALUES ('nacos', 'ROLE_ADMIN');
 
 ---
 apiVersion: v1
@@ -326,6 +327,7 @@ kind: ConfigMap
 metadata:
   name: ${{ defaults.app_name }}-console
   labels:
+    app: ${{ defaults.app_name }}-console
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-console
 data:
   vn-homevn-nacosvn-confvn-clustervn-conf: |
@@ -342,7 +344,8 @@ spec:
     spec:
       containers:
         - name: mysql-init
-          image: mysql:8.0.30
+          image: mysql:8.0.44
+          imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:
@@ -375,6 +378,13 @@ spec:
               mysql -h${MYSQL_HOST} -P${MYSQL_PORT} -uroot -p${MYSQL_ROOT_PASSWORD} < /tmp/nacos-mysql.sql
               
               echo "Database initialization completed successfully."
+          resources:
+            requests:
+              cpu: 50m
+              memory: 51Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: vn-tmpvn-nacosvn-mysqlvn-sql
               mountPath: /tmp/nacos-mysql.sql
@@ -397,7 +407,8 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}-console
   annotations:
-    originImageName: nacos/nacos-server:v3.0.3
+    originImageName: nacos/nacos-server:v3.2.2
+    docker-to-sealos.resource-override-source: "README.md#Implementation-Details: validated single-node Nacos JVM profile capped at 1024Mi"
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -418,7 +429,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-console
-          image: nacos/nacos-server:v3.0.3
+          image: nacos/nacos-server:v3.2.2
           imagePullPolicy: IfNotPresent
           env:
             - name: NACOS_DEPLOYMENT_TYPE
@@ -427,6 +438,12 @@ spec:
               value: hostname
             - name: MODE
               value: standalone
+            - name: JVM_XMS
+              value: 512m
+            - name: JVM_XMX
+              value: 512m
+            - name: JVM_XMN
+              value: 256m
             - name: SPRING_DATASOURCE_PLATFORM
               value: mysql
             - name: MYSQL_SERVICE_HOST
@@ -442,7 +459,10 @@ spec:
             - name: MYSQL_SERVICE_DB_NAME
               value: nacos_devtest
             - name: MYSQL_SERVICE_USER
-              value: root
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
             - name: MYSQL_SERVICE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -451,6 +471,10 @@ spec:
             - name: MYSQL_SERVICE_DB_PARAM
               value: characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
             - name: NACOS_AUTH_ENABLE
+              value: 'true'
+            - name: NACOS_AUTH_ADMIN_ENABLE
+              value: 'true'
+            - name: NACOS_AUTH_CONSOLE_ENABLE
               value: 'true'
             - name: NACOS_AUTH_TOKEN
               value: ${{ inputs.auth_token }}
@@ -464,10 +488,10 @@ spec:
           resources:
             requests:
               cpu: 20m
-              memory: 512Mi
+              memory: 102Mi
             limits:
               cpu: 200m
-              memory: 1Gi
+              memory: 1024Mi
           volumeMounts:
             - name: vn-homevn-nacosvn-logs
               mountPath: /home/nacos/logs
@@ -502,6 +526,7 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}-console
   labels:
+    app: ${{ defaults.app_name }}-console
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-console
 spec:
   ports:
@@ -517,7 +542,8 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: nacos/nacos-server:v3.0.3
+    originImageName: nacos/nacos-server:v3.2.2
+    docker-to-sealos.resource-override-source: "README.md#Implementation-Details: validated single-node Nacos JVM profile capped at 1024Mi"
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -538,7 +564,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: nacos/nacos-server:v3.0.3
+          image: nacos/nacos-server:v3.2.2
           imagePullPolicy: IfNotPresent
           env:
             - name: NACOS_DEPLOYMENT_TYPE
@@ -547,6 +573,12 @@ spec:
               value: hostname
             - name: MODE
               value: standalone
+            - name: JVM_XMS
+              value: 512m
+            - name: JVM_XMX
+              value: 512m
+            - name: JVM_XMN
+              value: 256m
             - name: SPRING_DATASOURCE_PLATFORM
               value: mysql
             - name: MYSQL_SERVICE_HOST
@@ -562,7 +594,10 @@ spec:
             - name: MYSQL_SERVICE_DB_NAME
               value: nacos_devtest
             - name: MYSQL_SERVICE_USER
-              value: root
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
             - name: MYSQL_SERVICE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -571,6 +606,10 @@ spec:
             - name: MYSQL_SERVICE_DB_PARAM
               value: characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
             - name: NACOS_AUTH_ENABLE
+              value: 'true'
+            - name: NACOS_AUTH_ADMIN_ENABLE
+              value: 'true'
+            - name: NACOS_AUTH_CONSOLE_ENABLE
               value: 'true'
             - name: NACOS_AUTH_TOKEN
               value: ${{ inputs.auth_token }}
@@ -589,7 +628,7 @@ spec:
               memory: 102Mi
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 1024Mi
           volumeMounts:
             - name: vn-homevn-nacosvn-logs
               mountPath: /home/nacos/logs
@@ -627,6 +666,7 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:


### PR DESCRIPTION
## Summary

Refresh 12 existing Sealos templates with updated runtime definitions, current image tags, stronger health checks, App resources, managed database wiring, and expanded bilingual deployment docs.

Updated templates:

- `langflow`
- `listmonk`
- `lobe-chat`
- `logto`
- `loki`
- `mage-ai`
- `matomo`
- `meilisearch`
- `metabase`
- `mlflow`
- `mongo-express`
- `nacos`

Key changes:

- Update template metadata, README links, icons, screenshots, categories, and Simplified Chinese descriptions.
- Refresh application images to pinned versions and remove floating image usage where present.
- Align managed database resources with current KubeBlocks structures and approved secret references.
- Add or improve startup, readiness, and liveness probes for web-facing services.
- Add Sealos `App` resources where missing so deployed apps expose their public URL in the dashboard.
- Expand English and Chinese READMEs with architecture, deployment, login/setup, scaling, troubleshooting, and official resource links.

## Validation

- [x] `python .agents/skills/docker-to-sealos/scripts/path_converter.py --self-test`
- [x] `python .agents/skills/docker-to-sealos/scripts/test_check_consistency.py` — 84 tests passed
- [x] `python .agents/skills/docker-to-sealos/scripts/test_compose_to_template.py` — 33 tests passed
- [x] `python .agents/skills/docker-to-sealos/scripts/test_check_must_coverage.py` — 4 tests passed
- [x] `python .agents/skills/docker-to-sealos/scripts/check_consistency.py --skill ... --references ... --rules-file ... --artifacts <12 index.yaml files>` — 35 rules passed
- [x] `DOCKER_TO_SEALOS_ARTIFACTS=<12 index.yaml files> python .agents/skills/docker-to-sealos/scripts/quality_gate.py`
- [x] `git diff --check upstream/kb-0.9...HEAD`

## Notes

- `langflow` uses Sealos template conditional syntax (`${{ if(...) }}`), so generic PyYAML parsing reports a scanner error. The docker-to-sealos consistency checker and quality gate both parse and validate it successfully.