### PR TITLE
fix(dify): use postgres client image for database init

### DIFF
--- a/template/dify/index.yaml
+++ b/template/dify/index.yaml
@@ -74,7 +74,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-db
-          image: senzing/postgresql-client:2.2.4
+          image: postgres:14-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_USERNAME
@@ -431,7 +431,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-db
-          image: senzing/postgresql-client:2.2.4
+          image: postgres:14-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_USERNAME
@@ -701,7 +701,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-db
-          image: senzing/postgresql-client:2.2.4
+          image: postgres:14-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_USERNAME
@@ -962,7 +962,7 @@ spec:
     spec:
       containers:
         - name: pgsql-init
-          image: senzing/postgresql-client:2.2.4
+          image: postgres:14-alpine
           env:
             - name: PG_USERNAME
               valueFrom:
@@ -985,8 +985,13 @@ spec:
             - /bin/sh
             - -c
             - |
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE dify;' &>/dev/null; do sleep 1; done
-              until psql ${DATABASE_URL} -c 'CREATE DATABASE dify_plugin;' &>/dev/null; do sleep 1; done
+              until pg_isready -d "${DATABASE_URL}"; do
+                sleep 2
+              done
+              psql "${DATABASE_URL}" -tc "SELECT 1 FROM pg_database WHERE datname = 'dify'" | grep -q 1 \
+                || psql "${DATABASE_URL}" -c "CREATE DATABASE dify;"
+              psql "${DATABASE_URL}" -tc "SELECT 1 FROM pg_database WHERE datname = 'dify_plugin'" | grep -q 1 \
+                || psql "${DATABASE_URL}" -c "CREATE DATABASE dify_plugin;"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## Summary

Update the Dify template to use the official PostgreSQL client image for database wait/init containers and make the PostgreSQL init job idempotent.

## What changed

- Replaced four `senzing/postgresql-client:2.2.4` usages with `postgres:14-alpine` in `template/dify/index.yaml`.
- Updated the `pg-init` job to wait with `pg_isready`.
- Changed database creation for `dify` and `dify_plugin` to check for existing databases before running `CREATE DATABASE`.

## Why

The previous init job retried `CREATE DATABASE` in a loop. If the database already existed, PostgreSQL returned an error and the job could keep retrying instead of completing. The new logic makes repeated runs safe.

## Verification

- User verified the modified YAML matches expectations.
- Ran YAML parsing for the repository templates:

```bash
ruby - <<'RUBY'
require 'yaml'
root = '/Users/mafirsc/Documents/sealos/templates'
files = [File.join(root, 'template.yaml')] + Dir.glob(File.join(root, 'template', '*', 'index.yaml')).sort
files.each { |path| YAML.load_file(path) }
puts "OK parsed #{files.length} YAML files"
RUBY
```

Result:

```text
OK parsed 217 YAML files
```

- Ran:

```bash
git diff --check upstream/kb-0.9..HEAD
```

Result: no whitespace errors.

## Rollback

If this causes an issue after merge, revert this PR with GitHub's Revert action.
