### PR TITLE
fix(payload): activate pnpm before start

### DIFF
--- a/template/payload/index.yaml
+++ b/template/payload/index.yaml
@@ -199,6 +199,12 @@ spec:
         - name: ${{ defaults.app_name }}
           image: ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c
           imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -lc
+          args:
+            - |
+              corepack prepare pnpm@10.15.1 --activate && exec docker-entrypoint.sh pnpm start
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
## Summary

Fix the Payload template startup command by activating the expected pnpm version before launching the application.

## Why

The Payload image needs pnpm 10.15.1 activated through corepack before running `pnpm start`. This makes the container startup use the expected package manager version explicitly.

## Changes

- Add `/bin/sh -lc` as the container command.
- Run `corepack prepare pnpm@10.15.1 --activate` before `docker-entrypoint.sh pnpm start`.

## Verification

- User confirmed the updated YAML matches expectations.
- Ran `git diff --check upstream/kb-0.9..HEAD`.
- Ran `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML OK"' /Users/mafirsc/Documents/sealos/templates/template/payload/index.yaml`.
- Confirmed the PR branch is ahead of `labring-actions/templates:kb-0.9` by 1 commit and behind by 0.

## Rollback

If this causes startup issues, revert this PR to restore the previous container startup behavior.
