### PR TITLE
fix: add atbox to asktable template

### DIFF
--- a/template/asktable/index.yaml
+++ b/template/asktable/index.yaml
@@ -192,7 +192,7 @@ metadata:
   name: ${{ defaults.app_name }}-atbox
   labels:
     app: ${{ defaults.app_name }}-atbox
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-atbox
 spec:
   replicas: 1
   selector:
@@ -225,8 +225,8 @@ spec:
               cpu: 100m
               memory: 128Mi
             limits:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -246,7 +246,7 @@ metadata:
   name: ${{ defaults.app_name }}-atbox
   labels:
     app: ${{ defaults.app_name }}-atbox
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-atbox
 spec:
   selector:
     app: ${{ defaults.app_name }}-atbox

--- a/template/asktable/index.yaml
+++ b/template/asktable/index.yaml
@@ -138,6 +138,8 @@ spec:
               value: '6379'
             - name: REDIS_URL
               value: redis://default:$(REDIS_PASSWORD)@$(REDIS_HOST):$(REDIS_PORT)
+            - name: ATBOX_URL
+              value: http://${{ defaults.app_name }}-atbox.${{ SEALOS_NAMESPACE }}.svc.cluster.local:5300
             - name: LLM_API_KEY
               value: ${{ inputs.LLM_API_KEY }}
             - name: LLM_BASE_URL
@@ -182,6 +184,75 @@ spec:
   ports:
     - port: 80
       targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ defaults.app_name }}-atbox
+  labels:
+    app: ${{ defaults.app_name }}-atbox
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${{ defaults.app_name }}-atbox
+  template:
+    metadata:
+      labels:
+        app: ${{ defaults.app_name }}-atbox
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: atbox
+          image: registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest
+          env:
+            - name: TZ
+              value: Asia/Shanghai
+            - name: ATBOX_MAX_WORKERS
+              value: '8'
+            - name: ATBOX_DEFAULT_TIMEOUT
+              value: 30s
+            - name: ATBOX_MAX_TIMEOUT
+              value: 120s
+            - name: ATBOX_ENABLE_NETWORK
+              value: '0'
+          ports:
+            - containerPort: 5300
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - SETUID
+                - SETGID
+                - SYS_CHROOT
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ defaults.app_name }}-atbox
+  labels:
+    app: ${{ defaults.app_name }}-atbox
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+spec:
+  selector:
+    app: ${{ defaults.app_name }}-atbox
+  ports:
+    - port: 5300
+      targetPort: 5300
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## What changed

- Add an `asktable-atbox` Deployment and Service to the AskTable template.
- Inject `ATBOX_URL` into the main AskTable container.

## Why

The latest AskTable deployment requires `atbox` for the conversation / Python sandbox workflow. Without this service, the chat feature can report:

```text
Failed to connect to atbox: All connection attempts failed
Redis has already been added in the previous AskTable template update. This PR completes the current AskTable runtime dependencies by adding atbox.
``` 

## Test
Deployed the AskTable template manually.
Verified the atbox pod starts successfully.
Verified the main AskTable service can call atbox and the conversation flow can run.