### PR TITLE
chore: refresh Sealos template image versions

### DIFF
--- a/.sealos/update-reports/template-version-refresh-status.json
+++ b/.sealos/update-reports/template-version-refresh-status.json
@@ -1,0 +1,373 @@
+{
+  "generated_at": "2026-06-24T13:10:47.133772+00:00",
+  "source_report": ".sealos/update-reports/template-version-updates.json",
+  "selection_policy": "Start with patch-level application image candidates, then ship only candidates whose focused docker-to-sealos validation can pass with image-refresh-scoped edits.",
+  "updated_candidates": [
+    {
+      "template": "pdf2zh",
+      "current_image": "byaidu/pdf2zh:1.9.6",
+      "candidate_image": "byaidu/pdf2zh:1.9.11",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/pdf2zh/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "byaidu/pdf2zh:1.9.6"
+        },
+        {
+          "path": "template/pdf2zh/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "byaidu/pdf2zh:1.9.6"
+        }
+      ],
+      "changed_files": [
+        "template/pdf2zh/index.yaml"
+      ],
+      "candidate_status": "updated",
+      "reason": "Patch-level application image update selected and Service metadata normalized to satisfy docker-to-sealos validation."
+    }
+  ],
+  "skipped_candidates": [
+    {
+      "template": "affine",
+      "current_image": "ghcr.io/toeverything/affine:0.26.6",
+      "candidate_image": "ghcr.io/toeverything/affine:0.26.7",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/affine/index.yaml",
+          "line": 358,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.6"
+        },
+        {
+          "path": "template/affine/index.yaml",
+          "line": 420,
+          "key": "originImageName",
+          "image": "ghcr.io/toeverything/affine:0.26.6"
+        },
+        {
+          "path": "template/affine/index.yaml",
+          "line": 486,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.6"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "cronicle",
+      "current_image": "soulteary/cronicle:0.9.46",
+      "candidate_image": "soulteary/cronicle:0.9.80",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/cronicle/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "soulteary/cronicle:0.9.46"
+        },
+        {
+          "path": "template/cronicle/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "soulteary/cronicle:0.9.46"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 9 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "illa-builder",
+      "current_image": "illasoft/illa-builder:v4.8.2",
+      "candidate_image": "illasoft/illa-builder:v4.8.5",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/illa-builder/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "illasoft/illa-builder:v4.8.2"
+        },
+        {
+          "path": "template/illa-builder/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "illasoft/illa-builder:v4.8.2"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 10 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "kanboard",
+      "current_image": "kanboard/kanboard:v1.2.50",
+      "candidate_image": "kanboard/kanboard:v1.2.52",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/kanboard/index.yaml",
+          "line": 121,
+          "key": "originImageName",
+          "image": "kanboard/kanboard:v1.2.50"
+        },
+        {
+          "path": "template/kanboard/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "kanboard/kanboard:v1.2.50"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "lobe-chat-db",
+      "current_image": "lobehub/lobe-chat-database:1.143.2",
+      "candidate_image": "lobehub/lobe-chat-database:1.143.3",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/lobe-chat-db/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "lobehub/lobe-chat-database:1.143.2"
+        },
+        {
+          "path": "template/lobe-chat-db/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "lobehub/lobe-chat-database:1.143.2"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "outline",
+      "current_image": "outlinewiki/outline:1.8.0-1",
+      "candidate_image": "outlinewiki/outline:1.8.2-0",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/outline/index.yaml",
+          "line": 427,
+          "key": "originImageName",
+          "image": "outlinewiki/outline:1.8.0-1"
+        },
+        {
+          "path": "template/outline/index.yaml",
+          "line": 448,
+          "key": "image",
+          "image": "outlinewiki/outline:1.8.0-1"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "pageplug",
+      "current_image": "cloudtogouser/pageplug-ce:v1.9.35",
+      "candidate_image": "cloudtogouser/pageplug-ce:v1.9.37",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/pageplug/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35"
+        },
+        {
+          "path": "template/pageplug/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 9 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "presenton",
+      "current_image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+      "candidate_image": "ghcr.io/presenton/presenton:v0.8.9-beta",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/presenton/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta"
+        },
+        {
+          "path": "template/presenton/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 3 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "stalwart",
+      "current_image": "stalwartlabs/stalwart:v0.16.7",
+      "candidate_image": "stalwartlabs/stalwart:v0.16.10",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/stalwart/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "stalwartlabs/stalwart:v0.16.7"
+        },
+        {
+          "path": "template/stalwart/index.yaml",
+          "line": 302,
+          "key": "image",
+          "image": "stalwartlabs/stalwart:v0.16.7"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "sub2api",
+      "current_image": "weishaw/sub2api:0.1.104",
+      "candidate_image": "weishaw/sub2api:0.1.138",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/sub2api/index.yaml",
+          "line": 368,
+          "key": "originImageName",
+          "image": "weishaw/sub2api:0.1.104"
+        },
+        {
+          "path": "template/sub2api/index.yaml",
+          "line": 397,
+          "key": "image",
+          "image": "weishaw/sub2api:0.1.104"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 5 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "tailchat",
+      "current_image": "moonrailgun/tailchat:1.11.5",
+      "candidate_image": "moonrailgun/tailchat:1.11.11",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/tailchat/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "moonrailgun/tailchat:1.11.5"
+        },
+        {
+          "path": "template/tailchat/index.yaml",
+          "line": 86,
+          "key": "image",
+          "image": "moonrailgun/tailchat:1.11.5"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 22 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "tududi",
+      "current_image": "chrisvel/tududi:1.1.0",
+      "candidate_image": "chrisvel/tududi:1.1.1",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/tududi/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "chrisvel/tududi:1.1.0"
+        },
+        {
+          "path": "template/tududi/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "chrisvel/tududi:1.1.0"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope."
+    },
+    {
+      "template": "webos",
+      "current_image": "fs185085781/webos:v1.4.1",
+      "candidate_image": "fs185085781/webos:v1.4.4",
+      "action": "update",
+      "confidence": "high",
+      "evidence_source": "crane ls",
+      "record_locations": [
+        {
+          "path": "template/webos/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "fs185085781/webos:v1.4.1"
+        },
+        {
+          "path": "template/webos/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "fs185085781/webos:v1.4.1"
+        }
+      ],
+      "changed_files": [],
+      "candidate_status": "skipped",
+      "reason": "Skipped from this PR because focused docker-to-sealos validation found 6 existing template issues outside the image-refresh scope."
+    }
+  ],
+  "blocked_candidates": [],
+  "validation_notes": [
+    "Repository scripts/check_consistency.py and scripts/quality_gate.py are not present in this checkout.",
+    "docker-to-sealos self-tests passed.",
+    "Focused docker-to-sealos validation passes for template/pdf2zh/index.yaml after the scoped Service metadata fix."
+  ]
+}

--- a/.sealos/update-reports/template-version-refresh-status.md
+++ b/.sealos/update-reports/template-version-refresh-status.md
@@ -1,0 +1,37 @@
+# Sealos Template Version Refresh Status
+
+Generated: 2026-06-24T13:10:47.133772+00:00
+
+## Selection Policy
+
+Start with patch-level application image candidates, then ship only candidates whose focused docker-to-sealos validation can pass with image-refresh-scoped edits.
+
+## Updated Candidates
+
+| Template | Current image | Candidate image | Status | Evidence |
+|---|---|---|---|---|
+| pdf2zh | `byaidu/pdf2zh:1.9.6` | `byaidu/pdf2zh:1.9.11` | updated | crane ls |
+
+## Skipped Candidates
+
+| Template | Candidate image | Reason |
+|---|---|---|
+| affine | `ghcr.io/toeverything/affine:0.26.7` | Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope. |
+| cronicle | `soulteary/cronicle:0.9.80` | Skipped from this PR because focused docker-to-sealos validation found 9 existing template issues outside the image-refresh scope. |
+| illa-builder | `illasoft/illa-builder:v4.8.5` | Skipped from this PR because focused docker-to-sealos validation found 10 existing template issues outside the image-refresh scope. |
+| kanboard | `kanboard/kanboard:v1.2.52` | Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope. |
+| lobe-chat-db | `lobehub/lobe-chat-database:1.143.3` | Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope. |
+| outline | `outlinewiki/outline:1.8.2-0` | Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope. |
+| pageplug | `cloudtogouser/pageplug-ce:v1.9.37` | Skipped from this PR because focused docker-to-sealos validation found 9 existing template issues outside the image-refresh scope. |
+| presenton | `ghcr.io/presenton/presenton:v0.8.9-beta` | Skipped from this PR because focused docker-to-sealos validation found 3 existing template issues outside the image-refresh scope. |
+| stalwart | `stalwartlabs/stalwart:v0.16.10` | Skipped from this PR because focused docker-to-sealos validation found 8 existing template issues outside the image-refresh scope. |
+| sub2api | `weishaw/sub2api:0.1.138` | Skipped from this PR because focused docker-to-sealos validation found 5 existing template issues outside the image-refresh scope. |
+| tailchat | `moonrailgun/tailchat:1.11.11` | Skipped from this PR because focused docker-to-sealos validation found 22 existing template issues outside the image-refresh scope. |
+| tududi | `chrisvel/tududi:1.1.1` | Skipped from this PR because focused docker-to-sealos validation found 4 existing template issues outside the image-refresh scope. |
+| webos | `fs185085781/webos:v1.4.4` | Skipped from this PR because focused docker-to-sealos validation found 6 existing template issues outside the image-refresh scope. |
+
+## Validation Notes
+
+- Repository scripts/check_consistency.py and scripts/quality_gate.py are not present in this checkout.
+- docker-to-sealos self-tests passed.
+- Focused docker-to-sealos validation passes for template/pdf2zh/index.yaml after the scoped Service metadata fix.

--- a/.sealos/update-reports/template-version-updates.json
+++ b/.sealos/update-reports/template-version-updates.json
@@ -1,0 +1,19048 @@
+{
+  "generated_at": "2026-06-24T12:58:32.213242+00:00",
+  "repo": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates",
+  "record_count": 1070,
+  "candidate_count": 556,
+  "candidates": [
+    {
+      "template": "AllinSSL",
+      "image": "docker.io/allinssl/allinssl",
+      "repository": "docker.io/allinssl/allinssl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "AllinSSL",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/AllinSSL/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "docker.io/allinssl/allinssl",
+          "repository": "docker.io/allinssl/allinssl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "AllinSSL",
+      "image": "docker.io/allinssl/allinssl:latest",
+      "repository": "docker.io/allinssl/allinssl",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "AllinSSL",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/AllinSSL/index.yaml",
+          "line": 70,
+          "key": "image",
+          "image": "docker.io/allinssl/allinssl:latest",
+          "repository": "docker.io/allinssl/allinssl",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "OpenDeepWiki",
+      "image": "${{ inputs.wiki_image }}",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/OpenDeepWiki/index.yaml",
+          "line": 132,
+          "key": "originImageName",
+          "image": "${{ inputs.wiki_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/OpenDeepWiki/index.yaml",
+          "line": 159,
+          "key": "image",
+          "image": "${{ inputs.wiki_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "OpenDeepWiki",
+      "image": "${{ inputs.wiki_web_image }}",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/OpenDeepWiki/index.yaml",
+          "line": 302,
+          "key": "originImageName",
+          "image": "${{ inputs.wiki_web_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/OpenDeepWiki/index.yaml",
+          "line": 327,
+          "key": "image",
+          "image": "${{ inputs.wiki_web_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "amruthpillai/reactive-resume:v4.1.2",
+      "repository": "amruthpillai/reactive-resume",
+      "current_tag": "v4.1.2",
+      "candidate_tag": "v5.1.9",
+      "candidate_image": "amruthpillai/reactive-resume:v5.1.9",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 351,
+          "key": "image",
+          "image": "amruthpillai/reactive-resume:v4.1.2",
+          "repository": "amruthpillai/reactive-resume",
+          "tag": "v4.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "bitnamilegacy/postgresql:latest",
+      "repository": "bitnamilegacy/postgresql",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 541,
+          "key": "image",
+          "image": "bitnamilegacy/postgresql:latest",
+          "repository": "bitnamilegacy/postgresql",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 563,
+          "key": "image",
+          "image": "bitnamilegacy/postgresql:latest",
+          "repository": "bitnamilegacy/postgresql",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "ghcr.io/browserless/chromium:v2.11.0",
+      "repository": "ghcr.io/browserless/chromium",
+      "current_tag": "v2.11.0",
+      "candidate_tag": "v2.54.1",
+      "candidate_image": "ghcr.io/browserless/chromium:v2.54.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "ghcr.io/browserless/chromium:v2.11.0",
+          "repository": "ghcr.io/browserless/chromium",
+          "tag": "v2.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 165,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+      "repository": "quay.io/minio/minio",
+      "current_tag": "RELEASE.2023-03-22T06-36-24Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Reactive-Resume/index.yaml",
+          "line": 198,
+          "key": "image",
+          "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+          "repository": "quay.io/minio/minio",
+          "tag": "RELEASE.2023-03-22T06-36-24Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Readeck",
+      "image": "codeberg.org/readeck/readeck:0.16.0",
+      "repository": "codeberg.org/readeck/readeck",
+      "current_tag": "0.16.0",
+      "candidate_tag": "0.22.3",
+      "candidate_image": "codeberg.org/readeck/readeck:0.22.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Readeck",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Readeck/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "codeberg.org/readeck/readeck:0.16.0",
+          "repository": "codeberg.org/readeck/readeck",
+          "tag": "0.16.0",
+          "digest": null
+        },
+        {
+          "template": "Readeck",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Readeck/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "codeberg.org/readeck/readeck:0.16.0",
+          "repository": "codeberg.org/readeck/readeck",
+          "tag": "0.16.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Ruiqi-Waf",
+      "image": "limbo2342/ruiqi-waf:sha-32b359f",
+      "repository": "limbo2342/ruiqi-waf",
+      "current_tag": "sha-32b359f",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Ruiqi-Waf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/Ruiqi-Waf/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "limbo2342/ruiqi-waf:sha-32b359f",
+          "repository": "limbo2342/ruiqi-waf",
+          "tag": "sha-32b359f",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ace-step",
+      "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+      "repository": "ghcr.io/ace-step/ace-step-1.5",
+      "current_tag": "v0.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "ace-step",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ace-step/index.yaml",
+          "line": 91,
+          "key": "originImageName",
+          "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+          "repository": "ghcr.io/ace-step/ace-step-1.5",
+          "tag": "v0.1.0",
+          "digest": null
+        },
+        {
+          "template": "ace-step",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ace-step/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+          "repository": "ghcr.io/ace-step/ace-step-1.5",
+          "tag": "v0.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "affine",
+      "image": "ghcr.io/toeverything/affine:0.26.6",
+      "repository": "ghcr.io/toeverything/affine",
+      "current_tag": "0.26.6",
+      "candidate_tag": "0.26.7",
+      "candidate_image": "ghcr.io/toeverything/affine:0.26.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 358,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.6",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.6",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 420,
+          "key": "originImageName",
+          "image": "ghcr.io/toeverything/affine:0.26.6",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.6",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 486,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.6",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "affine",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 318,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/affine/index.yaml",
+          "line": 445,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "agora",
+      "image": "agoracn/token:0.1.2023053011",
+      "repository": "agoracn/token",
+      "current_tag": "0.1.2023053011",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "agora",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/agora/index.yaml",
+          "line": 49,
+          "key": "originImageName",
+          "image": "agoracn/token:0.1.2023053011",
+          "repository": "agoracn/token",
+          "tag": "0.1.2023053011",
+          "digest": null
+        },
+        {
+          "template": "agora",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/agora/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "agoracn/token:0.1.2023053011",
+          "repository": "agoracn/token",
+          "tag": "0.1.2023053011",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/bootloader:0.63.11",
+      "repository": "airbyte/bootloader",
+      "current_tag": "0.63.11",
+      "candidate_tag": "2.1.0",
+      "candidate_image": "airbyte/bootloader:2.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 371,
+          "key": "image",
+          "image": "airbyte/bootloader:0.63.11",
+          "repository": "airbyte/bootloader",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/connector-builder-server:0.63.11",
+      "repository": "airbyte/connector-builder-server",
+      "current_tag": "0.63.11",
+      "candidate_tag": "2.0.1",
+      "candidate_image": "airbyte/connector-builder-server:2.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 422,
+          "key": "originImageName",
+          "image": "airbyte/connector-builder-server:0.63.11",
+          "repository": "airbyte/connector-builder-server",
+          "tag": "0.63.11",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 443,
+          "key": "image",
+          "image": "airbyte/connector-builder-server:0.63.11",
+          "repository": "airbyte/connector-builder-server",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/cron:0.63.11",
+      "repository": "airbyte/cron",
+      "current_tag": "0.63.11",
+      "candidate_tag": "2.1.0",
+      "candidate_image": "airbyte/cron:2.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1126,
+          "key": "originImageName",
+          "image": "airbyte/cron:0.63.11",
+          "repository": "airbyte/cron",
+          "tag": "0.63.11",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1147,
+          "key": "image",
+          "image": "airbyte/cron:0.63.11",
+          "repository": "airbyte/cron",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/server:0.63.11",
+      "repository": "airbyte/server",
+      "current_tag": "0.63.11",
+      "candidate_tag": "2.1.0",
+      "candidate_image": "airbyte/server:2.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 521,
+          "key": "originImageName",
+          "image": "airbyte/server:0.63.11",
+          "repository": "airbyte/server",
+          "tag": "0.63.11",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 544,
+          "key": "image",
+          "image": "airbyte/server:0.63.11",
+          "repository": "airbyte/server",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/webapp:0.63.11",
+      "repository": "airbyte/webapp",
+      "current_tag": "0.63.11",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1359,
+          "key": "originImageName",
+          "image": "airbyte/webapp:0.63.11",
+          "repository": "airbyte/webapp",
+          "tag": "0.63.11",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1380,
+          "key": "image",
+          "image": "airbyte/webapp:0.63.11",
+          "repository": "airbyte/webapp",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/worker:0.63.11",
+      "repository": "airbyte/worker",
+      "current_tag": "0.63.11",
+      "candidate_tag": "2.1.0",
+      "candidate_image": "airbyte/worker:2.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 813,
+          "key": "originImageName",
+          "image": "airbyte/worker:0.63.11",
+          "repository": "airbyte/worker",
+          "tag": "0.63.11",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 834,
+          "key": "image",
+          "image": "airbyte/worker:0.63.11",
+          "repository": "airbyte/worker",
+          "tag": "0.63.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "docker.io/apecloud/spilo:16.4.0",
+      "repository": "docker.io/apecloud/spilo",
+      "current_tag": "16.4.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 328,
+          "key": "image",
+          "image": "docker.io/apecloud/spilo:16.4.0",
+          "repository": "docker.io/apecloud/spilo",
+          "tag": "16.4.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "temporalio/auto-setup:1.23.0",
+      "repository": "temporalio/auto-setup",
+      "current_tag": "1.23.0",
+      "candidate_tag": "1.29.7",
+      "candidate_image": "temporalio/auto-setup:1.29.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1260,
+          "key": "originImageName",
+          "image": "temporalio/auto-setup:1.23.0",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.23.0",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/airbyte/index.yaml",
+          "line": 1281,
+          "key": "image",
+          "image": "temporalio/auto-setup:1.23.0",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.23.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "anki-sync-server",
+      "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+      "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+      "current_tag": "24.06.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "anki-sync-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/anki-sync-server/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+          "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+          "tag": "24.06.3",
+          "digest": null
+        },
+        {
+          "template": "anki-sync-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/anki-sync-server/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+          "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+          "tag": "24.06.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/backend-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 965,
+          "key": "originImageName",
+          "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/backend-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1013,
+          "key": "image",
+          "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/backend-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+      "repository": "apitable/databus-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1458,
+          "key": "originImageName",
+          "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+          "repository": "apitable/databus-server",
+          "tag": null,
+          "digest": "sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600"
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1503,
+          "key": "image",
+          "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+          "repository": "apitable/databus-server",
+          "tag": null,
+          "digest": "sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600"
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+      "repository": "apitable/imageproxy-server",
+      "current_tag": "v0.13.4-alpha_build13",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1587,
+          "key": "originImageName",
+          "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+          "repository": "apitable/imageproxy-server",
+          "tag": "v0.13.4-alpha_build13",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1609,
+          "key": "image",
+          "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+          "repository": "apitable/imageproxy-server",
+          "tag": "v0.13.4-alpha_build13",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+      "repository": "apitable/init-appdata",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 865,
+          "key": "originImageName",
+          "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+          "repository": "apitable/init-appdata",
+          "tag": null,
+          "digest": "sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b"
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 923,
+          "key": "image",
+          "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+          "repository": "apitable/init-appdata",
+          "tag": null,
+          "digest": "sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b"
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/init-db:v1.13.0-beta.1_2016",
+      "repository": "apitable/init-db",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 761,
+          "key": "originImageName",
+          "image": "apitable/init-db:v1.13.0-beta.1_2016",
+          "repository": "apitable/init-db",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 819,
+          "key": "image",
+          "image": "apitable/init-db:v1.13.0-beta.1_2016",
+          "repository": "apitable/init-db",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/room-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/room-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1170,
+          "key": "originImageName",
+          "image": "apitable/room-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/room-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1218,
+          "key": "image",
+          "image": "apitable/room-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/room-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/web-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/web-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1378,
+          "key": "originImageName",
+          "image": "apitable/web-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/web-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1400,
+          "key": "image",
+          "image": "apitable/web-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/web-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 988,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1193,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1480,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "mysql:8.0.32",
+      "repository": "mysql",
+      "current_tag": "8.0.32",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 579,
+          "key": "originImageName",
+          "image": "mysql:8.0.32",
+          "repository": "mysql",
+          "tag": "8.0.32",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 596,
+          "key": "image",
+          "image": "mysql:8.0.32",
+          "repository": "mysql",
+          "tag": "8.0.32",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 779,
+          "key": "image",
+          "image": "mysql:8.0.32",
+          "repository": "mysql",
+          "tag": "8.0.32",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 883,
+          "key": "image",
+          "image": "mysql:8.0.32",
+          "repository": "mysql",
+          "tag": "8.0.32",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "nginx:1.27.5-alpine",
+      "repository": "nginx",
+      "current_tag": "1.27.5-alpine",
+      "candidate_tag": "1.31.2-alpine",
+      "candidate_image": "nginx:1.31.2-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1672,
+          "key": "originImageName",
+          "image": "nginx:1.27.5-alpine",
+          "repository": "nginx",
+          "tag": "1.27.5-alpine",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 1694,
+          "key": "image",
+          "image": "nginx:1.27.5-alpine",
+          "repository": "nginx",
+          "tag": "1.27.5-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "rabbitmq:3.11.9-management",
+      "repository": "rabbitmq",
+      "current_tag": "3.11.9-management",
+      "candidate_tag": "4.3.2-management",
+      "candidate_image": "rabbitmq:4.3.2-management",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 649,
+          "key": "originImageName",
+          "image": "rabbitmq:3.11.9-management",
+          "repository": "rabbitmq",
+          "tag": "3.11.9-management",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/apitable/index.yaml",
+          "line": 674,
+          "key": "image",
+          "image": "rabbitmq:3.11.9-management",
+          "repository": "rabbitmq",
+          "tag": "3.11.9-management",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_cloud:0.15.22",
+      "repository": "appflowyinc/appflowy_cloud",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/appflowy_cloud:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 491,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_cloud:0.15.22",
+          "repository": "appflowyinc/appflowy_cloud",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 511,
+          "key": "image",
+          "image": "appflowyinc/appflowy_cloud:0.15.22",
+          "repository": "appflowyinc/appflowy_cloud",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_web:0.14.9",
+      "repository": "appflowyinc/appflowy_web",
+      "current_tag": "0.14.9",
+      "candidate_tag": "0.15.4",
+      "candidate_image": "appflowyinc/appflowy_web:0.15.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 820,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_web:0.14.9",
+          "repository": "appflowyinc/appflowy_web",
+          "tag": "0.14.9",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 840,
+          "key": "image",
+          "image": "appflowyinc/appflowy_web:0.14.9",
+          "repository": "appflowyinc/appflowy_web",
+          "tag": "0.14.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_worker:0.15.22",
+      "repository": "appflowyinc/appflowy_worker",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/appflowy_worker:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 692,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_worker:0.15.22",
+          "repository": "appflowyinc/appflowy_worker",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 712,
+          "key": "image",
+          "image": "appflowyinc/appflowy_worker:0.15.22",
+          "repository": "appflowyinc/appflowy_worker",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/gotrue:0.15.22",
+      "repository": "appflowyinc/gotrue",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/gotrue:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 356,
+          "key": "originImageName",
+          "image": "appflowyinc/gotrue:0.15.22",
+          "repository": "appflowyinc/gotrue",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 376,
+          "key": "image",
+          "image": "appflowyinc/gotrue:0.15.22",
+          "repository": "appflowyinc/gotrue",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appflowy/index.yaml",
+          "line": 205,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appsmith",
+      "image": "appsmith/appsmith-ce:v1.29",
+      "repository": "appsmith/appsmith-ce",
+      "current_tag": "v1.29",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "appsmith",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appsmith/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "appsmith/appsmith-ce:v1.29",
+          "repository": "appsmith/appsmith-ce",
+          "tag": "v1.29",
+          "digest": null
+        },
+        {
+          "template": "appsmith",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/appsmith/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "appsmith/appsmith-ce:v1.29",
+          "repository": "appsmith/appsmith-ce",
+          "tag": "v1.29",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "artalk",
+      "image": "artalk/artalk-go:latest",
+      "repository": "artalk/artalk-go",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "artalk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/artalk/index.yaml",
+          "line": 43,
+          "key": "originImageName",
+          "image": "artalk/artalk-go:latest",
+          "repository": "artalk/artalk-go",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "artalk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/artalk/index.yaml",
+          "line": 66,
+          "key": "image",
+          "image": "artalk/artalk-go:latest",
+          "repository": "artalk/artalk-go",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/asktable/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest",
+      "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/asktable/index.yaml",
+          "line": 113,
+          "key": "image",
+          "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest",
+          "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest",
+      "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/asktable/index.yaml",
+          "line": 209,
+          "key": "image",
+          "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest",
+          "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "authentik",
+      "image": "ghcr.io/goauthentik/server:2025.12.3",
+      "repository": "ghcr.io/goauthentik/server",
+      "current_tag": "2025.12.3",
+      "candidate_tag": "2026.5.3",
+      "candidate_image": "ghcr.io/goauthentik/server:2026.5.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/authentik/index.yaml",
+          "line": 175,
+          "key": "originImageName",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/authentik/index.yaml",
+          "line": 195,
+          "key": "image",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/authentik/index.yaml",
+          "line": 290,
+          "key": "originImageName",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/authentik/index.yaml",
+          "line": 310,
+          "key": "image",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "authentik",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/authentik/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "banana-slides",
+      "image": "anoinex/banana-slides-backend:latest",
+      "repository": "anoinex/banana-slides-backend",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/banana-slides/index.yaml",
+          "line": 112,
+          "key": "originImageName",
+          "image": "anoinex/banana-slides-backend:latest",
+          "repository": "anoinex/banana-slides-backend",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/banana-slides/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "anoinex/banana-slides-backend:latest",
+          "repository": "anoinex/banana-slides-backend",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "banana-slides",
+      "image": "anoinex/banana-slides-frontend:latest",
+      "repository": "anoinex/banana-slides-frontend",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/banana-slides/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "anoinex/banana-slides-frontend:latest",
+          "repository": "anoinex/banana-slides-frontend",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/banana-slides/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "anoinex/banana-slides-frontend:latest",
+          "repository": "anoinex/banana-slides-frontend",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "alpine/openssl:3.5.4",
+      "repository": "alpine/openssl",
+      "current_tag": "3.5.4",
+      "candidate_tag": "3.5.7",
+      "candidate_image": "alpine/openssl:3.5.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6468,
+          "key": "image",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "tag": "3.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+      "repository": "alpine/socat",
+      "current_tag": "1.8.0.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6692,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6723,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6755,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+      "repository": "billionmail/core",
+      "current_tag": "4.9.3",
+      "candidate_tag": "4.9.5",
+      "candidate_image": "billionmail/core:4.9.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6434,
+          "key": "originImageName",
+          "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "repository": "billionmail/core",
+          "tag": "4.9.3",
+          "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 7033,
+          "key": "image",
+          "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "repository": "billionmail/core",
+          "tag": "4.9.3",
+          "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab",
+      "repository": "billionmail/dovecot",
+      "current_tag": "1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6822,
+          "key": "image",
+          "image": "billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab",
+          "repository": "billionmail/dovecot",
+          "tag": "1.6",
+          "digest": "sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342",
+      "repository": "billionmail/postfix",
+      "current_tag": "1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6901,
+          "key": "image",
+          "image": "billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342",
+          "repository": "billionmail/postfix",
+          "tag": "1.6",
+          "digest": "sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058",
+      "repository": "billionmail/rspamd",
+      "current_tag": "1.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6775,
+          "key": "image",
+          "image": "billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058",
+          "repository": "billionmail/rspamd",
+          "tag": "1.2",
+          "digest": "sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6509,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "python:3.12.12-alpine",
+      "repository": "python",
+      "current_tag": "3.12.12-alpine",
+      "candidate_tag": "3.14.6-alpine",
+      "candidate_image": "python:3.14.6-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6672,
+          "key": "image",
+          "image": "python:3.12.12-alpine",
+          "repository": "python",
+          "tag": "3.12.12-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+      "repository": "roundcube/roundcubemail",
+      "current_tag": "1.6.11-fpm-alpine",
+      "candidate_tag": "1.7.1-fpm-alpine",
+      "candidate_image": "roundcube/roundcubemail:1.7.1-fpm-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/billionmail/index.yaml",
+          "line": 6974,
+          "key": "image",
+          "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+          "repository": "roundcube/roundcubemail",
+          "tag": "1.6.11-fpm-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "blossom",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/blossom/index.yaml",
+          "line": 315,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "blossom",
+      "image": "jasminexzzz/blossom:1.16.0",
+      "repository": "jasminexzzz/blossom",
+      "current_tag": "1.16.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/blossom/index.yaml",
+          "line": 46,
+          "key": "originImageName",
+          "image": "jasminexzzz/blossom:1.16.0",
+          "repository": "jasminexzzz/blossom",
+          "tag": "1.16.0",
+          "digest": null
+        },
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/blossom/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "jasminexzzz/blossom:1.16.0",
+          "repository": "jasminexzzz/blossom",
+          "tag": "1.16.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "btpanel",
+      "image": "btpanel/baota:nas",
+      "repository": "btpanel/baota",
+      "current_tag": "nas",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "btpanel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/btpanel/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "btpanel/baota:nas",
+          "repository": "btpanel/baota",
+          "tag": "nas",
+          "digest": null
+        },
+        {
+          "template": "btpanel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/btpanel/index.yaml",
+          "line": 56,
+          "key": "image",
+          "image": "btpanel/baota:nas",
+          "repository": "btpanel/baota",
+          "tag": "nas",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/apps:3.15.0",
+      "repository": "budibase/apps",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.21",
+      "candidate_image": "budibase/apps:3.39.21",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 429,
+          "key": "originImageName",
+          "image": "budibase/apps:3.15.0",
+          "repository": "budibase/apps",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "budibase/apps:3.15.0",
+          "repository": "budibase/apps",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+      "repository": "budibase/couchdb",
+      "current_tag": "v3.3.3-sqs-v2.1.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 254,
+          "key": "originImageName",
+          "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+          "repository": "budibase/couchdb",
+          "tag": "v3.3.3-sqs-v2.1.1",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+          "repository": "budibase/couchdb",
+          "tag": "v3.3.3-sqs-v2.1.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/proxy:3.15.0",
+      "repository": "budibase/proxy",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.21",
+      "candidate_image": "budibase/proxy:3.39.21",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 821,
+          "key": "originImageName",
+          "image": "budibase/proxy:3.15.0",
+          "repository": "budibase/proxy",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 841,
+          "key": "image",
+          "image": "budibase/proxy:3.15.0",
+          "repository": "budibase/proxy",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/worker:3.15.0",
+      "repository": "budibase/worker",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.21",
+      "candidate_image": "budibase/worker:3.39.21",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 625,
+          "key": "originImageName",
+          "image": "budibase/worker:3.15.0",
+          "repository": "budibase/worker",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 645,
+          "key": "image",
+          "image": "budibase/worker:3.15.0",
+          "repository": "budibase/worker",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/budibase/index.yaml",
+          "line": 276,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+      "current_tag": "1.6.11",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 607,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 680,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb-ui",
+      "current_tag": "1.6.11",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 855,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-ui",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-ui",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb",
+      "current_tag": "1.6.11",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 418,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 511,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/library/busybox:1.36.1",
+      "repository": "docker.io/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "docker.io/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 487,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 633,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 656,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/library/postgres:16.4-alpine",
+      "repository": "docker.io/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 174,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 446,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 881,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/traefik/whoami:v1.11.0",
+      "repository": "docker.io/traefik/whoami",
+      "current_tag": "v1.11.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 349,
+          "key": "originImageName",
+          "image": "docker.io/traefik/whoami:v1.11.0",
+          "repository": "docker.io/traefik/whoami",
+          "tag": "v1.11.0",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bunkerweb/index.yaml",
+          "line": 369,
+          "key": "image",
+          "image": "docker.io/traefik/whoami:v1.11.0",
+          "repository": "docker.io/traefik/whoami",
+          "tag": "v1.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bytebase",
+      "image": "bytebase/bytebase:3.6.1",
+      "repository": "bytebase/bytebase",
+      "current_tag": "3.6.1",
+      "candidate_tag": "3.19.1",
+      "candidate_image": "bytebase/bytebase:3.19.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bytebase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bytebase/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "bytebase/bytebase:3.6.1",
+          "repository": "bytebase/bytebase",
+          "tag": "3.6.1",
+          "digest": null
+        },
+        {
+          "template": "bytebase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/bytebase/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "bytebase/bytebase:3.6.1",
+          "repository": "bytebase/bytebase",
+          "tag": "3.6.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "calcom",
+      "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+      "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+      "current_tag": "v6.2.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/calcom/index.yaml",
+          "line": 217,
+          "key": "originImageName",
+          "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+          "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+          "tag": "v6.2.0",
+          "digest": null
+        },
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/calcom/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+          "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+          "tag": "v6.2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "calcom",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/calcom/index.yaml",
+          "line": 173,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+      "repository": "ghcr.io/capsoftware/cap-media-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cap/index.yaml",
+          "line": 342,
+          "key": "originImageName",
+          "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+          "repository": "ghcr.io/capsoftware/cap-media-server",
+          "tag": null,
+          "digest": "sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad"
+        },
+        {
+          "template": "cap",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cap/index.yaml",
+          "line": 362,
+          "key": "image",
+          "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+          "repository": "ghcr.io/capsoftware/cap-media-server",
+          "tag": null,
+          "digest": "sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad"
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+      "repository": "ghcr.io/capsoftware/cap-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cap/index.yaml",
+          "line": 207,
+          "key": "originImageName",
+          "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+          "repository": "ghcr.io/capsoftware/cap-web",
+          "tag": null,
+          "digest": "sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57"
+        },
+        {
+          "template": "cap",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cap/index.yaml",
+          "line": 227,
+          "key": "image",
+          "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+          "repository": "ghcr.io/capsoftware/cap-web",
+          "tag": null,
+          "digest": "sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57"
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "mysql:8.0.46-debian",
+      "repository": "mysql",
+      "current_tag": "8.0.46-debian",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cap/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "mysql:8.0.46-debian",
+          "repository": "mysql",
+          "tag": "8.0.46-debian",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "casbin/casdoor:v1.702.0",
+      "repository": "casbin/casdoor",
+      "current_tag": "v1.702.0",
+      "candidate_tag": "v2.190.0",
+      "candidate_image": "casbin/casdoor:v2.190.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/casdoor/index.yaml",
+          "line": 425,
+          "key": "image",
+          "image": "casbin/casdoor:v1.702.0",
+          "repository": "casbin/casdoor",
+          "tag": "v1.702.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "casbin/casdoor:v2.32.0",
+      "repository": "casbin/casdoor",
+      "current_tag": "v2.32.0",
+      "candidate_tag": "v2.190.0",
+      "candidate_image": "casbin/casdoor:v2.190.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/casdoor/index.yaml",
+          "line": 334,
+          "key": "originImageName",
+          "image": "casbin/casdoor:v2.32.0",
+          "repository": "casbin/casdoor",
+          "tag": "v2.32.0",
+          "digest": null
+        },
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/casdoor/index.yaml",
+          "line": 355,
+          "key": "image",
+          "image": "casbin/casdoor:v2.32.0",
+          "repository": "casbin/casdoor",
+          "tag": "v2.32.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "mysql:8.0",
+      "repository": "mysql",
+      "current_tag": "8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/casdoor/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "mysql:8.0",
+          "repository": "mysql",
+          "tag": "8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/casdoor/index.yaml",
+          "line": 308,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "changedetection",
+      "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+      "repository": "ghcr.io/dgtlmoon/changedetection.io",
+      "current_tag": "0.50.43",
+      "candidate_tag": "0.55.7",
+      "candidate_image": "ghcr.io/dgtlmoon/changedetection.io:0.55.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "changedetection",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/changedetection/index.yaml",
+          "line": 43,
+          "key": "originImageName",
+          "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "repository": "ghcr.io/dgtlmoon/changedetection.io",
+          "tag": "0.50.43",
+          "digest": null
+        },
+        {
+          "template": "changedetection",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/changedetection/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "repository": "ghcr.io/dgtlmoon/changedetection.io",
+          "tag": "0.50.43",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatany",
+      "image": "licoy/chatany:v3.5.0",
+      "repository": "licoy/chatany",
+      "current_tag": "v3.5.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "chatany",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatany/index.yaml",
+          "line": 81,
+          "key": "originImageName",
+          "image": "licoy/chatany:v3.5.0",
+          "repository": "licoy/chatany",
+          "tag": "v3.5.0",
+          "digest": null
+        },
+        {
+          "template": "chatany",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatany/index.yaml",
+          "line": 106,
+          "key": "image",
+          "image": "licoy/chatany:v3.5.0",
+          "repository": "licoy/chatany",
+          "tag": "v3.5.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatbot-ui",
+      "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+      "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+      "current_tag": "main",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatbot-ui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatbot-ui/index.yaml",
+          "line": 41,
+          "key": "originImageName",
+          "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+          "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+          "tag": "main",
+          "digest": null
+        },
+        {
+          "template": "chatbot-ui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatbot-ui/index.yaml",
+          "line": 66,
+          "key": "image",
+          "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+          "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+          "tag": "main",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-next-web",
+      "image": "yidadaa/chatgpt-next-web:v2.12.4",
+      "repository": "yidadaa/chatgpt-next-web",
+      "current_tag": "v2.12.4",
+      "candidate_tag": "v2.16.1",
+      "candidate_image": "yidadaa/chatgpt-next-web:v2.16.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatgpt-next-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-next-web/index.yaml",
+          "line": 89,
+          "key": "originImageName",
+          "image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "repository": "yidadaa/chatgpt-next-web",
+          "tag": "v2.12.4",
+          "digest": null
+        },
+        {
+          "template": "chatgpt-next-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-next-web/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "repository": "yidadaa/chatgpt-next-web",
+          "tag": "v2.12.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-on-wechat",
+      "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+      "repository": "zhayujie/chatgpt-on-wechat",
+      "current_tag": "1.6.8",
+      "candidate_tag": "2.1.2",
+      "candidate_image": "zhayujie/chatgpt-on-wechat:2.1.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatgpt-on-wechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-on-wechat/index.yaml",
+          "line": 78,
+          "key": "originImageName",
+          "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "repository": "zhayujie/chatgpt-on-wechat",
+          "tag": "1.6.8",
+          "digest": null
+        },
+        {
+          "template": "chatgpt-on-wechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-on-wechat/index.yaml",
+          "line": 98,
+          "key": "image",
+          "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "repository": "zhayujie/chatgpt-on-wechat",
+          "tag": "1.6.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-web",
+      "image": "chenzhaoyu94/chatgpt-web",
+      "repository": "chenzhaoyu94/chatgpt-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatgpt-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-web/index.yaml",
+          "line": 83,
+          "key": "originImageName",
+          "image": "chenzhaoyu94/chatgpt-web",
+          "repository": "chenzhaoyu94/chatgpt-web",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "chatgpt-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatgpt-web/index.yaml",
+          "line": 108,
+          "key": "image",
+          "image": "chenzhaoyu94/chatgpt-web",
+          "repository": "chenzhaoyu94/chatgpt-web",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatnio",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatnio/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatnio",
+      "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+      "repository": "programzmh/chatnio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatnio/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+          "repository": "programzmh/chatnio",
+          "tag": null,
+          "digest": "sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d"
+        },
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatnio/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+          "repository": "programzmh/chatnio",
+          "tag": null,
+          "digest": "sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d"
+        }
+      ]
+    },
+    {
+      "template": "chatwoot",
+      "image": "chatwoot/chatwoot:v4.7.0",
+      "repository": "chatwoot/chatwoot",
+      "current_tag": "v4.7.0",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "chatwoot/chatwoot:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 171,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 383,
+          "key": "originImageName",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 404,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 507,
+          "key": "originImageName",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 528,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatwoot",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chatwoot/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chrome",
+      "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+      "repository": "lscr.io/linuxserver/chrome",
+      "current_tag": "148.0.7778.178-1-ls95",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chrome",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chrome/index.yaml",
+          "line": 75,
+          "key": "originImageName",
+          "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+          "repository": "lscr.io/linuxserver/chrome",
+          "tag": "148.0.7778.178-1-ls95",
+          "digest": null
+        },
+        {
+          "template": "chrome",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/chrome/index.yaml",
+          "line": 104,
+          "key": "image",
+          "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+          "repository": "lscr.io/linuxserver/chrome",
+          "tag": "148.0.7778.178-1-ls95",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cloudreve",
+      "image": "arey/mysql-client:latest",
+      "repository": "arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cloudreve/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "arey/mysql-client:latest",
+          "repository": "arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cloudreve",
+      "image": "cloudreve/cloudreve",
+      "repository": "cloudreve/cloudreve",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cloudreve/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "cloudreve/cloudreve",
+          "repository": "cloudreve/cloudreve",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cloudreve/index.yaml",
+          "line": 109,
+          "key": "image",
+          "image": "cloudreve/cloudreve",
+          "repository": "cloudreve/cloudreve",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cobalt",
+      "image": "ghcr.io/imputnet/cobalt:7.13.3",
+      "repository": "ghcr.io/imputnet/cobalt",
+      "current_tag": "7.13.3",
+      "candidate_tag": "11.7.1",
+      "candidate_image": "ghcr.io/imputnet/cobalt:11.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "cobalt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cobalt/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "repository": "ghcr.io/imputnet/cobalt",
+          "tag": "7.13.3",
+          "digest": null
+        },
+        {
+          "template": "cobalt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cobalt/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "repository": "ghcr.io/imputnet/cobalt",
+          "tag": "7.13.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "code-server",
+      "image": "codercom/code-server:4.90.3-39",
+      "repository": "codercom/code-server",
+      "current_tag": "4.90.3-39",
+      "candidate_tag": "4.125.0-39",
+      "candidate_image": "codercom/code-server:4.125.0-39",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "code-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/code-server/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "codercom/code-server:4.90.3-39",
+          "repository": "codercom/code-server",
+          "tag": "4.90.3-39",
+          "digest": null
+        },
+        {
+          "template": "code-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/code-server/index.yaml",
+          "line": 72,
+          "key": "image",
+          "image": "codercom/code-server:4.90.3-39",
+          "repository": "codercom/code-server",
+          "tag": "4.90.3-39",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "alpine/curl:8.12.1",
+      "repository": "alpine/curl",
+      "current_tag": "8.12.1",
+      "candidate_tag": "8.20.0",
+      "candidate_image": "alpine/curl:8.20.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1042,
+          "key": "image",
+          "image": "alpine/curl:8.12.1",
+          "repository": "alpine/curl",
+          "tag": "8.12.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3",
+      "repository": "alpine/git",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 915,
+          "key": "image",
+          "image": "alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3",
+          "repository": "alpine/git",
+          "tag": null,
+          "digest": "sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3"
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "bitnamilegacy/elasticsearch:8.18.0",
+      "repository": "bitnamilegacy/elasticsearch",
+      "current_tag": "8.18.0",
+      "candidate_tag": "9.1.2",
+      "candidate_image": "bitnamilegacy/elasticsearch:9.1.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 633,
+          "key": "originImageName",
+          "image": "bitnamilegacy/elasticsearch:8.18.0",
+          "repository": "bitnamilegacy/elasticsearch",
+          "tag": "8.18.0",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 666,
+          "key": "image",
+          "image": "bitnamilegacy/elasticsearch:8.18.0",
+          "repository": "bitnamilegacy/elasticsearch",
+          "tag": "8.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+      "repository": "bitnamilegacy/etcd",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 518,
+          "key": "originImageName",
+          "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+          "repository": "bitnamilegacy/etcd",
+          "tag": null,
+          "digest": "sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0"
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 551,
+          "key": "image",
+          "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+          "repository": "bitnamilegacy/etcd",
+          "tag": null,
+          "digest": "sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0"
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 540,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 655,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 908,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 982,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 989,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 996,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1148,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "cozedev/coze-studio-server:0.5.1",
+      "repository": "cozedev/coze-studio-server",
+      "current_tag": "0.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 888,
+          "key": "originImageName",
+          "image": "cozedev/coze-studio-server:0.5.1",
+          "repository": "cozedev/coze-studio-server",
+          "tag": "0.5.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1156,
+          "key": "image",
+          "image": "cozedev/coze-studio-server:0.5.1",
+          "repository": "cozedev/coze-studio-server",
+          "tag": "0.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "cozedev/coze-studio-web:0.5.1",
+      "repository": "cozedev/coze-studio-web",
+      "current_tag": "0.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1361,
+          "key": "originImageName",
+          "image": "cozedev/coze-studio-web:0.5.1",
+          "repository": "cozedev/coze-studio-web",
+          "tag": "0.5.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1379,
+          "key": "image",
+          "image": "cozedev/coze-studio-web:0.5.1",
+          "repository": "cozedev/coze-studio-web",
+          "tag": "0.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "milvusdb/milvus:v2.5.10",
+      "repository": "milvusdb/milvus",
+      "current_tag": "v2.5.10",
+      "candidate_tag": "v2.6.18",
+      "candidate_image": "milvusdb/milvus:v2.6.18",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 755,
+          "key": "originImageName",
+          "image": "milvusdb/milvus:v2.5.10",
+          "repository": "milvusdb/milvus",
+          "tag": "v2.5.10",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 775,
+          "key": "image",
+          "image": "milvusdb/milvus:v2.5.10",
+          "repository": "milvusdb/milvus",
+          "tag": "v2.5.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1",
+      "repository": "minio/mc",
+      "current_tag": "RELEASE.2025-05-21T01-59-54Z-cpuv1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 1003,
+          "key": "image",
+          "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1",
+          "repository": "minio/mc",
+          "tag": "RELEASE.2025-05-21T01-59-54Z-cpuv1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "mysql:8.0.36",
+      "repository": "mysql",
+      "current_tag": "8.0.36",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "mysql:8.0.36",
+          "repository": "mysql",
+          "tag": "8.0.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "nsqio/nsq:v1.2.1",
+      "repository": "nsqio/nsq",
+      "current_tag": "v1.2.1",
+      "candidate_tag": "v1.3.0",
+      "candidate_image": "nsqio/nsq:v1.3.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 378,
+          "key": "originImageName",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 394,
+          "key": "image",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 447,
+          "key": "originImageName",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/coze-studio/index.yaml",
+          "line": 463,
+          "key": "image",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+      "repository": "ghcr.io/yangchuansheng/crmeb",
+      "current_tag": "v5.4.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/crmeb/index.yaml",
+          "line": 350,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        },
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/crmeb/index.yaml",
+          "line": 373,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        },
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/crmeb/index.yaml",
+          "line": 404,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/crmeb/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "nginx:alpine3.20",
+      "repository": "nginx",
+      "current_tag": "alpine3.20",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/crmeb/index.yaml",
+          "line": 381,
+          "key": "image",
+          "image": "nginx:alpine3.20",
+          "repository": "nginx",
+          "tag": "alpine3.20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cronicle",
+      "image": "soulteary/cronicle:0.9.46",
+      "repository": "soulteary/cronicle",
+      "current_tag": "0.9.46",
+      "candidate_tag": "0.9.80",
+      "candidate_image": "soulteary/cronicle:0.9.80",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "cronicle",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cronicle/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "soulteary/cronicle:0.9.46",
+          "repository": "soulteary/cronicle",
+          "tag": "0.9.46",
+          "digest": null
+        },
+        {
+          "template": "cronicle",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/cronicle/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "soulteary/cronicle:0.9.46",
+          "repository": "soulteary/cronicle",
+          "tag": "0.9.46",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dataease/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dataease/index.yaml",
+          "line": 358,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+      "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+      "current_tag": "v2.10.12",
+      "candidate_tag": "v2.10.25",
+      "candidate_image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dataease/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+          "tag": "v2.10.12",
+          "digest": null
+        },
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dataease/index.yaml",
+          "line": 113,
+          "key": "image",
+          "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+          "tag": "v2.10.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dbgate",
+      "image": "dbgate/dbgate:5.3.1-alpine",
+      "repository": "dbgate/dbgate",
+      "current_tag": "5.3.1-alpine",
+      "candidate_tag": "7.2.1-alpine",
+      "candidate_image": "dbgate/dbgate:7.2.1-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dbgate",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dbgate/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "dbgate/dbgate:5.3.1-alpine",
+          "repository": "dbgate/dbgate",
+          "tag": "5.3.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "dbgate",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dbgate/index.yaml",
+          "line": 78,
+          "key": "image",
+          "image": "dbgate/dbgate:5.3.1-alpine",
+          "repository": "dbgate/dbgate",
+          "tag": "5.3.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "deeplx",
+      "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+      "repository": "ghcr.io/owo-network/deeplx",
+      "current_tag": "v0.9.5",
+      "candidate_tag": "v1.2.2",
+      "candidate_image": "ghcr.io/owo-network/deeplx:v1.2.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "deeplx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/deeplx/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "repository": "ghcr.io/owo-network/deeplx",
+          "tag": "v0.9.5",
+          "digest": null
+        },
+        {
+          "template": "deeplx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/deeplx/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "repository": "ghcr.io/owo-network/deeplx",
+          "tag": "v0.9.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "derper",
+      "image": "bitnamilegacy/kubectl:1.28.9",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": "1.28.9",
+      "candidate_tag": "1.33.4",
+      "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "derper",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/derper/index.yaml",
+          "line": 196,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.28.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "derper",
+      "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+      "repository": "ghcr.io/yangchuansheng/derper",
+      "current_tag": "v1.99.0-pre",
+      "candidate_tag": "v1.101.0-pre",
+      "candidate_image": "ghcr.io/yangchuansheng/derper:v1.101.0-pre",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "derper",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/derper/index.yaml",
+          "line": 110,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "repository": "ghcr.io/yangchuansheng/derper",
+          "tag": "v1.99.0-pre",
+          "digest": null
+        },
+        {
+          "template": "derper",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/derper/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "repository": "ghcr.io/yangchuansheng/derper",
+          "tag": "v1.99.0-pre",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 112,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-api:1.11.2",
+      "repository": "langgenius/dify-api",
+      "current_tag": "1.11.2",
+      "candidate_tag": "1.14.2",
+      "candidate_image": "langgenius/dify-api:1.14.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 131,
+          "key": "image",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 273,
+          "key": "image",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+      "repository": "langgenius/dify-plugin-daemon",
+      "current_tag": "0.5.2-local",
+      "candidate_tag": "0.6.2-local",
+      "candidate_image": "langgenius/dify-plugin-daemon:0.6.2-local",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 681,
+          "key": "originImageName",
+          "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "repository": "langgenius/dify-plugin-daemon",
+          "tag": "0.5.2-local",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 740,
+          "key": "image",
+          "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "repository": "langgenius/dify-plugin-daemon",
+          "tag": "0.5.2-local",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-sandbox:0.2.12",
+      "repository": "langgenius/dify-sandbox",
+      "current_tag": "0.2.12",
+      "candidate_tag": "0.2.15",
+      "candidate_image": "langgenius/dify-sandbox:0.2.15",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 601,
+          "key": "originImageName",
+          "image": "langgenius/dify-sandbox:0.2.12",
+          "repository": "langgenius/dify-sandbox",
+          "tag": "0.2.12",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 624,
+          "key": "image",
+          "image": "langgenius/dify-sandbox:0.2.12",
+          "repository": "langgenius/dify-sandbox",
+          "tag": "0.2.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-web:1.11.2",
+      "repository": "langgenius/dify-web",
+      "current_tag": "1.11.2",
+      "candidate_tag": "1.14.2",
+      "candidate_image": "langgenius/dify-web:1.14.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 414,
+          "key": "originImageName",
+          "image": "langgenius/dify-web:1.11.2",
+          "repository": "langgenius/dify-web",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 470,
+          "key": "image",
+          "image": "langgenius/dify-web:1.11.2",
+          "repository": "langgenius/dify-web",
+          "tag": "1.11.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 434,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 704,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 965,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "semitechnologies/weaviate:1.27.0",
+      "repository": "semitechnologies/weaviate",
+      "current_tag": "1.27.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 1120,
+          "key": "originImageName",
+          "image": "semitechnologies/weaviate:1.27.0",
+          "repository": "semitechnologies/weaviate",
+          "tag": "1.27.0",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dify/index.yaml",
+          "line": 1141,
+          "key": "image",
+          "image": "semitechnologies/weaviate:1.27.0",
+          "repository": "semitechnologies/weaviate",
+          "tag": "1.27.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "directus/directus:11.17.4",
+      "repository": "directus/directus",
+      "current_tag": "11.17.4",
+      "candidate_tag": "12.0.2",
+      "candidate_image": "directus/directus:12.0.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 332,
+          "key": "originImageName",
+          "image": "directus/directus:11.17.4",
+          "repository": "directus/directus",
+          "tag": "11.17.4",
+          "digest": null
+        },
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "directus/directus:11.17.4",
+          "repository": "directus/directus",
+          "tag": "11.17.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 357,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 380,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/directus/index.yaml",
+          "line": 421,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docker-stacks",
+      "image": "jupyter/scipy-notebook:2023-10-20",
+      "repository": "jupyter/scipy-notebook",
+      "current_tag": "2023-10-20",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "docker-stacks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/docker-stacks/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "jupyter/scipy-notebook:2023-10-20",
+          "repository": "jupyter/scipy-notebook",
+          "tag": "2023-10-20",
+          "digest": null
+        },
+        {
+          "template": "docker-stacks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/docker-stacks/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "jupyter/scipy-notebook:2023-10-20",
+          "repository": "jupyter/scipy-notebook",
+          "tag": "2023-10-20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docuseal",
+      "image": "docuseal/docuseal:3.0.1",
+      "repository": "docuseal/docuseal",
+      "current_tag": "3.0.1",
+      "candidate_tag": "3.1.1",
+      "candidate_image": "docuseal/docuseal:3.1.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/docuseal/index.yaml",
+          "line": 184,
+          "key": "originImageName",
+          "image": "docuseal/docuseal:3.0.1",
+          "repository": "docuseal/docuseal",
+          "tag": "3.0.1",
+          "digest": null
+        },
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/docuseal/index.yaml",
+          "line": 207,
+          "key": "image",
+          "image": "docuseal/docuseal:3.0.1",
+          "repository": "docuseal/docuseal",
+          "tag": "3.0.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docuseal",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/docuseal/index.yaml",
+          "line": 139,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dolibarr",
+      "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+      "repository": "dolibarr/dolibarr",
+      "current_tag": "23.0.3-php8.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dolibarr/index.yaml",
+          "line": 213,
+          "key": "originImageName",
+          "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+          "repository": "dolibarr/dolibarr",
+          "tag": "23.0.3-php8.2",
+          "digest": "sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865"
+        },
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dolibarr/index.yaml",
+          "line": 234,
+          "key": "image",
+          "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+          "repository": "dolibarr/dolibarr",
+          "tag": "23.0.3-php8.2",
+          "digest": "sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865"
+        }
+      ]
+    },
+    {
+      "template": "dolibarr",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/dolibarr/index.yaml",
+          "line": 161,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "drawdb",
+      "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+      "repository": "ghcr.io/drawdb-io/drawdb",
+      "current_tag": "v1.5.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/drawdb-io/drawdb:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "drawdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/drawdb/index.yaml",
+          "line": 60,
+          "key": "originImageName",
+          "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "repository": "ghcr.io/drawdb-io/drawdb",
+          "tag": "v1.5.0",
+          "digest": null
+        },
+        {
+          "template": "drawdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/drawdb/index.yaml",
+          "line": 81,
+          "key": "image",
+          "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "repository": "ghcr.io/drawdb-io/drawdb",
+          "tag": "v1.5.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "drizzle-studio",
+      "image": "ghcr.io/drizzle-team/gateway:latest",
+      "repository": "ghcr.io/drizzle-team/gateway",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "drizzle-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/drizzle-studio/index.yaml",
+          "line": 42,
+          "key": "originImageName",
+          "image": "ghcr.io/drizzle-team/gateway:latest",
+          "repository": "ghcr.io/drizzle-team/gateway",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "drizzle-studio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/drizzle-studio/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "ghcr.io/drizzle-team/gateway:latest",
+          "repository": "ghcr.io/drizzle-team/gateway",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "eaglercraft-server",
+      "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1",
+      "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+      "current_tag": "1.12.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "eaglercraft-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/eaglercraft-server/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1",
+          "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+          "tag": "1.12.1",
+          "digest": null
+        },
+        {
+          "template": "eaglercraft-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/eaglercraft-server/index.yaml",
+          "line": 67,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1",
+          "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+          "tag": "1.12.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+      "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+      "current_tag": "0.12.2",
+      "candidate_tag": "0.12.11",
+      "candidate_image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/edgequake/index.yaml",
+          "line": 380,
+          "key": "originImageName",
+          "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+          "tag": "0.12.2",
+          "digest": null
+        },
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/edgequake/index.yaml",
+          "line": 400,
+          "key": "image",
+          "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+          "tag": "0.12.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+      "repository": "ghcr.io/raphaelmansuy/edgequake",
+      "current_tag": "0.12.2",
+      "candidate_tag": "0.12.11",
+      "candidate_image": "ghcr.io/raphaelmansuy/edgequake:0.12.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/edgequake/index.yaml",
+          "line": 282,
+          "key": "originImageName",
+          "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake",
+          "tag": "0.12.2",
+          "digest": null
+        },
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/edgequake/index.yaml",
+          "line": 302,
+          "key": "image",
+          "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake",
+          "tag": "0.12.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/edgequake/index.yaml",
+          "line": 163,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "elasticsearch",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/elasticsearch/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "elasticsearch",
+      "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+      "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+      "current_tag": "9.4.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/elasticsearch/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+          "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+          "tag": "9.4.1",
+          "digest": null
+        },
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/elasticsearch/index.yaml",
+          "line": 84,
+          "key": "image",
+          "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+          "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+          "tag": "9.4.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "emqx",
+      "image": "emqx/emqx:5.8.9",
+      "repository": "emqx/emqx",
+      "current_tag": "5.8.9",
+      "candidate_tag": "6.2.1",
+      "candidate_image": "emqx/emqx:6.2.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "emqx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/emqx/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "emqx/emqx:5.8.9",
+          "repository": "emqx/emqx",
+          "tag": "5.8.9",
+          "digest": null
+        },
+        {
+          "template": "emqx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/emqx/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "emqx/emqx:5.8.9",
+          "repository": "emqx/emqx",
+          "tag": "5.8.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/enshrouded/index.yaml",
+          "line": 90,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/enshrouded/index.yaml",
+          "line": 102,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/enshrouded/index.yaml",
+          "line": 211,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+      "current_tag": "v0.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/enshrouded/index.yaml",
+          "line": 68,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+          "tag": "v0.2",
+          "digest": null
+        },
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/enshrouded/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+          "tag": "v0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "frappe/erpnext:v16.21.1",
+      "repository": "frappe/erpnext",
+      "current_tag": "v16.21.1",
+      "candidate_tag": "v16.25.0",
+      "candidate_image": "frappe/erpnext:v16.25.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 374,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 530,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 666,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 731,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 786,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 882,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 962,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1027,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1118,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1214,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1275,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1371,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1432,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1497,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "mariadb:11.4.7",
+      "repository": "mariadb",
+      "current_tag": "11.4.7",
+      "candidate_tag": "12.3.2",
+      "candidate_image": "mariadb:12.3.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "mariadb:11.4.7",
+          "repository": "mariadb",
+          "tag": "11.4.7",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 89,
+          "key": "image",
+          "image": "mariadb:11.4.7",
+          "repository": "mariadb",
+          "tag": "11.4.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 319,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 475,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 687,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 710,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 807,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 861,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 983,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1006,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1139,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1193,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1296,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1350,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1453,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1476,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 342,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 498,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 830,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1162,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/erpnext/index.yaml",
+          "line": 1319,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 208,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+      "repository": "ghcr.io/ever-co/gauzy-api-demo",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 186,
+          "key": "originImageName",
+          "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+          "repository": "ghcr.io/ever-co/gauzy-api-demo",
+          "tag": null,
+          "digest": "sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4"
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 271,
+          "key": "image",
+          "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+          "repository": "ghcr.io/ever-co/gauzy-api-demo",
+          "tag": null,
+          "digest": "sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4"
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+      "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 516,
+          "key": "originImageName",
+          "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+          "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+          "tag": null,
+          "digest": "sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493"
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 537,
+          "key": "image",
+          "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+          "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+          "tag": null,
+          "digest": "sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493"
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 149,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ever-gauzy/index.yaml",
+          "line": 228,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "evoapicloud/evolution-api:v2.3.7",
+      "repository": "evoapicloud/evolution-api",
+      "current_tag": "v2.3.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 315,
+          "key": "originImageName",
+          "image": "evoapicloud/evolution-api:v2.3.7",
+          "repository": "evoapicloud/evolution-api",
+          "tag": "v2.3.7",
+          "digest": null
+        },
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 424,
+          "key": "image",
+          "image": "evoapicloud/evolution-api:v2.3.7",
+          "repository": "evoapicloud/evolution-api",
+          "tag": "v2.3.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 340,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 152,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 361,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/evolution-api/index.yaml",
+          "line": 393,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "excalidraw",
+      "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+      "repository": "excalidraw/excalidraw",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "excalidraw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/excalidraw/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+          "repository": "excalidraw/excalidraw",
+          "tag": null,
+          "digest": "sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f"
+        },
+        {
+          "template": "excalidraw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/excalidraw/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+          "repository": "excalidraw/excalidraw",
+          "tag": null,
+          "digest": "sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f"
+        }
+      ]
+    },
+    {
+      "template": "fast-poster",
+      "image": "fastposter/fastposter:latest",
+      "repository": "fastposter/fastposter",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fast-poster",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fast-poster/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "fastposter/fastposter:latest",
+          "repository": "fastposter/fastposter",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "fast-poster",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fast-poster/index.yaml",
+          "line": 52,
+          "key": "image",
+          "image": "fastposter/fastposter:latest",
+          "repository": "fastposter/fastposter",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 369,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1013,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1033,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1126,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1146,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 852,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 872,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.25",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 562,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 582,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1238,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt/index.yaml",
+          "line": 1258,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 1176,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 678,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 704,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 774,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 800,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 417,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 443,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.25",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 136,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 580,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-milvus/index.yaml",
+          "line": 606,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1161,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1181,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1274,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1294,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1000,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1020,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.25",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 855,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 875,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.25",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 563,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 583,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.3",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1386,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fastgpt-pro/index.yaml",
+          "line": 1406,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-api-server:5.0.5",
+      "repository": "featbit/featbit-api-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-api-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1118,
+          "key": "originImageName",
+          "image": "featbit/featbit-api-server:5.0.5",
+          "repository": "featbit/featbit-api-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1179,
+          "key": "image",
+          "image": "featbit/featbit-api-server:5.0.5",
+          "repository": "featbit/featbit-api-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-data-analytics-server:5.0.5",
+      "repository": "featbit/featbit-data-analytics-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-data-analytics-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1247,
+          "key": "originImageName",
+          "image": "featbit/featbit-data-analytics-server:5.0.5",
+          "repository": "featbit/featbit-data-analytics-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1308,
+          "key": "image",
+          "image": "featbit/featbit-data-analytics-server:5.0.5",
+          "repository": "featbit/featbit-data-analytics-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-evaluation-server:5.0.5",
+      "repository": "featbit/featbit-evaluation-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-evaluation-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1370,
+          "key": "originImageName",
+          "image": "featbit/featbit-evaluation-server:5.0.5",
+          "repository": "featbit/featbit-evaluation-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1431,
+          "key": "image",
+          "image": "featbit/featbit-evaluation-server:5.0.5",
+          "repository": "featbit/featbit-evaluation-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-ui:5.0.5",
+      "repository": "featbit/featbit-ui",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-ui:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1497,
+          "key": "originImageName",
+          "image": "featbit/featbit-ui:5.0.5",
+          "repository": "featbit/featbit-ui",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1519,
+          "key": "image",
+          "image": "featbit/featbit-ui:5.0.5",
+          "repository": "featbit/featbit-ui",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 240,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1140,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1269,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/featbit-standard/index.yaml",
+          "line": 1392,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "filecodebox",
+      "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+      "repository": "lanol/filecodebox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "filecodebox",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/filecodebox/index.yaml",
+          "line": 126,
+          "key": "originImageName",
+          "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+          "repository": "lanol/filecodebox",
+          "tag": null,
+          "digest": "sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2"
+        },
+        {
+          "template": "filecodebox",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/filecodebox/index.yaml",
+          "line": 147,
+          "key": "image",
+          "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+          "repository": "lanol/filecodebox",
+          "tag": null,
+          "digest": "sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2"
+        }
+      ]
+    },
+    {
+      "template": "fireboom",
+      "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+      "repository": "fireboomapi/fireboom_server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fireboom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fireboom/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+          "repository": "fireboomapi/fireboom_server",
+          "tag": null,
+          "digest": "sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f"
+        },
+        {
+          "template": "fireboom",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/fireboom/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+          "repository": "fireboomapi/fireboom_server",
+          "tag": null,
+          "digest": "sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f"
+        }
+      ]
+    },
+    {
+      "template": "firefox",
+      "image": "jlesage/firefox:latest",
+      "repository": "jlesage/firefox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "firefox",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/firefox/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "jlesage/firefox:latest",
+          "repository": "jlesage/firefox",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "firefox",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/firefox/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "jlesage/firefox:latest",
+          "repository": "jlesage/firefox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flarum",
+      "image": "crazymax/flarum:1.8.10",
+      "repository": "crazymax/flarum",
+      "current_tag": "1.8.10",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flarum/index.yaml",
+          "line": 129,
+          "key": "originImageName",
+          "image": "crazymax/flarum:1.8.10",
+          "repository": "crazymax/flarum",
+          "tag": "1.8.10",
+          "digest": null
+        },
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flarum/index.yaml",
+          "line": 202,
+          "key": "image",
+          "image": "crazymax/flarum:1.8.10",
+          "repository": "crazymax/flarum",
+          "tag": "1.8.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flarum",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flarum/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flowise",
+      "image": "flowiseai/flowise:3.0.5",
+      "repository": "flowiseai/flowise",
+      "current_tag": "3.0.5",
+      "candidate_tag": "3.1.2",
+      "candidate_image": "flowiseai/flowise:3.1.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flowise/index.yaml",
+          "line": 195,
+          "key": "originImageName",
+          "image": "flowiseai/flowise:3.0.5",
+          "repository": "flowiseai/flowise",
+          "tag": "3.0.5",
+          "digest": null
+        },
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flowise/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "flowiseai/flowise:3.0.5",
+          "repository": "flowiseai/flowise",
+          "tag": "3.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flowise",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flowise/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/flowise/index.yaml",
+          "line": 217,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "formbricks",
+      "image": "ghcr.io/formbricks/formbricks:4.9.7",
+      "repository": "ghcr.io/formbricks/formbricks",
+      "current_tag": "4.9.7",
+      "candidate_tag": "5.1.4",
+      "candidate_image": "ghcr.io/formbricks/formbricks:5.1.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/formbricks/index.yaml",
+          "line": 344,
+          "key": "originImageName",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        },
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/formbricks/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        },
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/formbricks/index.yaml",
+          "line": 426,
+          "key": "image",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "formbricks",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/formbricks/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "frp",
+      "image": "bitnamilegacy/kubectl:1.28.9",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": "1.28.9",
+      "candidate_tag": "1.33.4",
+      "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "frp",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/frp/index.yaml",
+          "line": 299,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.28.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "frp",
+      "image": "snowdreamtech/frps:0.59",
+      "repository": "snowdreamtech/frps",
+      "current_tag": "0.59",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "frp",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/frp/index.yaml",
+          "line": 79,
+          "key": "originImageName",
+          "image": "snowdreamtech/frps:0.59",
+          "repository": "snowdreamtech/frps",
+          "tag": "0.59",
+          "digest": null
+        },
+        {
+          "template": "frp",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/frp/index.yaml",
+          "line": 104,
+          "key": "image",
+          "image": "snowdreamtech/frps:0.59",
+          "repository": "snowdreamtech/frps",
+          "tag": "0.59",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+      "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+      "current_tag": "0.8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 232,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 300,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 320,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+      "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+      "current_tag": "0.8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 429,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+          "tag": "0.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/full-stack-fastapi/index.yaml",
+          "line": 183,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "ghost:6.44.1-alpine",
+      "repository": "ghost",
+      "current_tag": "6.44.1-alpine",
+      "candidate_tag": "6.46.0-alpine",
+      "candidate_image": "ghost:6.46.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ghost/index.yaml",
+          "line": 250,
+          "key": "originImageName",
+          "image": "ghost:6.44.1-alpine",
+          "repository": "ghost",
+          "tag": "6.44.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ghost/index.yaml",
+          "line": 339,
+          "key": "image",
+          "image": "ghost:6.44.1-alpine",
+          "repository": "ghost",
+          "tag": "6.44.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+      "repository": "public.ecr.aws/docker/library/mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ghost/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ghost/index.yaml",
+          "line": 300,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "public.ecr.aws/docker/library/node:22-alpine",
+      "repository": "public.ecr.aws/docker/library/node",
+      "current_tag": "22-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ghost/index.yaml",
+          "line": 277,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/node:22-alpine",
+          "repository": "public.ecr.aws/docker/library/node",
+          "tag": "22-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "gitea",
+      "image": "gitea/gitea:1.22.0-rootless",
+      "repository": "gitea/gitea",
+      "current_tag": "1.22.0-rootless",
+      "candidate_tag": "1.26.4-rootless",
+      "candidate_image": "gitea/gitea:1.26.4-rootless",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "gitea",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/gitea/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "gitea/gitea:1.22.0-rootless",
+          "repository": "gitea/gitea",
+          "tag": "1.22.0-rootless",
+          "digest": null
+        },
+        {
+          "template": "gitea",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/gitea/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "gitea/gitea:1.22.0-rootless",
+          "repository": "gitea/gitea",
+          "tag": "1.22.0-rootless",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glance",
+      "image": "glanceapp/glance",
+      "repository": "glanceapp/glance",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "glance",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glance/index.yaml",
+          "line": 146,
+          "key": "originImageName",
+          "image": "glanceapp/glance",
+          "repository": "glanceapp/glance",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glance",
+      "image": "glanceapp/glance:latest",
+      "repository": "glanceapp/glance",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "glance",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glance/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "glanceapp/glance:latest",
+          "repository": "glanceapp/glance",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glitchtip",
+      "image": "glitchtip/glitchtip:v4.1.5",
+      "repository": "glitchtip/glitchtip",
+      "current_tag": "v4.1.5",
+      "candidate_tag": "v6.0.3",
+      "candidate_image": "glitchtip/glitchtip:v6.0.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glitchtip/index.yaml",
+          "line": 61,
+          "key": "originImageName",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glitchtip/index.yaml",
+          "line": 86,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glitchtip/index.yaml",
+          "line": 175,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glitchtip/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glitchtip",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/glitchtip/index.yaml",
+          "line": 623,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "gpt-academic",
+      "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+      "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+      "current_tag": "master",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "gpt-academic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/gpt-academic/index.yaml",
+          "line": 63,
+          "key": "originImageName",
+          "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+          "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+          "tag": "master",
+          "digest": null
+        },
+        {
+          "template": "gpt-academic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/gpt-academic/index.yaml",
+          "line": 88,
+          "key": "image",
+          "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+          "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+          "tag": "master",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 242,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 372,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "grafana/grafana:12.3.0",
+      "repository": "grafana/grafana",
+      "current_tag": "12.3.0",
+      "candidate_tag": "13.1.0",
+      "candidate_image": "grafana/grafana:13.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 351,
+          "key": "originImageName",
+          "image": "grafana/grafana:12.3.0",
+          "repository": "grafana/grafana",
+          "tag": "12.3.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 384,
+          "key": "image",
+          "image": "grafana/grafana:12.3.0",
+          "repository": "grafana/grafana",
+          "tag": "12.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "otel/opentelemetry-collector:0.99.0",
+      "repository": "otel/opentelemetry-collector",
+      "current_tag": "0.99.0",
+      "candidate_tag": "0.154.0",
+      "candidate_image": "otel/opentelemetry-collector:0.154.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 70,
+          "key": "originImageName",
+          "image": "otel/opentelemetry-collector:0.99.0",
+          "repository": "otel/opentelemetry-collector",
+          "tag": "0.99.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "otel/opentelemetry-collector:0.99.0",
+          "repository": "otel/opentelemetry-collector",
+          "tag": "0.99.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "prom/prometheus:v3.8.0",
+      "repository": "prom/prometheus",
+      "current_tag": "v3.8.0",
+      "candidate_tag": "v3.12.0",
+      "candidate_image": "prom/prometheus:v3.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 221,
+          "key": "originImageName",
+          "image": "prom/prometheus:v3.8.0",
+          "repository": "prom/prometheus",
+          "tag": "v3.8.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/grafana-otel/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "prom/prometheus:v3.8.0",
+          "repository": "prom/prometheus",
+          "tag": "v3.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "halo",
+      "image": "halohub/halo:2.18.0",
+      "repository": "halohub/halo",
+      "current_tag": "2.18.0",
+      "candidate_tag": "2.25.4",
+      "candidate_image": "halohub/halo:2.25.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "halo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/halo/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "halohub/halo:2.18.0",
+          "repository": "halohub/halo",
+          "tag": "2.18.0",
+          "digest": null
+        },
+        {
+          "template": "halo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/halo/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "halohub/halo:2.18.0",
+          "repository": "halohub/halo",
+          "tag": "2.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "halo",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "halo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/halo/index.yaml",
+          "line": 271,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "happy-server",
+      "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+      "repository": "ghcr.io/yangchuansheng/happy-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/happy-server/index.yaml",
+          "line": 704,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+          "repository": "ghcr.io/yangchuansheng/happy-server",
+          "tag": null,
+          "digest": "sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe"
+        },
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/happy-server/index.yaml",
+          "line": 724,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+          "repository": "ghcr.io/yangchuansheng/happy-server",
+          "tag": null,
+          "digest": "sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe"
+        }
+      ]
+    },
+    {
+      "template": "happy-server",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/happy-server/index.yaml",
+          "line": 523,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-core:v2.14.4",
+      "repository": "goharbor/harbor-core",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/harbor-core:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 606,
+          "key": "originImageName",
+          "image": "goharbor/harbor-core:v2.14.4",
+          "repository": "goharbor/harbor-core",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 628,
+          "key": "image",
+          "image": "goharbor/harbor-core:v2.14.4",
+          "repository": "goharbor/harbor-core",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-jobservice:v2.14.4",
+      "repository": "goharbor/harbor-jobservice",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/harbor-jobservice:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 739,
+          "key": "originImageName",
+          "image": "goharbor/harbor-jobservice:v2.14.4",
+          "repository": "goharbor/harbor-jobservice",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 762,
+          "key": "image",
+          "image": "goharbor/harbor-jobservice:v2.14.4",
+          "repository": "goharbor/harbor-jobservice",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-portal:v2.14.4",
+      "repository": "goharbor/harbor-portal",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/harbor-portal:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 840,
+          "key": "originImageName",
+          "image": "goharbor/harbor-portal:v2.14.4",
+          "repository": "goharbor/harbor-portal",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 862,
+          "key": "image",
+          "image": "goharbor/harbor-portal:v2.14.4",
+          "repository": "goharbor/harbor-portal",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-registryctl:v2.14.4",
+      "repository": "goharbor/harbor-registryctl",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/harbor-registryctl:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 1041,
+          "key": "originImageName",
+          "image": "goharbor/harbor-registryctl:v2.14.4",
+          "repository": "goharbor/harbor-registryctl",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 1063,
+          "key": "image",
+          "image": "goharbor/harbor-registryctl:v2.14.4",
+          "repository": "goharbor/harbor-registryctl",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/registry-photon:v2.14.4",
+      "repository": "goharbor/registry-photon",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/registry-photon:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 903,
+          "key": "originImageName",
+          "image": "goharbor/registry-photon:v2.14.4",
+          "repository": "goharbor/registry-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 926,
+          "key": "image",
+          "image": "goharbor/registry-photon:v2.14.4",
+          "repository": "goharbor/registry-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/trivy-adapter-photon:v2.14.4",
+      "repository": "goharbor/trivy-adapter-photon",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.1",
+      "candidate_image": "goharbor/trivy-adapter-photon:v2.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 1121,
+          "key": "originImageName",
+          "image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "repository": "goharbor/trivy-adapter-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 1146,
+          "key": "image",
+          "image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "repository": "goharbor/trivy-adapter-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/harbor/index.yaml",
+          "line": 163,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "hasura",
+      "image": "hasura/graphql-data-connector:v2.48.11",
+      "repository": "hasura/graphql-data-connector",
+      "current_tag": "v2.48.11",
+      "candidate_tag": "v2.49.3",
+      "candidate_image": "hasura/graphql-data-connector:v2.49.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/hasura/index.yaml",
+          "line": 215,
+          "key": "originImageName",
+          "image": "hasura/graphql-data-connector:v2.48.11",
+          "repository": "hasura/graphql-data-connector",
+          "tag": "v2.48.11",
+          "digest": null
+        },
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/hasura/index.yaml",
+          "line": 235,
+          "key": "image",
+          "image": "hasura/graphql-data-connector:v2.48.11",
+          "repository": "hasura/graphql-data-connector",
+          "tag": "v2.48.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "hasura",
+      "image": "hasura/graphql-engine:v2.48.11",
+      "repository": "hasura/graphql-engine",
+      "current_tag": "v2.48.11",
+      "candidate_tag": "v2.49.3",
+      "candidate_image": "hasura/graphql-engine:v2.49.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/hasura/index.yaml",
+          "line": 121,
+          "key": "originImageName",
+          "image": "hasura/graphql-engine:v2.48.11",
+          "repository": "hasura/graphql-engine",
+          "tag": "v2.48.11",
+          "digest": null
+        },
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/hasura/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "hasura/graphql-engine:v2.48.11",
+          "repository": "hasura/graphql-engine",
+          "tag": "v2.48.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 945,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "ghcr.io/tale/headplane:0.6.3",
+      "repository": "ghcr.io/tale/headplane",
+      "current_tag": "0.6.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 1042,
+          "key": "image",
+          "image": "ghcr.io/tale/headplane:0.6.3",
+          "repository": "ghcr.io/tale/headplane",
+          "tag": "0.6.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "headscale/headscale:0.29.0-beta.1-debug",
+      "repository": "headscale/headscale",
+      "current_tag": "0.29.0-beta.1-debug",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 879,
+          "key": "originImageName",
+          "image": "headscale/headscale:0.29.0-beta.1-debug",
+          "repository": "headscale/headscale",
+          "tag": "0.29.0-beta.1-debug",
+          "digest": null
+        },
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 998,
+          "key": "image",
+          "image": "headscale/headscale:0.29.0-beta.1-debug",
+          "repository": "headscale/headscale",
+          "tag": "0.29.0-beta.1-debug",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 140,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/headscale/index.yaml",
+          "line": 906,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "heyform",
+      "image": "heyform/community-edition:v3.0.0-rc.7",
+      "repository": "heyform/community-edition",
+      "current_tag": "v3.0.0-rc.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "heyform",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/heyform/index.yaml",
+          "line": 271,
+          "key": "originImageName",
+          "image": "heyform/community-edition:v3.0.0-rc.7",
+          "repository": "heyform/community-edition",
+          "tag": "v3.0.0-rc.7",
+          "digest": null
+        },
+        {
+          "template": "heyform",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/heyform/index.yaml",
+          "line": 293,
+          "key": "image",
+          "image": "heyform/community-edition:v3.0.0-rc.7",
+          "repository": "heyform/community-edition",
+          "tag": "v3.0.0-rc.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "illa-builder",
+      "image": "illasoft/illa-builder:v4.8.2",
+      "repository": "illasoft/illa-builder",
+      "current_tag": "v4.8.2",
+      "candidate_tag": "v4.8.5",
+      "candidate_image": "illasoft/illa-builder:v4.8.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "illa-builder",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/illa-builder/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "illasoft/illa-builder:v4.8.2",
+          "repository": "illasoft/illa-builder",
+          "tag": "v4.8.2",
+          "digest": null
+        },
+        {
+          "template": "illa-builder",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/illa-builder/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "illasoft/illa-builder:v4.8.2",
+          "repository": "illasoft/illa-builder",
+          "tag": "v4.8.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+      "repository": "ghcr.io/immich-app/immich-machine-learning",
+      "current_tag": "v2.7.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 506,
+          "key": "originImageName",
+          "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-machine-learning",
+          "tag": "v2.7.5",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 529,
+          "key": "image",
+          "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-machine-learning",
+          "tag": "v2.7.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+      "repository": "ghcr.io/immich-app/immich-server",
+      "current_tag": "v2.7.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 319,
+          "key": "originImageName",
+          "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-server",
+          "tag": "v2.7.5",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 388,
+          "key": "image",
+          "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-server",
+          "tag": "v2.7.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 255,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/immich/index.yaml",
+          "line": 342,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "influxdb",
+      "image": "docker.io/library/influxdb:2.9.1",
+      "repository": "docker.io/library/influxdb",
+      "current_tag": "2.9.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "influxdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/influxdb/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "docker.io/library/influxdb:2.9.1",
+          "repository": "docker.io/library/influxdb",
+          "tag": "2.9.1",
+          "digest": null
+        },
+        {
+          "template": "influxdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/influxdb/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "docker.io/library/influxdb:2.9.1",
+          "repository": "docker.io/library/influxdb",
+          "tag": "2.9.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "inpaint-web",
+      "image": "yangchuansheng/inpaint-web",
+      "repository": "yangchuansheng/inpaint-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "inpaint-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/inpaint-web/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "yangchuansheng/inpaint-web",
+          "repository": "yangchuansheng/inpaint-web",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "inpaint-web",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/inpaint-web/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "yangchuansheng/inpaint-web",
+          "repository": "yangchuansheng/inpaint-web",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "apecloud/kubeblocks-tools:0.9.3",
+      "repository": "apecloud/kubeblocks-tools",
+      "current_tag": "0.9.3",
+      "candidate_tag": "1.0.2",
+      "candidate_image": "apecloud/kubeblocks-tools:1.0.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "apecloud/kubeblocks-tools:0.9.3",
+          "repository": "apecloud/kubeblocks-tools",
+          "tag": "0.9.3",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 352,
+          "key": "image",
+          "image": "apecloud/kubeblocks-tools:0.9.3",
+          "repository": "apecloud/kubeblocks-tools",
+          "tag": "0.9.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+      "repository": "ghcr.io/insforge/deno-runtime",
+      "current_tag": "2.0.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 767,
+          "key": "originImageName",
+          "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+          "repository": "ghcr.io/insforge/deno-runtime",
+          "tag": "2.0.6",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 787,
+          "key": "image",
+          "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+          "repository": "ghcr.io/insforge/deno-runtime",
+          "tag": "2.0.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+      "repository": "ghcr.io/insforge/insforge-oss",
+      "current_tag": "v2.1.8",
+      "candidate_tag": "v2.2.2",
+      "candidate_image": "ghcr.io/insforge/insforge-oss:v2.2.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 420,
+          "key": "originImageName",
+          "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "repository": "ghcr.io/insforge/insforge-oss",
+          "tag": "v2.1.8",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 500,
+          "key": "image",
+          "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "repository": "ghcr.io/insforge/insforge-oss",
+          "tag": "v2.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 441,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "postgrest/postgrest:v12.2.12",
+      "repository": "postgrest/postgrest",
+      "current_tag": "v12.2.12",
+      "candidate_tag": "v13.0.8",
+      "candidate_image": "postgrest/postgrest:v13.0.8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 675,
+          "key": "originImageName",
+          "image": "postgrest/postgrest:v12.2.12",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.2.12",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/insforge/index.yaml",
+          "line": 695,
+          "key": "image",
+          "image": "postgrest/postgrest:v12.2.12",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.2.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "it-tools",
+      "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+      "repository": "ghcr.io/corentinth/it-tools",
+      "current_tag": "2024.5.13-a0bc346",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "it-tools",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/it-tools/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+          "repository": "ghcr.io/corentinth/it-tools",
+          "tag": "2024.5.13-a0bc346",
+          "digest": null
+        },
+        {
+          "template": "it-tools",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/it-tools/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+          "repository": "ghcr.io/corentinth/it-tools",
+          "tag": "2024.5.13-a0bc346",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "jsoncrack",
+      "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+      "repository": "shokohsc/jsoncrack",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "jsoncrack",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/jsoncrack/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+          "repository": "shokohsc/jsoncrack",
+          "tag": null,
+          "digest": "sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef"
+        },
+        {
+          "template": "jsoncrack",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/jsoncrack/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+          "repository": "shokohsc/jsoncrack",
+          "tag": null,
+          "digest": "sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef"
+        }
+      ]
+    },
+    {
+      "template": "kanboard",
+      "image": "kanboard/kanboard:v1.2.50",
+      "repository": "kanboard/kanboard",
+      "current_tag": "v1.2.50",
+      "candidate_tag": "v1.2.52",
+      "candidate_image": "kanboard/kanboard:v1.2.52",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kanboard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kanboard/index.yaml",
+          "line": 121,
+          "key": "originImageName",
+          "image": "kanboard/kanboard:v1.2.50",
+          "repository": "kanboard/kanboard",
+          "tag": "v1.2.50",
+          "digest": null
+        },
+        {
+          "template": "kanboard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kanboard/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "kanboard/kanboard:v1.2.50",
+          "repository": "kanboard/kanboard",
+          "tag": "v1.2.50",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "ghcr.io/usekaneo/api:1.1.8",
+      "repository": "ghcr.io/usekaneo/api",
+      "current_tag": "1.1.8",
+      "candidate_tag": "2.7.7",
+      "candidate_image": "ghcr.io/usekaneo/api:2.7.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kaneo/index.yaml",
+          "line": 170,
+          "key": "originImageName",
+          "image": "ghcr.io/usekaneo/api:1.1.8",
+          "repository": "ghcr.io/usekaneo/api",
+          "tag": "1.1.8",
+          "digest": null
+        },
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kaneo/index.yaml",
+          "line": 190,
+          "key": "image",
+          "image": "ghcr.io/usekaneo/api:1.1.8",
+          "repository": "ghcr.io/usekaneo/api",
+          "tag": "1.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "ghcr.io/usekaneo/web:1.1.8",
+      "repository": "ghcr.io/usekaneo/web",
+      "current_tag": "1.1.8",
+      "candidate_tag": "2.7.7",
+      "candidate_image": "ghcr.io/usekaneo/web:2.7.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kaneo/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "ghcr.io/usekaneo/web:1.1.8",
+          "repository": "ghcr.io/usekaneo/web",
+          "tag": "1.1.8",
+          "digest": null
+        },
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kaneo/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "ghcr.io/usekaneo/web:1.1.8",
+          "repository": "ghcr.io/usekaneo/web",
+          "tag": "1.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kaneo/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keycloak",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keycloak/index.yaml",
+          "line": 152,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keycloak",
+      "image": "quay.io/keycloak/keycloak:26.3.2",
+      "repository": "quay.io/keycloak/keycloak",
+      "current_tag": "26.3.2",
+      "candidate_tag": "26.6.3",
+      "candidate_image": "quay.io/keycloak/keycloak:26.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keycloak/index.yaml",
+          "line": 177,
+          "key": "originImageName",
+          "image": "quay.io/keycloak/keycloak:26.3.2",
+          "repository": "quay.io/keycloak/keycloak",
+          "tag": "26.3.2",
+          "digest": null
+        },
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keycloak/index.yaml",
+          "line": 198,
+          "key": "image",
+          "image": "quay.io/keycloak/keycloak:26.3.2",
+          "repository": "quay.io/keycloak/keycloak",
+          "tag": "26.3.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keystone",
+      "image": "node:22.22.1-alpine",
+      "repository": "node",
+      "current_tag": "22.22.1-alpine",
+      "candidate_tag": "26.3.1-alpine",
+      "candidate_image": "node:26.3.1-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keystone/index.yaml",
+          "line": 479,
+          "key": "originImageName",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keystone/index.yaml",
+          "line": 544,
+          "key": "image",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keystone/index.yaml",
+          "line": 620,
+          "key": "image",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keystone",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/keystone/index.yaml",
+          "line": 149,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kitten-tts",
+      "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+      "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+      "current_tag": "cpu-v1.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kitten-tts/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        },
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kitten-tts/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        },
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kitten-tts/index.yaml",
+          "line": 76,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kodcloud",
+      "image": "kodcloud/kodbox:latest",
+      "repository": "kodcloud/kodbox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kodcloud",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kodcloud/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "kodcloud/kodbox:latest",
+          "repository": "kodcloud/kodbox",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "kodcloud",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kodcloud/index.yaml",
+          "line": 67,
+          "key": "image",
+          "image": "kodcloud/kodbox:latest",
+          "repository": "kodcloud/kodbox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuboard",
+      "image": "eipwork/kuboard:v3",
+      "repository": "eipwork/kuboard",
+      "current_tag": "v3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kuboard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuboard/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "eipwork/kuboard:v3",
+          "repository": "eipwork/kuboard",
+          "tag": "v3",
+          "digest": null
+        },
+        {
+          "template": "kuboard",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuboard/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "eipwork/kuboard:v3",
+          "repository": "eipwork/kuboard",
+          "tag": "v3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuvasz",
+      "image": "kuvaszmonitoring/kuvasz:3.11.0",
+      "repository": "kuvaszmonitoring/kuvasz",
+      "current_tag": "3.11.0",
+      "candidate_tag": "4.0.1",
+      "candidate_image": "kuvaszmonitoring/kuvasz:4.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuvasz/index.yaml",
+          "line": 201,
+          "key": "originImageName",
+          "image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "repository": "kuvaszmonitoring/kuvasz",
+          "tag": "3.11.0",
+          "digest": null
+        },
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuvasz/index.yaml",
+          "line": 277,
+          "key": "image",
+          "image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "repository": "kuvaszmonitoring/kuvasz",
+          "tag": "3.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuvasz",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuvasz/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/kuvasz/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/laf-server:sha-ef30cd9",
+      "repository": "docker.io/lafyun/laf-server",
+      "current_tag": "sha-ef30cd9",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 209,
+          "key": "image",
+          "image": "docker.io/lafyun/laf-server:sha-ef30cd9",
+          "repository": "docker.io/lafyun/laf-server",
+          "tag": "sha-ef30cd9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/laf-web:sha-e9d012d",
+      "repository": "docker.io/lafyun/laf-web",
+      "current_tag": "sha-e9d012d",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 328,
+          "key": "image",
+          "image": "docker.io/lafyun/laf-web:sha-e9d012d",
+          "repository": "docker.io/lafyun/laf-web",
+          "tag": "sha-e9d012d",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/runtime-node-init:sha-67b3cd6",
+      "repository": "docker.io/lafyun/runtime-node-init",
+      "current_tag": "sha-67b3cd6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1418,
+          "key": "image",
+          "image": "docker.io/lafyun/runtime-node-init:sha-67b3cd6",
+          "repository": "docker.io/lafyun/runtime-node-init",
+          "tag": "sha-67b3cd6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/runtime-node:sha-67b3cd6",
+      "repository": "docker.io/lafyun/runtime-node",
+      "current_tag": "sha-67b3cd6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1396,
+          "key": "image",
+          "image": "docker.io/lafyun/runtime-node:sha-67b3cd6",
+          "repository": "docker.io/lafyun/runtime-node",
+          "tag": "sha-67b3cd6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/library/nginx:latest",
+      "repository": "docker.io/library/nginx",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1441,
+          "key": "image",
+          "image": "docker.io/library/nginx:latest",
+          "repository": "docker.io/library/nginx",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+      "repository": "quay.io/minio/mc",
+      "current_tag": "RELEASE.2022-11-07T23-47-39Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1094,
+          "key": "image",
+          "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+          "repository": "quay.io/minio/mc",
+          "tag": "RELEASE.2022-11-07T23-47-39Z",
+          "digest": null
+        },
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1148,
+          "key": "image",
+          "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+          "repository": "quay.io/minio/mc",
+          "tag": "RELEASE.2022-11-07T23-47-39Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 975,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+      "repository": "quay.io/minio/minio",
+      "current_tag": "RELEASE.2023-03-22T06-36-24Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 1008,
+          "key": "image",
+          "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+          "repository": "quay.io/minio/minio",
+          "tag": "RELEASE.2023-03-22T06-36-24Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/prometheus/prometheus:v2.45.0",
+      "repository": "quay.io/prometheus/prometheus",
+      "current_tag": "v2.45.0",
+      "candidate_tag": "v3.12.0",
+      "candidate_image": "quay.io/prometheus/prometheus:v3.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/laf/index.yaml",
+          "line": 519,
+          "key": "image",
+          "image": "quay.io/prometheus/prometheus:v2.45.0",
+          "repository": "quay.io/prometheus/prometheus",
+          "tag": "v2.45.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langflow",
+      "image": "langflowai/langflow:1.9.5",
+      "repository": "langflowai/langflow",
+      "current_tag": "1.9.5",
+      "candidate_tag": "1.10.1",
+      "candidate_image": "langflowai/langflow:1.10.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langflow/index.yaml",
+          "line": 219,
+          "key": "originImageName",
+          "image": "langflowai/langflow:1.9.5",
+          "repository": "langflowai/langflow",
+          "tag": "1.9.5",
+          "digest": null
+        },
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langflow/index.yaml",
+          "line": 247,
+          "key": "image",
+          "image": "langflowai/langflow:1.9.5",
+          "repository": "langflowai/langflow",
+          "tag": "1.9.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langflow",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langflow/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "clickhouse/clickhouse-server:25.4.2",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.4.2",
+      "candidate_tag": "26.5.3",
+      "candidate_image": "clickhouse/clickhouse-server:26.5.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 385,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 409,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+      "repository": "docker.io/langfuse/langfuse-worker",
+      "current_tag": "3.180.0",
+      "candidate_tag": "3.196.0",
+      "candidate_image": "docker.io/langfuse/langfuse-worker:3.196.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 528,
+          "key": "originImageName",
+          "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "repository": "docker.io/langfuse/langfuse-worker",
+          "tag": "3.180.0",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 622,
+          "key": "image",
+          "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "repository": "docker.io/langfuse/langfuse-worker",
+          "tag": "3.180.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "docker.io/langfuse/langfuse:3.180.0",
+      "repository": "docker.io/langfuse/langfuse",
+      "current_tag": "3.180.0",
+      "candidate_tag": "3.196.0",
+      "candidate_image": "docker.io/langfuse/langfuse:3.196.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 786,
+          "key": "originImageName",
+          "image": "docker.io/langfuse/langfuse:3.180.0",
+          "repository": "docker.io/langfuse/langfuse",
+          "tag": "3.180.0",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 839,
+          "key": "image",
+          "image": "docker.io/langfuse/langfuse:3.180.0",
+          "repository": "docker.io/langfuse/langfuse",
+          "tag": "3.180.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+      "repository": "minio/minio",
+      "current_tag": "RELEASE.2025-09-07T16-13-09Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 1042,
+          "key": "originImageName",
+          "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+          "repository": "minio/minio",
+          "tag": "RELEASE.2025-09-07T16-13-09Z",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 1065,
+          "key": "image",
+          "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+          "repository": "minio/minio",
+          "tag": "RELEASE.2025-09-07T16-13-09Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 184,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 550,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 591,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/langfuse/index.yaml",
+          "line": 808,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "librechat",
+      "image": "getmeili/meilisearch:v1.5",
+      "repository": "getmeili/meilisearch",
+      "current_tag": "v1.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/librechat/index.yaml",
+          "line": 260,
+          "key": "originImageName",
+          "image": "getmeili/meilisearch:v1.5",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.5",
+          "digest": null
+        },
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/librechat/index.yaml",
+          "line": 283,
+          "key": "image",
+          "image": "getmeili/meilisearch:v1.5",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "librechat",
+      "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+      "repository": "ghcr.io/danny-avila/librechat",
+      "current_tag": "v0.7.3",
+      "candidate_tag": "v0.8.6",
+      "candidate_image": "ghcr.io/danny-avila/librechat:v0.8.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/librechat/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "repository": "ghcr.io/danny-avila/librechat",
+          "tag": "v0.7.3",
+          "digest": null
+        },
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/librechat/index.yaml",
+          "line": 75,
+          "key": "image",
+          "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "repository": "ghcr.io/danny-avila/librechat",
+          "tag": "v0.7.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/liebianbao/index.yaml",
+          "line": 99,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/liebianbao/index.yaml",
+          "line": 712,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "docker.io/labring4docker/php-custom:7.2-fpm",
+      "repository": "docker.io/labring4docker/php-custom",
+      "current_tag": "7.2-fpm",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/liebianbao/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "docker.io/labring4docker/php-custom:7.2-fpm",
+          "repository": "docker.io/labring4docker/php-custom",
+          "tag": "7.2-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "labring4docker/php-custom:7.2-fpm",
+      "repository": "labring4docker/php-custom",
+      "current_tag": "7.2-fpm",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/liebianbao/index.yaml",
+          "line": 78,
+          "key": "originImageName",
+          "image": "labring4docker/php-custom:7.2-fpm",
+          "repository": "labring4docker/php-custom",
+          "tag": "7.2-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "nginx:1.25.2",
+      "repository": "nginx",
+      "current_tag": "1.25.2",
+      "candidate_tag": "1.31.2",
+      "candidate_image": "nginx:1.31.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/liebianbao/index.yaml",
+          "line": 253,
+          "key": "image",
+          "image": "nginx:1.25.2",
+          "repository": "nginx",
+          "tag": "1.25.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/listmonk/index.yaml",
+          "line": 252,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "listmonk/listmonk:v6.1.0",
+      "repository": "listmonk/listmonk",
+      "current_tag": "v6.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/listmonk/index.yaml",
+          "line": 224,
+          "key": "originImageName",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        },
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/listmonk/index.yaml",
+          "line": 274,
+          "key": "image",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        },
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/listmonk/index.yaml",
+          "line": 343,
+          "key": "image",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/listmonk/index.yaml",
+          "line": 151,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llama2-chinese",
+      "image": "luanshaotong/text-generation-webui-cpu:dev",
+      "repository": "luanshaotong/text-generation-webui-cpu",
+      "current_tag": "dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llama2-chinese",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llama2-chinese/index.yaml",
+          "line": 64,
+          "key": "originImageName",
+          "image": "luanshaotong/text-generation-webui-cpu:dev",
+          "repository": "luanshaotong/text-generation-webui-cpu",
+          "tag": "dev",
+          "digest": null
+        },
+        {
+          "template": "llama2-chinese",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llama2-chinese/index.yaml",
+          "line": 89,
+          "key": "image",
+          "image": "luanshaotong/text-generation-webui-cpu:dev",
+          "repository": "luanshaotong/text-generation-webui-cpu",
+          "tag": "dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llama3-8b-chinese",
+      "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+      "current_tag": "q4_k_m",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llama3-8b-chinese",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llama3-8b-chinese/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+          "tag": "q4_k_m",
+          "digest": null
+        },
+        {
+          "template": "llama3-8b-chinese",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llama3-8b-chinese/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+          "tag": "q4_k_m",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-api",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.5.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-api:v1.5.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 357,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-api",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 442,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-api",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-docs",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.5.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-docs:v1.5.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 1195,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-docs",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 1217,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-docs",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-gateway",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.5.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-gateway:v1.5.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 590,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-gateway",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 716,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-gateway",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-ui",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.5.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-ui:v1.5.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 1066,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-ui",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 1087,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-ui",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-worker",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.5.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-worker:v1.5.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 874,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-worker",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 1001,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-worker",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 378,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 611,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 652,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 896,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 419,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 693,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/llmgateway/index.yaml",
+          "line": 978,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat",
+      "image": "lobehub/lobe-chat:1.143.3",
+      "repository": "lobehub/lobe-chat",
+      "current_tag": "1.143.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "lobe-chat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/lobe-chat/index.yaml",
+          "line": 61,
+          "key": "originImageName",
+          "image": "lobehub/lobe-chat:1.143.3",
+          "repository": "lobehub/lobe-chat",
+          "tag": "1.143.3",
+          "digest": null
+        },
+        {
+          "template": "lobe-chat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/lobe-chat/index.yaml",
+          "line": 87,
+          "key": "image",
+          "image": "lobehub/lobe-chat:1.143.3",
+          "repository": "lobehub/lobe-chat",
+          "tag": "1.143.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat-db",
+      "image": "lobehub/lobe-chat-database:1.143.2",
+      "repository": "lobehub/lobe-chat-database",
+      "current_tag": "1.143.2",
+      "candidate_tag": "1.143.3",
+      "candidate_image": "lobehub/lobe-chat-database:1.143.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/lobe-chat-db/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "lobehub/lobe-chat-database:1.143.2",
+          "repository": "lobehub/lobe-chat-database",
+          "tag": "1.143.2",
+          "digest": null
+        },
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/lobe-chat-db/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "lobehub/lobe-chat-database:1.143.2",
+          "repository": "lobehub/lobe-chat-database",
+          "tag": "1.143.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat-db",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/lobe-chat-db/index.yaml",
+          "line": 172,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "logto",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "logto",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/logto/index.yaml",
+          "line": 127,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "logto",
+      "image": "svhd/logto:1.40.1",
+      "repository": "svhd/logto",
+      "current_tag": "1.40.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "logto",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/logto/index.yaml",
+          "line": 179,
+          "key": "originImageName",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        },
+        {
+          "template": "logto",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/logto/index.yaml",
+          "line": 204,
+          "key": "image",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        },
+        {
+          "template": "logto",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/logto/index.yaml",
+          "line": 253,
+          "key": "image",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "loki",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "loki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/loki/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "loki",
+      "image": "docker.io/grafana/loki:3.7.2",
+      "repository": "docker.io/grafana/loki",
+      "current_tag": "3.7.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "loki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/loki/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "docker.io/grafana/loki:3.7.2",
+          "repository": "docker.io/grafana/loki",
+          "tag": "3.7.2",
+          "digest": null
+        },
+        {
+          "template": "loki",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/loki/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "docker.io/grafana/loki:3.7.2",
+          "repository": "docker.io/grafana/loki",
+          "tag": "3.7.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mage-ai",
+      "image": "mageai/mageai:0.9.79",
+      "repository": "mageai/mageai",
+      "current_tag": "0.9.79",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mage-ai/index.yaml",
+          "line": 211,
+          "key": "originImageName",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        },
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mage-ai/index.yaml",
+          "line": 233,
+          "key": "image",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        },
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mage-ai/index.yaml",
+          "line": 283,
+          "key": "image",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mage-ai",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mage-ai/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+      "repository": "ghcr.io/mastodon/mastodon-streaming",
+      "current_tag": "v4.5.11",
+      "candidate_tag": "v4.6.0",
+      "candidate_image": "ghcr.io/mastodon/mastodon-streaming:v4.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 937,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon-streaming",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 1004,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon-streaming",
+          "tag": "v4.5.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+      "repository": "ghcr.io/mastodon/mastodon",
+      "current_tag": "v4.5.11",
+      "candidate_tag": "v4.6.0",
+      "candidate_image": "ghcr.io/mastodon/mastodon:v4.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 455,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 572,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 639,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 753,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 817,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 598,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 776,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 963,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "public.ecr.aws/docker/library/redis:7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mastodon/index.yaml",
+          "line": 434,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matomo",
+      "image": "matomo:5.10.0-apache",
+      "repository": "matomo",
+      "current_tag": "5.10.0-apache",
+      "candidate_tag": "5.11.2-apache",
+      "candidate_image": "matomo:5.11.2-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matomo/index.yaml",
+          "line": 179,
+          "key": "originImageName",
+          "image": "matomo:5.10.0-apache",
+          "repository": "matomo",
+          "tag": "5.10.0-apache",
+          "digest": null
+        },
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matomo/index.yaml",
+          "line": 201,
+          "key": "image",
+          "image": "matomo:5.10.0-apache",
+          "repository": "matomo",
+          "tag": "5.10.0-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matomo",
+      "image": "mysql:8.0.44",
+      "repository": "mysql",
+      "current_tag": "8.0.44",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matomo/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "tag": "8.0.44",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "${{ defaults.app_name }}-api",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matrixgorilla/index.yaml",
+          "line": 79,
+          "key": "originImageName",
+          "image": "${{ defaults.app_name }}-api",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "${{ defaults.app_name }}-web",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matrixgorilla/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "${{ defaults.app_name }}-web",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest",
+      "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matrixgorilla/index.yaml",
+          "line": 101,
+          "key": "image",
+          "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest",
+          "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest",
+      "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/matrixgorilla/index.yaml",
+          "line": 58,
+          "key": "image",
+          "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest",
+          "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 473,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 597,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "mautic/mautic:7.1.2-apache",
+      "repository": "mautic/mautic",
+      "current_tag": "7.1.2-apache",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 242,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 266,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 343,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 440,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 492,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 564,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 616,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "mysql:8.4.2",
+      "repository": "mysql",
+      "current_tag": "8.4.2",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mautic/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "mysql:8.4.2",
+          "repository": "mysql",
+          "tag": "8.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mazanoke",
+      "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+      "repository": "ghcr.io/civilblur/mazanoke",
+      "current_tag": "v1.1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mazanoke",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mazanoke/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+          "repository": "ghcr.io/civilblur/mazanoke",
+          "tag": "v1.1.6",
+          "digest": null
+        },
+        {
+          "template": "mazanoke",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mazanoke/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+          "repository": "ghcr.io/civilblur/mazanoke",
+          "tag": "v1.1.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "meilisearch",
+      "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+      "repository": "eyeix/meilisearch-ui",
+      "current_tag": "v0.15.1-lite",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/meilisearch/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+          "repository": "eyeix/meilisearch-ui",
+          "tag": "v0.15.1-lite",
+          "digest": null
+        },
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/meilisearch/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+          "repository": "eyeix/meilisearch-ui",
+          "tag": "v0.15.1-lite",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "meilisearch",
+      "image": "getmeili/meilisearch:v1.45.1",
+      "repository": "getmeili/meilisearch",
+      "current_tag": "v1.45.1",
+      "candidate_tag": "v1.48.1",
+      "candidate_image": "getmeili/meilisearch:v1.48.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/meilisearch/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "getmeili/meilisearch:v1.45.1",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.45.1",
+          "digest": null
+        },
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/meilisearch/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "getmeili/meilisearch:v1.45.1",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.45.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "memos",
+      "image": "ghcr.io/usememos/memos:latest",
+      "repository": "ghcr.io/usememos/memos",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "memos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/memos/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "ghcr.io/usememos/memos:latest",
+          "repository": "ghcr.io/usememos/memos",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "memos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/memos/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "ghcr.io/usememos/memos:latest",
+          "repository": "ghcr.io/usememos/memos",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "metabase",
+      "image": "metabase/metabase:v0.61.3",
+      "repository": "metabase/metabase",
+      "current_tag": "v0.61.3",
+      "candidate_tag": "v0.62.3",
+      "candidate_image": "metabase/metabase:v0.62.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/metabase/index.yaml",
+          "line": 171,
+          "key": "originImageName",
+          "image": "metabase/metabase:v0.61.3",
+          "repository": "metabase/metabase",
+          "tag": "v0.61.3",
+          "digest": null
+        },
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/metabase/index.yaml",
+          "line": 194,
+          "key": "image",
+          "image": "metabase/metabase:v0.61.3",
+          "repository": "metabase/metabase",
+          "tag": "v0.61.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "metabase",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/metabase/index.yaml",
+          "line": 128,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "midjourney-ui",
+      "image": "erictik/midjourney-ui:1.1.47",
+      "repository": "erictik/midjourney-ui",
+      "current_tag": "1.1.47",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "midjourney-ui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/midjourney-ui/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "erictik/midjourney-ui:1.1.47",
+          "repository": "erictik/midjourney-ui",
+          "tag": "1.1.47",
+          "digest": null
+        },
+        {
+          "template": "midjourney-ui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/midjourney-ui/index.yaml",
+          "line": 82,
+          "key": "image",
+          "image": "erictik/midjourney-ui:1.1.47",
+          "repository": "erictik/midjourney-ui",
+          "tag": "1.1.47",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindoc",
+      "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+      "current_tag": "v2.2-beta.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindoc/index.yaml",
+          "line": 274,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+          "tag": "v2.2-beta.1",
+          "digest": null
+        },
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindoc/index.yaml",
+          "line": 299,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+          "tag": "v2.2-beta.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindoc",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindoc/index.yaml",
+          "line": 133,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindsdb",
+      "image": "mindsdb/mindsdb:v26.1.0",
+      "repository": "mindsdb/mindsdb",
+      "current_tag": "v26.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindsdb/index.yaml",
+          "line": 253,
+          "key": "originImageName",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindsdb/index.yaml",
+          "line": 323,
+          "key": "image",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindsdb/index.yaml",
+          "line": 365,
+          "key": "image",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindsdb",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindsdb/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mindsdb/index.yaml",
+          "line": 276,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minecraft",
+      "image": "alpine:3.22.4",
+      "repository": "alpine",
+      "current_tag": "3.22.4",
+      "candidate_tag": "3.24.1",
+      "candidate_image": "alpine:3.24.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/minecraft/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "alpine:3.22.4",
+          "repository": "alpine",
+          "tag": "3.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minecraft",
+      "image": "itzg/minecraft-server:2026.5.3-java25",
+      "repository": "itzg/minecraft-server",
+      "current_tag": "2026.5.3-java25",
+      "candidate_tag": "2026.6.1-java8",
+      "candidate_image": "itzg/minecraft-server:2026.6.1-java8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/minecraft/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "itzg/minecraft-server:2026.5.3-java25",
+          "repository": "itzg/minecraft-server",
+          "tag": "2026.5.3-java25",
+          "digest": null
+        },
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/minecraft/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "itzg/minecraft-server:2026.5.3-java25",
+          "repository": "itzg/minecraft-server",
+          "tag": "2026.5.3-java25",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minio",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "minio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/minio/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "minio",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/minio/index.yaml",
+          "line": 80,
+          "key": "image",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mlflow",
+      "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+      "repository": "ghcr.io/mlflow/mlflow",
+      "current_tag": "v3.12.0",
+      "candidate_tag": "v3.14.0",
+      "candidate_image": "ghcr.io/mlflow/mlflow:v3.14.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mlflow/index.yaml",
+          "line": 201,
+          "key": "originImageName",
+          "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "repository": "ghcr.io/mlflow/mlflow",
+          "tag": "v3.12.0",
+          "digest": null
+        },
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mlflow/index.yaml",
+          "line": 270,
+          "key": "image",
+          "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "repository": "ghcr.io/mlflow/mlflow",
+          "tag": "v3.12.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mlflow",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mlflow/index.yaml",
+          "line": 151,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        },
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mlflow/index.yaml",
+          "line": 222,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "moneyprinterturbo",
+      "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+      "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+      "current_tag": "20240510083200",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "moneyprinterturbo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/moneyprinterturbo/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+          "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+          "tag": "20240510083200",
+          "digest": null
+        },
+        {
+          "template": "moneyprinterturbo",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/moneyprinterturbo/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+          "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+          "tag": "20240510083200",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mongo-express",
+      "image": "mongo-express:1.0.2-20-alpine3.19",
+      "repository": "mongo-express",
+      "current_tag": "1.0.2-20-alpine3.19",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mongo-express",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mongo-express/index.yaml",
+          "line": 127,
+          "key": "originImageName",
+          "image": "mongo-express:1.0.2-20-alpine3.19",
+          "repository": "mongo-express",
+          "tag": "1.0.2-20-alpine3.19",
+          "digest": null
+        },
+        {
+          "template": "mongo-express",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/mongo-express/index.yaml",
+          "line": 147,
+          "key": "image",
+          "image": "mongo-express:1.0.2-20-alpine3.19",
+          "repository": "mongo-express",
+          "tag": "1.0.2-20-alpine3.19",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 362,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 605,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "n8nio/n8n:2.22.4",
+      "repository": "n8nio/n8n",
+      "current_tag": "2.22.4",
+      "candidate_tag": "2.28.1",
+      "candidate_image": "n8nio/n8n:2.28.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 337,
+          "key": "originImageName",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 583,
+          "key": "originImageName",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 624,
+          "key": "image",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "n8nio/runners:2.22.4",
+      "repository": "n8nio/runners",
+      "current_tag": "2.22.4",
+      "candidate_tag": "2.28.1",
+      "candidate_image": "n8nio/runners:2.28.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 522,
+          "key": "originImageName",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 544,
+          "key": "image",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 711,
+          "key": "originImageName",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 733,
+          "key": "image",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/n8n/index.yaml",
+          "line": 296,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nacos",
+      "image": "mysql:8.0.44",
+      "repository": "mysql",
+      "current_tag": "8.0.44",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nacos/index.yaml",
+          "line": 347,
+          "key": "image",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "tag": "8.0.44",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nacos",
+      "image": "nacos/nacos-server:v3.2.2",
+      "repository": "nacos/nacos-server",
+      "current_tag": "v3.2.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nacos/index.yaml",
+          "line": 410,
+          "key": "originImageName",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nacos/index.yaml",
+          "line": 432,
+          "key": "image",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nacos/index.yaml",
+          "line": 545,
+          "key": "originImageName",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nacos/index.yaml",
+          "line": 567,
+          "key": "image",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 261,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "heroiclabs/nakama:3.39.0",
+      "repository": "heroiclabs/nakama",
+      "current_tag": "3.39.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 237,
+          "key": "originImageName",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 327,
+          "key": "image",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 187,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nakama/index.yaml",
+          "line": 278,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/dashboard:v2.38.1",
+      "repository": "netbirdio/dashboard",
+      "current_tag": "v2.38.1",
+      "candidate_tag": "v2.80.0",
+      "candidate_image": "netbirdio/dashboard:v2.80.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 150,
+          "key": "originImageName",
+          "image": "netbirdio/dashboard:v2.38.1",
+          "repository": "netbirdio/dashboard",
+          "tag": "v2.38.1",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 170,
+          "key": "image",
+          "image": "netbirdio/dashboard:v2.38.1",
+          "repository": "netbirdio/dashboard",
+          "tag": "v2.38.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/management:0.71.4",
+      "repository": "netbirdio/management",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.73.2",
+      "candidate_image": "netbirdio/management:0.73.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 217,
+          "key": "originImageName",
+          "image": "netbirdio/management:0.71.4",
+          "repository": "netbirdio/management",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 238,
+          "key": "image",
+          "image": "netbirdio/management:0.71.4",
+          "repository": "netbirdio/management",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/relay:0.71.4",
+      "repository": "netbirdio/relay",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.73.2",
+      "candidate_image": "netbirdio/relay:0.73.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 356,
+          "key": "originImageName",
+          "image": "netbirdio/relay:0.71.4",
+          "repository": "netbirdio/relay",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 376,
+          "key": "image",
+          "image": "netbirdio/relay:0.71.4",
+          "repository": "netbirdio/relay",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/signal:0.71.4",
+      "repository": "netbirdio/signal",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.73.2",
+      "candidate_image": "netbirdio/signal:0.73.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 295,
+          "key": "originImageName",
+          "image": "netbirdio/signal:0.71.4",
+          "repository": "netbirdio/signal",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/netbird/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "netbirdio/signal:0.71.4",
+          "repository": "netbirdio/signal",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "new-api",
+      "image": "calciumion/new-api:v0.13.2",
+      "repository": "calciumion/new-api",
+      "current_tag": "v0.13.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/new-api/index.yaml",
+          "line": 304,
+          "key": "originImageName",
+          "image": "calciumion/new-api:v0.13.2",
+          "repository": "calciumion/new-api",
+          "tag": "v0.13.2",
+          "digest": null
+        },
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/new-api/index.yaml",
+          "line": 326,
+          "key": "image",
+          "image": "calciumion/new-api:v0.13.2",
+          "repository": "calciumion/new-api",
+          "tag": "v0.13.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "new-api",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/new-api/index.yaml",
+          "line": 252,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nexus",
+      "image": "alpine:3.22.2",
+      "repository": "alpine",
+      "current_tag": "3.22.2",
+      "candidate_tag": "3.24.1",
+      "candidate_image": "alpine:3.24.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nexus/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "alpine:3.22.2",
+          "repository": "alpine",
+          "tag": "3.22.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nexus",
+      "image": "sonatype/nexus3:3.92.3",
+      "repository": "sonatype/nexus3",
+      "current_tag": "3.92.3",
+      "candidate_tag": "3.93.1",
+      "candidate_image": "sonatype/nexus3:3.93.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nexus/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "sonatype/nexus3:3.92.3",
+          "repository": "sonatype/nexus3",
+          "tag": "3.92.3",
+          "digest": null
+        },
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nexus/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "sonatype/nexus3:3.92.3",
+          "repository": "sonatype/nexus3",
+          "tag": "3.92.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nocodb",
+      "image": "nocodb/nocodb:2026.05.2",
+      "repository": "nocodb/nocodb",
+      "current_tag": "2026.05.2",
+      "candidate_tag": "2026.06.1",
+      "candidate_image": "nocodb/nocodb:2026.06.1",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nocodb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nocodb/index.yaml",
+          "line": 132,
+          "key": "originImageName",
+          "image": "nocodb/nocodb:2026.05.2",
+          "repository": "nocodb/nocodb",
+          "tag": "2026.05.2",
+          "digest": null
+        },
+        {
+          "template": "nocodb",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nocodb/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "nocodb/nocodb:2026.05.2",
+          "repository": "nocodb/nocodb",
+          "tag": "2026.05.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "node-red",
+      "image": "nodered/node-red:4.1.10",
+      "repository": "nodered/node-red",
+      "current_tag": "4.1.10",
+      "candidate_tag": "5.0.0",
+      "candidate_image": "nodered/node-red:5.0.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "node-red",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/node-red/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "nodered/node-red:4.1.10",
+          "repository": "nodered/node-red",
+          "tag": "4.1.10",
+          "digest": null
+        },
+        {
+          "template": "node-red",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/node-red/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "nodered/node-red:4.1.10",
+          "repository": "nodered/node-red",
+          "tag": "4.1.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "alpine/openssl:3.5.4",
+      "repository": "alpine/openssl",
+      "current_tag": "3.5.4",
+      "candidate_tag": "3.5.7",
+      "candidate_image": "alpine/openssl:3.5.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 210,
+          "key": "image",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "tag": "3.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+      "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 189,
+          "key": "originImageName",
+          "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+          "tag": null,
+          "digest": "sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7"
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 273,
+          "key": "image",
+          "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+          "tag": null,
+          "digest": "sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7"
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+      "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 427,
+          "key": "originImageName",
+          "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+          "tag": null,
+          "digest": "sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887"
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 448,
+          "key": "image",
+          "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+          "tag": null,
+          "digest": "sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887"
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 136,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nofx/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "notifuse",
+      "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+      "repository": "notifuse/notifuse",
+      "current_tag": "v32.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/notifuse/index.yaml",
+          "line": 175,
+          "key": "originImageName",
+          "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+          "repository": "notifuse/notifuse",
+          "tag": "v32.1",
+          "digest": "sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb"
+        },
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/notifuse/index.yaml",
+          "line": 250,
+          "key": "image",
+          "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+          "repository": "notifuse/notifuse",
+          "tag": "v32.1",
+          "digest": "sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb"
+        }
+      ]
+    },
+    {
+      "template": "notifuse",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/notifuse/index.yaml",
+          "line": 138,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/notifuse/index.yaml",
+          "line": 196,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nsfw",
+      "image": "ethandai4869/nsfw-auth",
+      "repository": "ethandai4869/nsfw-auth",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nsfw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nsfw/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ethandai4869/nsfw-auth",
+          "repository": "ethandai4869/nsfw-auth",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "nsfw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/nsfw/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ethandai4869/nsfw-auth",
+          "repository": "ethandai4869/nsfw-auth",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "one-api",
+      "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+      "repository": "ghcr.io/songquanpeng/one-api",
+      "current_tag": "v0.6.10",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "one-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/one-api/index.yaml",
+          "line": 51,
+          "key": "originImageName",
+          "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+          "repository": "ghcr.io/songquanpeng/one-api",
+          "tag": "v0.6.10",
+          "digest": null
+        },
+        {
+          "template": "one-api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/one-api/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+          "repository": "ghcr.io/songquanpeng/one-api",
+          "tag": "v0.6.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "open-design",
+      "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+      "repository": "docker.io/vanjayak/open-design",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-design/index.yaml",
+          "line": 101,
+          "key": "originImageName",
+          "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+          "repository": "docker.io/vanjayak/open-design",
+          "tag": null,
+          "digest": "sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13"
+        },
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-design/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+          "repository": "docker.io/vanjayak/open-design",
+          "tag": null,
+          "digest": "sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13"
+        }
+      ]
+    },
+    {
+      "template": "open-design",
+      "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+      "repository": "nginxinc/nginx-unprivileged",
+      "current_tag": "1.25-alpine-slim",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-design/index.yaml",
+          "line": 222,
+          "key": "originImageName",
+          "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+          "repository": "nginxinc/nginx-unprivileged",
+          "tag": "1.25-alpine-slim",
+          "digest": null
+        },
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-design/index.yaml",
+          "line": 248,
+          "key": "image",
+          "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+          "repository": "nginxinc/nginx-unprivileged",
+          "tag": "1.25-alpine-slim",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "open-webui",
+      "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+      "repository": "ghcr.io/open-webui/open-webui",
+      "current_tag": "v0.5.4",
+      "candidate_tag": "v0.9.6",
+      "candidate_image": "ghcr.io/open-webui/open-webui:v0.9.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-webui/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-webui/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-webui/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/open-webui/index.yaml",
+          "line": 74,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openagents",
+      "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+      "repository": "ghcr.io/openagents-org/openagents",
+      "current_tag": "sha-48764c0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openagents",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openagents/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+          "repository": "ghcr.io/openagents-org/openagents",
+          "tag": "sha-48764c0",
+          "digest": null
+        },
+        {
+          "template": "openagents",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openagents/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+          "repository": "ghcr.io/openagents-org/openagents",
+          "tag": "sha-48764c0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openai-proxy",
+      "image": "unickcheng/openai-proxy",
+      "repository": "unickcheng/openai-proxy",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openai-proxy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openai-proxy/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "unickcheng/openai-proxy",
+          "repository": "unickcheng/openai-proxy",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "openai-proxy",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openai-proxy/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "unickcheng/openai-proxy",
+          "repository": "unickcheng/openai-proxy",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "opencart",
+      "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+      "repository": "ghcr.io/yangchuansheng/opencart",
+      "current_tag": "4.1.0.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "opencart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/opencart/index.yaml",
+          "line": 139,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+          "repository": "ghcr.io/yangchuansheng/opencart",
+          "tag": "4.1.0.3",
+          "digest": "sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94"
+        },
+        {
+          "template": "opencart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/opencart/index.yaml",
+          "line": 160,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+          "repository": "ghcr.io/yangchuansheng/opencart",
+          "tag": "4.1.0.3",
+          "digest": "sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94"
+        }
+      ]
+    },
+    {
+      "template": "openclaw",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openclaw/index.yaml",
+          "line": 85,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openclaw",
+      "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+      "repository": "ghcr.io/openclaw/openclaw",
+      "current_tag": "2026.3.8",
+      "candidate_tag": "2026.6.10",
+      "candidate_image": "ghcr.io/openclaw/openclaw:2026.6.10",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openclaw/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        },
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openclaw/index.yaml",
+          "line": 102,
+          "key": "image",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        },
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openclaw/index.yaml",
+          "line": 160,
+          "key": "image",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openlist",
+      "image": "openlistteam/openlist:v4.0.9-aria2",
+      "repository": "openlistteam/openlist",
+      "current_tag": "v4.0.9-aria2",
+      "candidate_tag": "v4.2.2-aria2",
+      "candidate_image": "openlistteam/openlist:v4.2.2-aria2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openlist",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openlist/index.yaml",
+          "line": 49,
+          "key": "originImageName",
+          "image": "openlistteam/openlist:v4.0.9-aria2",
+          "repository": "openlistteam/openlist",
+          "tag": "v4.0.9-aria2",
+          "digest": null
+        },
+        {
+          "template": "openlist",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openlist/index.yaml",
+          "line": 72,
+          "key": "image",
+          "image": "openlistteam/openlist:v4.0.9-aria2",
+          "repository": "openlistteam/openlist",
+          "tag": "v4.0.9-aria2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openobserve",
+      "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+      "repository": "public.ecr.aws/zinclabs/openobserve",
+      "current_tag": "v0.90.3",
+      "candidate_tag": "v0.91.0",
+      "candidate_image": "public.ecr.aws/zinclabs/openobserve:v0.91.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openobserve",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openobserve/index.yaml",
+          "line": 68,
+          "key": "originImageName",
+          "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "repository": "public.ecr.aws/zinclabs/openobserve",
+          "tag": "v0.90.3",
+          "digest": null
+        },
+        {
+          "template": "openobserve",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/openobserve/index.yaml",
+          "line": 97,
+          "key": "image",
+          "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "repository": "public.ecr.aws/zinclabs/openobserve",
+          "tag": "v0.90.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "outline",
+      "image": "outlinewiki/outline:1.8.0-1",
+      "repository": "outlinewiki/outline",
+      "current_tag": "1.8.0-1",
+      "candidate_tag": "1.8.2-0",
+      "candidate_image": "outlinewiki/outline:1.8.2-0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "outline",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/outline/index.yaml",
+          "line": 427,
+          "key": "originImageName",
+          "image": "outlinewiki/outline:1.8.0-1",
+          "repository": "outlinewiki/outline",
+          "tag": "1.8.0-1",
+          "digest": null
+        },
+        {
+          "template": "outline",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/outline/index.yaml",
+          "line": 448,
+          "key": "image",
+          "image": "outlinewiki/outline:1.8.0-1",
+          "repository": "outlinewiki/outline",
+          "tag": "1.8.0-1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "outline",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "outline",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/outline/index.yaml",
+          "line": 384,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "overleaf",
+      "image": "sharelatex/sharelatex:6.1.2",
+      "repository": "sharelatex/sharelatex",
+      "current_tag": "6.1.2",
+      "candidate_tag": "6.2.0",
+      "candidate_image": "sharelatex/sharelatex:6.2.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "overleaf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/overleaf/index.yaml",
+          "line": 260,
+          "key": "originImageName",
+          "image": "sharelatex/sharelatex:6.1.2",
+          "repository": "sharelatex/sharelatex",
+          "tag": "6.1.2",
+          "digest": null
+        },
+        {
+          "template": "overleaf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/overleaf/index.yaml",
+          "line": 284,
+          "key": "image",
+          "image": "sharelatex/sharelatex:6.1.2",
+          "repository": "sharelatex/sharelatex",
+          "tag": "6.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pageplug",
+      "image": "cloudtogouser/pageplug-ce:v1.9.35",
+      "repository": "cloudtogouser/pageplug-ce",
+      "current_tag": "v1.9.35",
+      "candidate_tag": "v1.9.37",
+      "candidate_image": "cloudtogouser/pageplug-ce:v1.9.37",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pageplug",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pageplug/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "repository": "cloudtogouser/pageplug-ce",
+          "tag": "v1.9.35",
+          "digest": null
+        },
+        {
+          "template": "pageplug",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pageplug/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "repository": "cloudtogouser/pageplug-ce",
+          "tag": "v1.9.35",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palacms",
+      "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+      "repository": "ghcr.io/palacms/palacms",
+      "current_tag": "v3.0.0-beta.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "2026/06/24 20:57:57 No matching credentials were found for \"ghcr.io\"\nError: reading tags for ghcr.io/palacms/palacms: GET https://ghcr.io/token?scope=repository%3Apalacms%2Fpalacms%3Apull&service=ghcr.io: DENIED: requested access to the resource is denied",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "palacms",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palacms/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+          "repository": "ghcr.io/palacms/palacms",
+          "tag": "v3.0.0-beta.1",
+          "digest": null
+        },
+        {
+          "template": "palacms",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palacms/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+          "repository": "ghcr.io/palacms/palacms",
+          "tag": "v3.0.0-beta.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld/index.yaml",
+          "line": 85,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "hurlenko/filebrowser",
+      "repository": "hurlenko/filebrowser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld/index.yaml",
+          "line": 158,
+          "key": "image",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "thijsvanloef/palworld-server-docker",
+      "repository": "thijsvanloef/palworld-server-docker",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "thijsvanloef/palworld-server-docker",
+          "repository": "thijsvanloef/palworld-server-docker",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld/index.yaml",
+          "line": 103,
+          "key": "image",
+          "image": "thijsvanloef/palworld-server-docker",
+          "repository": "thijsvanloef/palworld-server-docker",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-autobackup",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-autobackup",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-autobackup/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-export",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-export/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-export",
+      "image": "hurlenko/filebrowser",
+      "repository": "hurlenko/filebrowser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-export/index.yaml",
+          "line": 42,
+          "key": "originImageName",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-export/index.yaml",
+          "line": 76,
+          "key": "image",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-management",
+      "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+      "current_tag": "2024-02-18",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "palworld-management",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-management/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+          "tag": "2024-02-18",
+          "digest": null
+        },
+        {
+          "template": "palworld-management",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/palworld-management/index.yaml",
+          "line": 90,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+          "tag": "2024-02-18",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pangolin",
+      "image": "docker.io/fosrl/pangolin:1.15.2",
+      "repository": "docker.io/fosrl/pangolin",
+      "current_tag": "1.15.2",
+      "candidate_tag": "1.19.2",
+      "candidate_image": "docker.io/fosrl/pangolin:1.19.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pangolin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pangolin/index.yaml",
+          "line": 102,
+          "key": "originImageName",
+          "image": "docker.io/fosrl/pangolin:1.15.2",
+          "repository": "docker.io/fosrl/pangolin",
+          "tag": "1.15.2",
+          "digest": null
+        },
+        {
+          "template": "pangolin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pangolin/index.yaml",
+          "line": 122,
+          "key": "image",
+          "image": "docker.io/fosrl/pangolin:1.15.2",
+          "repository": "docker.io/fosrl/pangolin",
+          "tag": "1.15.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+      "repository": "ghcr.io/paperclipai/paperclip",
+      "current_tag": "sha-b8725c5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 231,
+          "key": "originImageName",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 319,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 470,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 692,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 178,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperclip/index.yaml",
+          "line": 278,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperless-ngx",
+      "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+      "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperless-ngx/index.yaml",
+          "line": 318,
+          "key": "originImageName",
+          "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+          "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperless-ngx/index.yaml",
+          "line": 339,
+          "key": "image",
+          "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+          "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperless-ngx",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/paperless-ngx/index.yaml",
+          "line": 294,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "payload",
+      "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+      "repository": "ghcr.io/yangchuansheng/payload",
+      "current_tag": "3.82.1-a7dd17c9be0c",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "payload",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/payload/index.yaml",
+          "line": 178,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+          "repository": "ghcr.io/yangchuansheng/payload",
+          "tag": "3.82.1-a7dd17c9be0c",
+          "digest": null
+        },
+        {
+          "template": "payload",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/payload/index.yaml",
+          "line": 200,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+          "repository": "ghcr.io/yangchuansheng/payload",
+          "tag": "3.82.1-a7dd17c9be0c",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "payload",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "payload",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/payload/index.yaml",
+          "line": 134,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pdf2zh",
+      "image": "byaidu/pdf2zh:1.9.6",
+      "repository": "byaidu/pdf2zh",
+      "current_tag": "1.9.6",
+      "candidate_tag": "1.9.11",
+      "candidate_image": "byaidu/pdf2zh:1.9.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pdf2zh",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pdf2zh/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "byaidu/pdf2zh:1.9.6",
+          "repository": "byaidu/pdf2zh",
+          "tag": "1.9.6",
+          "digest": null
+        },
+        {
+          "template": "pdf2zh",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pdf2zh/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "byaidu/pdf2zh:1.9.6",
+          "repository": "byaidu/pdf2zh",
+          "tag": "1.9.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/backend:2.1.2",
+      "repository": "penpotapp/backend",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.1",
+      "candidate_image": "penpotapp/backend:2.16.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 281,
+          "key": "originImageName",
+          "image": "penpotapp/backend:2.1.2",
+          "repository": "penpotapp/backend",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 307,
+          "key": "image",
+          "image": "penpotapp/backend:2.1.2",
+          "repository": "penpotapp/backend",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/exporter:2.1.2",
+      "repository": "penpotapp/exporter",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.1",
+      "candidate_image": "penpotapp/exporter:2.16.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 422,
+          "key": "originImageName",
+          "image": "penpotapp/exporter:2.1.2",
+          "repository": "penpotapp/exporter",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 447,
+          "key": "image",
+          "image": "penpotapp/exporter:2.1.2",
+          "repository": "penpotapp/exporter",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/frontend:2.1.2",
+      "repository": "penpotapp/frontend",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.1",
+      "candidate_image": "penpotapp/frontend:2.16.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 496,
+          "key": "originImageName",
+          "image": "penpotapp/frontend:2.1.2",
+          "repository": "penpotapp/frontend",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 523,
+          "key": "image",
+          "image": "penpotapp/frontend:2.1.2",
+          "repository": "penpotapp/frontend",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/penpot/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "perplexica",
+      "image": "itzcrazykns1337/perplexica:v1.10.2",
+      "repository": "itzcrazykns1337/perplexica",
+      "current_tag": "v1.10.2",
+      "candidate_tag": "v1.12.0",
+      "candidate_image": "itzcrazykns1337/perplexica:v1.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/perplexica/index.yaml",
+          "line": 261,
+          "key": "originImageName",
+          "image": "itzcrazykns1337/perplexica:v1.10.2",
+          "repository": "itzcrazykns1337/perplexica",
+          "tag": "v1.10.2",
+          "digest": null
+        },
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/perplexica/index.yaml",
+          "line": 284,
+          "key": "image",
+          "image": "itzcrazykns1337/perplexica:v1.10.2",
+          "repository": "itzcrazykns1337/perplexica",
+          "tag": "v1.10.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "perplexica",
+      "image": "searxng/searxng:2025.2.20-28d1240fc",
+      "repository": "searxng/searxng",
+      "current_tag": "2025.2.20-28d1240fc",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/perplexica/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "searxng/searxng:2025.2.20-28d1240fc",
+          "repository": "searxng/searxng",
+          "tag": "2025.2.20-28d1240fc",
+          "digest": null
+        },
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/perplexica/index.yaml",
+          "line": 158,
+          "key": "image",
+          "image": "searxng/searxng:2025.2.20-28d1240fc",
+          "repository": "searxng/searxng",
+          "tag": "2025.2.20-28d1240fc",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pgadmin4",
+      "image": "dpage/pgadmin4:8.9",
+      "repository": "dpage/pgadmin4",
+      "current_tag": "8.9",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "pgadmin4",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pgadmin4/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "dpage/pgadmin4:8.9",
+          "repository": "dpage/pgadmin4",
+          "tag": "8.9",
+          "digest": null
+        },
+        {
+          "template": "pgadmin4",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pgadmin4/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "dpage/pgadmin4:8.9",
+          "repository": "dpage/pgadmin4",
+          "tag": "8.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "photoprism",
+      "image": "photoprism/photoprism:240711",
+      "repository": "photoprism/photoprism",
+      "current_tag": "240711",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "photoprism",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/photoprism/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "photoprism/photoprism:240711",
+          "repository": "photoprism/photoprism",
+          "tag": "240711",
+          "digest": null
+        },
+        {
+          "template": "photoprism",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/photoprism/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "photoprism/photoprism:240711",
+          "repository": "photoprism/photoprism",
+          "tag": "240711",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "phpmyadmin",
+      "image": "phpmyadmin:5.2.1",
+      "repository": "phpmyadmin",
+      "current_tag": "5.2.1",
+      "candidate_tag": "5.2.3",
+      "candidate_image": "phpmyadmin:5.2.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "phpmyadmin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/phpmyadmin/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "phpmyadmin:5.2.1",
+          "repository": "phpmyadmin",
+          "tag": "5.2.1",
+          "digest": null
+        },
+        {
+          "template": "phpmyadmin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/phpmyadmin/index.yaml",
+          "line": 55,
+          "key": "image",
+          "image": "phpmyadmin:5.2.1",
+          "repository": "phpmyadmin",
+          "tag": "5.2.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-admin:v0.22-dev",
+      "repository": "makeplane/plane-admin",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 433,
+          "key": "originImageName",
+          "image": "makeplane/plane-admin:v0.22-dev",
+          "repository": "makeplane/plane-admin",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 458,
+          "key": "image",
+          "image": "makeplane/plane-admin:v0.22-dev",
+          "repository": "makeplane/plane-admin",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-backend:v0.22-dev",
+      "repository": "makeplane/plane-backend",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 511,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 536,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 678,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 703,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 820,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 845,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-frontend:v0.22-dev",
+      "repository": "makeplane/plane-frontend",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 1037,
+          "key": "originImageName",
+          "image": "makeplane/plane-frontend:v0.22-dev",
+          "repository": "makeplane/plane-frontend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 1062,
+          "key": "image",
+          "image": "makeplane/plane-frontend:v0.22-dev",
+          "repository": "makeplane/plane-frontend",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-space:v0.22-dev",
+      "repository": "makeplane/plane-space",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 962,
+          "key": "originImageName",
+          "image": "makeplane/plane-space:v0.22-dev",
+          "repository": "makeplane/plane-space",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 987,
+          "key": "image",
+          "image": "makeplane/plane-space:v0.22-dev",
+          "repository": "makeplane/plane-space",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plane/index.yaml",
+          "line": 145,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/planka/index.yaml",
+          "line": 219,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "ghcr.io/plankanban/planka:2.1.1",
+      "repository": "ghcr.io/plankanban/planka",
+      "current_tag": "2.1.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/planka/index.yaml",
+          "line": 198,
+          "key": "originImageName",
+          "image": "ghcr.io/plankanban/planka:2.1.1",
+          "repository": "ghcr.io/plankanban/planka",
+          "tag": "2.1.1",
+          "digest": null
+        },
+        {
+          "template": "planka",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/planka/index.yaml",
+          "line": 249,
+          "key": "image",
+          "image": "ghcr.io/plankanban/planka:2.1.1",
+          "repository": "ghcr.io/plankanban/planka",
+          "tag": "2.1.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/planka/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plausible",
+      "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "23.3.7.5-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plausible/index.yaml",
+          "line": 187,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "23.3.7.5-alpine",
+          "digest": null
+        },
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plausible/index.yaml",
+          "line": 208,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "23.3.7.5-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plausible",
+      "image": "plausible/analytics:v2.0",
+      "repository": "plausible/analytics",
+      "current_tag": "v2.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plausible/index.yaml",
+          "line": 282,
+          "key": "originImageName",
+          "image": "plausible/analytics:v2.0",
+          "repository": "plausible/analytics",
+          "tag": "v2.0",
+          "digest": null
+        },
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/plausible/index.yaml",
+          "line": 307,
+          "key": "image",
+          "image": "plausible/analytics:v2.0",
+          "repository": "plausible/analytics",
+          "tag": "v2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocket-id",
+      "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+      "repository": "ghcr.io/pocket-id/pocket-id",
+      "current_tag": "v2.2.0",
+      "candidate_tag": "v2.9.0",
+      "candidate_image": "ghcr.io/pocket-id/pocket-id:v2.9.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pocket-id",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pocket-id/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "repository": "ghcr.io/pocket-id/pocket-id",
+          "tag": "v2.2.0",
+          "digest": null
+        },
+        {
+          "template": "pocket-id",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pocket-id/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "repository": "ghcr.io/pocket-id/pocket-id",
+          "tag": "v2.2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocketbase",
+      "image": "adrianmusante/pocketbase:0.29.3",
+      "repository": "adrianmusante/pocketbase",
+      "current_tag": "0.29.3",
+      "candidate_tag": "0.39.4",
+      "candidate_image": "adrianmusante/pocketbase:0.39.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pocketbase/index.yaml",
+          "line": 58,
+          "key": "originImageName",
+          "image": "adrianmusante/pocketbase:0.29.3",
+          "repository": "adrianmusante/pocketbase",
+          "tag": "0.29.3",
+          "digest": null
+        },
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pocketbase/index.yaml",
+          "line": 87,
+          "key": "image",
+          "image": "adrianmusante/pocketbase:0.29.3",
+          "repository": "adrianmusante/pocketbase",
+          "tag": "0.29.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocketbase",
+      "image": "busybox:latest",
+      "repository": "busybox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pocketbase/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "busybox:latest",
+          "repository": "busybox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "clickhouse/clickhouse-server:25.8.12.129",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.8.12.129",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1559,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.8.12.129",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.8.12.129",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1579,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.8.12.129",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.8.12.129",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+      "repository": "docker.redpanda.com/redpandadata/redpanda",
+      "current_tag": "v25.1.9",
+      "candidate_tag": "v26.1.10",
+      "candidate_image": "docker.redpanda.com/redpandadata/redpanda:v26.1.10",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 339,
+          "key": "originImageName",
+          "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "repository": "docker.redpanda.com/redpandadata/redpanda",
+          "tag": "v25.1.9",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 360,
+          "key": "image",
+          "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "repository": "docker.redpanda.com/redpandadata/redpanda",
+          "tag": "v25.1.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+      "repository": "ghcr.io/posthog/posthog-node",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 968,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1005,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1068,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+      "repository": "ghcr.io/posthog/posthog/capture",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1302,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1322,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1359,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1379,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+      "repository": "ghcr.io/posthog/posthog/feature-flags",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 988,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1414,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 1434,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+      "repository": "ghcr.io/posthog/posthog",
+      "current_tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 600,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 620,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 784,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 804,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 146,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "zookeeper:3.9.3",
+      "repository": "zookeeper",
+      "current_tag": "3.9.3",
+      "candidate_tag": "3.9.5",
+      "candidate_image": "zookeeper:3.9.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 481,
+          "key": "originImageName",
+          "image": "zookeeper:3.9.3",
+          "repository": "zookeeper",
+          "tag": "3.9.3",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/posthog/index.yaml",
+          "line": 502,
+          "key": "image",
+          "image": "zookeeper:3.9.3",
+          "repository": "zookeeper",
+          "tag": "3.9.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 326,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 531,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "elasticsearch:7.17.27",
+      "repository": "elasticsearch",
+      "current_tag": "7.17.27",
+      "candidate_tag": "9.4.2",
+      "candidate_image": "elasticsearch:9.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 305,
+          "key": "originImageName",
+          "image": "elasticsearch:7.17.27",
+          "repository": "elasticsearch",
+          "tag": "7.17.27",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 341,
+          "key": "image",
+          "image": "elasticsearch:7.17.27",
+          "repository": "elasticsearch",
+          "tag": "7.17.27",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+      "repository": "ghcr.io/gitroomhq/postiz-app",
+      "current_tag": "v2.21.8",
+      "candidate_tag": "v2.21.10",
+      "candidate_image": "ghcr.io/gitroomhq/postiz-app:v2.21.10",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 510,
+          "key": "originImageName",
+          "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "repository": "ghcr.io/gitroomhq/postiz-app",
+          "tag": "v2.21.8",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 583,
+          "key": "image",
+          "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "repository": "ghcr.io/gitroomhq/postiz-app",
+          "tag": "v2.21.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "temporalio/auto-setup:1.28.1",
+      "repository": "temporalio/auto-setup",
+      "current_tag": "1.28.1",
+      "candidate_tag": "1.29.7",
+      "candidate_image": "temporalio/auto-setup:1.29.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 400,
+          "key": "originImageName",
+          "image": "temporalio/auto-setup:1.28.1",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.28.1",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/postiz/index.yaml",
+          "line": 420,
+          "key": "image",
+          "image": "temporalio/auto-setup:1.28.1",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.28.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "presenton",
+      "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+      "repository": "ghcr.io/presenton/presenton",
+      "current_tag": "v0.8.2-beta",
+      "candidate_tag": "v0.8.9-beta",
+      "candidate_image": "ghcr.io/presenton/presenton:v0.8.9-beta",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "presenton",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/presenton/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "repository": "ghcr.io/presenton/presenton",
+          "tag": "v0.8.2-beta",
+          "digest": null
+        },
+        {
+          "template": "presenton",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/presenton/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "repository": "ghcr.io/presenton/presenton",
+          "tag": "v0.8.2-beta",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "prestashop",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/prestashop/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "prestashop",
+      "image": "prestashop/prestashop:9.1.3-apache",
+      "repository": "prestashop/prestashop",
+      "current_tag": "9.1.3-apache",
+      "candidate_tag": "9.1.4-apache",
+      "candidate_image": "prestashop/prestashop:9.1.4-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/prestashop/index.yaml",
+          "line": 216,
+          "key": "originImageName",
+          "image": "prestashop/prestashop:9.1.3-apache",
+          "repository": "prestashop/prestashop",
+          "tag": "9.1.3-apache",
+          "digest": null
+        },
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/prestashop/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "prestashop/prestashop:9.1.3-apache",
+          "repository": "prestashop/prestashop",
+          "tag": "9.1.3-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/privatebin/index.yaml",
+          "line": 272,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "frooodle/privatebin:0.26.1-fat",
+      "repository": "frooodle/privatebin",
+      "current_tag": "0.26.1-fat",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/frooodle/privatebin: GET https://index.docker.io/v2/frooodle/privatebin/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:frooodle/privatebin Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/privatebin/index.yaml",
+          "line": 249,
+          "key": "originImageName",
+          "image": "frooodle/privatebin:0.26.1-fat",
+          "repository": "frooodle/privatebin",
+          "tag": "0.26.1-fat",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "ghcr.io/privatebin/fs:1.7.4",
+      "repository": "ghcr.io/privatebin/fs",
+      "current_tag": "1.7.4",
+      "candidate_tag": "2.0.4",
+      "candidate_image": "ghcr.io/privatebin/fs:2.0.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/privatebin/index.yaml",
+          "line": 280,
+          "key": "image",
+          "image": "ghcr.io/privatebin/fs:1.7.4",
+          "repository": "ghcr.io/privatebin/fs",
+          "tag": "1.7.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+      "repository": "ghcr.io/pterodactyl/panel",
+      "current_tag": "v1.12.4",
+      "candidate_tag": "v1.14.0",
+      "candidate_image": "ghcr.io/pterodactyl/panel:v1.14.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 399,
+          "key": "image",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 545,
+          "key": "originImageName",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 677,
+          "key": "image",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+      "repository": "public.ecr.aws/docker/library/mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 183,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 568,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 636,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 368,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pterodactyl/index.yaml",
+          "line": 606,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "qinglong",
+      "image": "whyour/qinglong:latest",
+      "repository": "whyour/qinglong",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "qinglong",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/qinglong/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "whyour/qinglong:latest",
+          "repository": "whyour/qinglong",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "qinglong",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/qinglong/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "whyour/qinglong:latest",
+          "repository": "whyour/qinglong",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/quay/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "python:3.12.8-alpine3.20",
+      "repository": "python",
+      "current_tag": "3.12.8-alpine3.20",
+      "candidate_tag": "3.14.6-alpine3.24",
+      "candidate_image": "python:3.14.6-alpine3.24",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/quay/index.yaml",
+          "line": 541,
+          "key": "image",
+          "image": "python:3.12.8-alpine3.20",
+          "repository": "python",
+          "tag": "3.12.8-alpine3.20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "quay.io/projectquay/quay:v3.9.8",
+      "repository": "quay.io/projectquay/quay",
+      "current_tag": "v3.9.8",
+      "candidate_tag": "v3.17.3",
+      "candidate_image": "quay.io/projectquay/quay:v3.17.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/quay/index.yaml",
+          "line": 301,
+          "key": "originImageName",
+          "image": "quay.io/projectquay/quay:v3.9.8",
+          "repository": "quay.io/projectquay/quay",
+          "tag": "v3.9.8",
+          "digest": null
+        },
+        {
+          "template": "quay",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/quay/index.yaml",
+          "line": 332,
+          "key": "image",
+          "image": "quay.io/projectquay/quay:v3.9.8",
+          "repository": "quay.io/projectquay/quay",
+          "tag": "v3.9.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "redisinsight",
+      "image": "redislabs/redisinsight:2.52",
+      "repository": "redislabs/redisinsight",
+      "current_tag": "2.52",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "redisinsight",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/redisinsight/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "redislabs/redisinsight:2.52",
+          "repository": "redislabs/redisinsight",
+          "tag": "2.52",
+          "digest": null
+        },
+        {
+          "template": "redisinsight",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/redisinsight/index.yaml",
+          "line": 54,
+          "key": "image",
+          "image": "redislabs/redisinsight:2.52",
+          "repository": "redislabs/redisinsight",
+          "tag": "2.52",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "mautic/mautic:5.2.3-fpm",
+      "repository": "mautic/mautic",
+      "current_tag": "5.2.3-fpm",
+      "candidate_tag": "7.1.2-fpm",
+      "candidate_image": "mautic/mautic:7.1.2-fpm",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 409,
+          "key": "image",
+          "image": "mautic/mautic:5.2.3-fpm",
+          "repository": "mautic/mautic",
+          "tag": "5.2.3-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/elasticsearch:7.10.2",
+      "repository": "reflyai/elasticsearch",
+      "current_tag": "7.10.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 386,
+          "key": "originImageName",
+          "image": "reflyai/elasticsearch:7.10.2",
+          "repository": "reflyai/elasticsearch",
+          "tag": "7.10.2",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 417,
+          "key": "image",
+          "image": "reflyai/elasticsearch:7.10.2",
+          "repository": "reflyai/elasticsearch",
+          "tag": "7.10.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/qdrant:v1.13.1",
+      "repository": "reflyai/qdrant",
+      "current_tag": "v1.13.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 305,
+          "key": "originImageName",
+          "image": "reflyai/qdrant:v1.13.1",
+          "repository": "reflyai/qdrant",
+          "tag": "v1.13.1",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 328,
+          "key": "image",
+          "image": "reflyai/qdrant:v1.13.1",
+          "repository": "reflyai/qdrant",
+          "tag": "v1.13.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+      "repository": "reflyai/refly-api",
+      "current_tag": "8d870210470801f62a4d2adb3423c947afddf400",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 479,
+          "key": "originImageName",
+          "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-api",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 504,
+          "key": "image",
+          "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-api",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+      "repository": "reflyai/refly-web",
+      "current_tag": "8d870210470801f62a4d2adb3423c947afddf400",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 824,
+          "key": "originImageName",
+          "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-web",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 849,
+          "key": "image",
+          "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-web",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/refly/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "registry",
+      "image": "joxit/docker-registry-ui:2.5.6-debian",
+      "repository": "joxit/docker-registry-ui",
+      "current_tag": "2.5.6-debian",
+      "candidate_tag": "2.6.0-debian",
+      "candidate_image": "joxit/docker-registry-ui:2.6.0-debian",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "registry",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/registry/index.yaml",
+          "line": 206,
+          "key": "originImageName",
+          "image": "joxit/docker-registry-ui:2.5.6-debian",
+          "repository": "joxit/docker-registry-ui",
+          "tag": "2.5.6-debian",
+          "digest": null
+        },
+        {
+          "template": "registry",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/registry/index.yaml",
+          "line": 230,
+          "key": "image",
+          "image": "joxit/docker-registry-ui:2.5.6-debian",
+          "repository": "joxit/docker-registry-ui",
+          "tag": "2.5.6-debian",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "registry",
+      "image": "registry:2.8.3",
+      "repository": "registry",
+      "current_tag": "2.8.3",
+      "candidate_tag": "3.1.1",
+      "candidate_image": "registry:3.1.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "registry",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/registry/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "registry:2.8.3",
+          "repository": "registry",
+          "tag": "2.8.3",
+          "digest": null
+        },
+        {
+          "template": "registry",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/registry/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "registry:2.8.3",
+          "repository": "registry",
+          "tag": "2.8.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat",
+      "image": "mongo:6.0",
+      "repository": "mongo",
+      "current_tag": "6.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "mongo:6.0",
+          "repository": "mongo",
+          "tag": "6.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat",
+      "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+      "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "registry.rocket.chat/rocketchat/rocket.chat:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat/index.yaml",
+          "line": 183,
+          "key": "originImageName",
+          "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "mongo:6.0",
+      "repository": "mongo",
+      "current_tag": "6.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "mongo:6.0",
+          "repository": "mongo",
+          "tag": "6.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "nats:2.4-alpine",
+      "repository": "nats",
+      "current_tag": "2.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 332,
+          "key": "originImageName",
+          "image": "nats:2.4-alpine",
+          "repository": "nats",
+          "tag": "2.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 367,
+          "key": "image",
+          "image": "nats:2.4-alpine",
+          "repository": "nats",
+          "tag": "2.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "natsio/nats-server-config-reloader:0.6.3",
+      "repository": "natsio/nats-server-config-reloader",
+      "current_tag": "0.6.3",
+      "candidate_tag": "0.23.0",
+      "candidate_image": "natsio/nats-server-config-reloader:0.23.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 438,
+          "key": "image",
+          "image": "natsio/nats-server-config-reloader:0.6.3",
+          "repository": "natsio/nats-server-config-reloader",
+          "tag": "0.6.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/account-service:7.9.0",
+      "repository": "rocketchat/account-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "rocketchat/account-service:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 517,
+          "key": "originImageName",
+          "image": "rocketchat/account-service:7.9.0",
+          "repository": "rocketchat/account-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 542,
+          "key": "image",
+          "image": "rocketchat/account-service:7.9.0",
+          "repository": "rocketchat/account-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/authorization-service:7.9.0",
+      "repository": "rocketchat/authorization-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "rocketchat/authorization-service:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 606,
+          "key": "originImageName",
+          "image": "rocketchat/authorization-service:7.9.0",
+          "repository": "rocketchat/authorization-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 631,
+          "key": "image",
+          "image": "rocketchat/authorization-service:7.9.0",
+          "repository": "rocketchat/authorization-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/ddp-streamer-service:7.9.0",
+      "repository": "rocketchat/ddp-streamer-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "rocketchat/ddp-streamer-service:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 695,
+          "key": "originImageName",
+          "image": "rocketchat/ddp-streamer-service:7.9.0",
+          "repository": "rocketchat/ddp-streamer-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 720,
+          "key": "image",
+          "image": "rocketchat/ddp-streamer-service:7.9.0",
+          "repository": "rocketchat/ddp-streamer-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/presence-service:7.9.0",
+      "repository": "rocketchat/presence-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "rocketchat/presence-service:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 793,
+          "key": "originImageName",
+          "image": "rocketchat/presence-service:7.9.0",
+          "repository": "rocketchat/presence-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 818,
+          "key": "image",
+          "image": "rocketchat/presence-service:7.9.0",
+          "repository": "rocketchat/presence-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/rocket.chat:7.9.0",
+      "repository": "rocketchat/rocket.chat",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.5.1",
+      "candidate_image": "rocketchat/rocket.chat:8.5.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 224,
+          "key": "originImageName",
+          "image": "rocketchat/rocket.chat:7.9.0",
+          "repository": "rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 249,
+          "key": "image",
+          "image": "rocketchat/rocket.chat:7.9.0",
+          "repository": "rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/stream-hub-service:7.9.0",
+      "repository": "rocketchat/stream-hub-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "7.13.9",
+      "candidate_image": "rocketchat/stream-hub-service:7.13.9",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 882,
+          "key": "originImageName",
+          "image": "rocketchat/stream-hub-service:7.9.0",
+          "repository": "rocketchat/stream-hub-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rocketchat-micro/index.yaml",
+          "line": 907,
+          "key": "image",
+          "image": "rocketchat/stream-hub-service:7.9.0",
+          "repository": "rocketchat/stream-hub-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rsshub",
+      "image": "browserless/chrome:1.61.1-chrome-stable",
+      "repository": "browserless/chrome",
+      "current_tag": "1.61.1-chrome-stable",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rsshub/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "browserless/chrome:1.61.1-chrome-stable",
+          "repository": "browserless/chrome",
+          "tag": "1.61.1-chrome-stable",
+          "digest": null
+        },
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rsshub/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "browserless/chrome:1.61.1-chrome-stable",
+          "repository": "browserless/chrome",
+          "tag": "1.61.1-chrome-stable",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rsshub",
+      "image": "diygod/rsshub:2024-07-06",
+      "repository": "diygod/rsshub",
+      "current_tag": "2024-07-06",
+      "candidate_tag": "2026-06-24",
+      "candidate_image": "diygod/rsshub:2026-06-24",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rsshub/index.yaml",
+          "line": 46,
+          "key": "originImageName",
+          "image": "diygod/rsshub:2024-07-06",
+          "repository": "diygod/rsshub",
+          "tag": "2024-07-06",
+          "digest": null
+        },
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rsshub/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "diygod/rsshub:2024-07-06",
+          "repository": "diygod/rsshub",
+          "tag": "2024-07-06",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustdesk",
+      "image": "rustdesk/rustdesk-server-s6:1.1.15",
+      "repository": "rustdesk/rustdesk-server-s6",
+      "current_tag": "1.1.15",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "rustdesk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rustdesk/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "rustdesk/rustdesk-server-s6:1.1.15",
+          "repository": "rustdesk/rustdesk-server-s6",
+          "tag": "1.1.15",
+          "digest": null
+        },
+        {
+          "template": "rustdesk",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rustdesk/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "rustdesk/rustdesk-server-s6:1.1.15",
+          "repository": "rustdesk/rustdesk-server-s6",
+          "tag": "1.1.15",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustfs",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rustfs/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustfs",
+      "image": "rustfs/rustfs:latest",
+      "repository": "rustfs/rustfs",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rustfs/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "rustfs/rustfs:latest",
+          "repository": "rustfs/rustfs",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rustfs/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "rustfs/rustfs:latest",
+          "repository": "rustfs/rustfs",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "clickhouse/clickhouse-server:25.4.2",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.4.2",
+      "candidate_tag": "26.5.3",
+      "candidate_image": "clickhouse/clickhouse-server:26.5.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 258,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 419,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+      "repository": "ghcr.io/rybbit-io/rybbit-backend",
+      "current_tag": "sha-aa404ba",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 392,
+          "key": "originImageName",
+          "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-backend",
+          "tag": "sha-aa404ba",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 464,
+          "key": "image",
+          "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-backend",
+          "tag": "sha-aa404ba",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+      "repository": "ghcr.io/rybbit-io/rybbit-client",
+      "current_tag": "sha-aa404ba",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 605,
+          "key": "originImageName",
+          "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-client",
+          "tag": "sha-aa404ba",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 632,
+          "key": "image",
+          "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-client",
+          "tag": "sha-aa404ba",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/rybbit/index.yaml",
+          "line": 432,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/s-pdf/index.yaml",
+          "line": 251,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+      "repository": "ghcr.io/stirling-tools/stirling-pdf",
+      "current_tag": "1.2.0-fat",
+      "candidate_tag": "2.13.1-fat",
+      "candidate_image": "ghcr.io/stirling-tools/stirling-pdf:2.13.1-fat",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/s-pdf/index.yaml",
+          "line": 228,
+          "key": "originImageName",
+          "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "repository": "ghcr.io/stirling-tools/stirling-pdf",
+          "tag": "1.2.0-fat",
+          "digest": null
+        },
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/s-pdf/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "repository": "ghcr.io/stirling-tools/stirling-pdf",
+          "tag": "1.2.0-fat",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/s-pdf/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "samarium",
+      "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+      "repository": "ghcr.io/yangchuansheng/samarium",
+      "current_tag": "0.0.0-9514fcadb867",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/samarium/index.yaml",
+          "line": 142,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        },
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/samarium/index.yaml",
+          "line": 168,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        },
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/samarium/index.yaml",
+          "line": 332,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 447,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "busybox:1.28",
+      "repository": "busybox",
+      "current_tag": "1.28",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 566,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 683,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 740,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 840,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "clickhouse/clickhouse-server:25.5.6",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.5.6",
+      "candidate_tag": "26.5.3",
+      "candidate_image": "clickhouse/clickhouse-server:26.5.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 524,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 548,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 570,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/signoz-otel-collector:v0.144.2",
+      "repository": "signoz/signoz-otel-collector",
+      "current_tag": "v0.144.2",
+      "candidate_tag": "v0.144.5",
+      "candidate_image": "signoz/signoz-otel-collector:v0.144.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 687,
+          "key": "image",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 821,
+          "key": "originImageName",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 844,
+          "key": "image",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/signoz:v0.117.0",
+      "repository": "signoz/signoz",
+      "current_tag": "v0.117.0",
+      "candidate_tag": "v0.130.1",
+      "candidate_image": "signoz/signoz:v0.130.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 719,
+          "key": "originImageName",
+          "image": "signoz/signoz:v0.117.0",
+          "repository": "signoz/signoz",
+          "tag": "v0.117.0",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 744,
+          "key": "image",
+          "image": "signoz/signoz:v0.117.0",
+          "repository": "signoz/signoz",
+          "tag": "v0.117.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/zookeeper:3.7.1",
+      "repository": "signoz/zookeeper",
+      "current_tag": "3.7.1",
+      "candidate_tag": "3.9.3",
+      "candidate_image": "signoz/zookeeper:3.9.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 421,
+          "key": "originImageName",
+          "image": "signoz/zookeeper:3.7.1",
+          "repository": "signoz/zookeeper",
+          "tag": "3.7.1",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/signoz/index.yaml",
+          "line": 454,
+          "key": "image",
+          "image": "signoz/zookeeper:3.7.1",
+          "repository": "signoz/zookeeper",
+          "tag": "3.7.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sillytavern",
+      "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+      "repository": "ghcr.io/sillytavern/sillytavern",
+      "current_tag": "1.18.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sillytavern/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        },
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sillytavern/index.yaml",
+          "line": 80,
+          "key": "image",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        },
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sillytavern/index.yaml",
+          "line": 154,
+          "key": "image",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "skardi",
+      "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+      "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+      "current_tag": "0.3.0",
+      "candidate_tag": "0.4.0",
+      "candidate_image": "ghcr.io/skardilabs/skardi/skardi-server:0.4.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "skardi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/skardi/index.yaml",
+          "line": 123,
+          "key": "originImageName",
+          "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+          "tag": "0.3.0",
+          "digest": null
+        },
+        {
+          "template": "skardi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/skardi/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+          "tag": "0.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "stalwart",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/stalwart/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/stalwart/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "stalwart",
+      "image": "stalwartlabs/stalwart:v0.16.7",
+      "repository": "stalwartlabs/stalwart",
+      "current_tag": "v0.16.7",
+      "candidate_tag": "v0.16.10",
+      "candidate_image": "stalwartlabs/stalwart:v0.16.10",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/stalwart/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "stalwartlabs/stalwart:v0.16.7",
+          "repository": "stalwartlabs/stalwart",
+          "tag": "v0.16.7",
+          "digest": null
+        },
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/stalwart/index.yaml",
+          "line": 302,
+          "key": "image",
+          "image": "stalwartlabs/stalwart:v0.16.7",
+          "repository": "stalwartlabs/stalwart",
+          "tag": "v0.16.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "steel-browser",
+      "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+      "repository": "ghcr.io/steel-dev/steel-browser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "steel-browser",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/steel-browser/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+          "repository": "ghcr.io/steel-dev/steel-browser",
+          "tag": null,
+          "digest": "sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1"
+        },
+        {
+          "template": "steel-browser",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/steel-browser/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+          "repository": "ghcr.io/steel-dev/steel-browser",
+          "tag": null,
+          "digest": "sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1"
+        }
+      ]
+    },
+    {
+      "template": "strapi",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/strapi/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "strapi",
+      "image": "vshadbolt/strapi:5.33.0",
+      "repository": "vshadbolt/strapi",
+      "current_tag": "5.33.0",
+      "candidate_tag": "5.48.1",
+      "candidate_image": "vshadbolt/strapi:5.48.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/strapi/index.yaml",
+          "line": 611,
+          "key": "originImageName",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        },
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/strapi/index.yaml",
+          "line": 632,
+          "key": "image",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        },
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/strapi/index.yaml",
+          "line": 706,
+          "key": "image",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sub2api",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sub2api/index.yaml",
+          "line": 218,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sub2api",
+      "image": "weishaw/sub2api:0.1.104",
+      "repository": "weishaw/sub2api",
+      "current_tag": "0.1.104",
+      "candidate_tag": "0.1.138",
+      "candidate_image": "weishaw/sub2api:0.1.138",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sub2api/index.yaml",
+          "line": 368,
+          "key": "originImageName",
+          "image": "weishaw/sub2api:0.1.104",
+          "repository": "weishaw/sub2api",
+          "tag": "0.1.104",
+          "digest": null
+        },
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/sub2api/index.yaml",
+          "line": 397,
+          "key": "image",
+          "image": "weishaw/sub2api:0.1.104",
+          "repository": "weishaw/sub2api",
+          "tag": "0.1.104",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "darthsim/imgproxy:v3.30.1",
+      "repository": "darthsim/imgproxy",
+      "current_tag": "v3.30.1",
+      "candidate_tag": "v4.0.5",
+      "candidate_image": "darthsim/imgproxy:v4.0.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1353,
+          "key": "originImageName",
+          "image": "darthsim/imgproxy:v3.30.1",
+          "repository": "darthsim/imgproxy",
+          "tag": "v3.30.1",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1373,
+          "key": "image",
+          "image": "darthsim/imgproxy:v3.30.1",
+          "repository": "darthsim/imgproxy",
+          "tag": "v3.30.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "kong:2.8.1",
+      "repository": "kong",
+      "current_tag": "2.8.1",
+      "candidate_tag": "3.9.3",
+      "candidate_image": "kong:3.9.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 848,
+          "key": "originImageName",
+          "image": "kong:2.8.1",
+          "repository": "kong",
+          "tag": "2.8.1",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 868,
+          "key": "image",
+          "image": "kong:2.8.1",
+          "repository": "kong",
+          "tag": "2.8.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 272,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+      "repository": "postgrest/postgrest",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1061,
+          "key": "originImageName",
+          "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+          "repository": "postgrest/postgrest",
+          "tag": null,
+          "digest": "sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9"
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1081,
+          "key": "image",
+          "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+          "repository": "postgrest/postgrest",
+          "tag": null,
+          "digest": "sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9"
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/edge-runtime:v1.70.3",
+      "repository": "supabase/edge-runtime",
+      "current_tag": "v1.70.3",
+      "candidate_tag": "v1.74.2",
+      "candidate_image": "supabase/edge-runtime:v1.74.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1492,
+          "key": "originImageName",
+          "image": "supabase/edge-runtime:v1.70.3",
+          "repository": "supabase/edge-runtime",
+          "tag": "v1.70.3",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1512,
+          "key": "image",
+          "image": "supabase/edge-runtime:v1.70.3",
+          "repository": "supabase/edge-runtime",
+          "tag": "v1.70.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/gotrue:v2.186.0",
+      "repository": "supabase/gotrue",
+      "current_tag": "v2.186.0",
+      "candidate_tag": "v2.191.0",
+      "candidate_image": "supabase/gotrue:v2.191.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 934,
+          "key": "originImageName",
+          "image": "supabase/gotrue:v2.186.0",
+          "repository": "supabase/gotrue",
+          "tag": "v2.186.0",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 954,
+          "key": "image",
+          "image": "supabase/gotrue:v2.186.0",
+          "repository": "supabase/gotrue",
+          "tag": "v2.186.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/logflare:1.31.2",
+      "repository": "supabase/logflare",
+      "current_tag": "1.31.2",
+      "candidate_tag": "1.45.4",
+      "candidate_image": "supabase/logflare:1.45.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1594,
+          "key": "originImageName",
+          "image": "supabase/logflare:1.31.2",
+          "repository": "supabase/logflare",
+          "tag": "1.31.2",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1614,
+          "key": "image",
+          "image": "supabase/logflare:1.31.2",
+          "repository": "supabase/logflare",
+          "tag": "1.31.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/postgres-meta:v0.95.2",
+      "repository": "supabase/postgres-meta",
+      "current_tag": "v0.95.2",
+      "candidate_tag": "v0.96.6",
+      "candidate_image": "supabase/postgres-meta:v0.96.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1430,
+          "key": "originImageName",
+          "image": "supabase/postgres-meta:v0.95.2",
+          "repository": "supabase/postgres-meta",
+          "tag": "v0.95.2",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1450,
+          "key": "image",
+          "image": "supabase/postgres-meta:v0.95.2",
+          "repository": "supabase/postgres-meta",
+          "tag": "v0.95.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/realtime:v2.76.5",
+      "repository": "supabase/realtime",
+      "current_tag": "v2.76.5",
+      "candidate_tag": "v2.111.4",
+      "candidate_image": "supabase/realtime:v2.111.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1133,
+          "key": "originImageName",
+          "image": "supabase/realtime:v2.76.5",
+          "repository": "supabase/realtime",
+          "tag": "v2.76.5",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1153,
+          "key": "image",
+          "image": "supabase/realtime:v2.76.5",
+          "repository": "supabase/realtime",
+          "tag": "v2.76.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/storage-api:v1.37.8",
+      "repository": "supabase/storage-api",
+      "current_tag": "v1.37.8",
+      "candidate_tag": "v1.61.2",
+      "candidate_image": "supabase/storage-api:v1.61.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1234,
+          "key": "originImageName",
+          "image": "supabase/storage-api:v1.37.8",
+          "repository": "supabase/storage-api",
+          "tag": "v1.37.8",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1254,
+          "key": "image",
+          "image": "supabase/storage-api:v1.37.8",
+          "repository": "supabase/storage-api",
+          "tag": "v1.37.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/studio:2026.02.16-sha-26c615c",
+      "repository": "supabase/studio",
+      "current_tag": "2026.02.16-sha-26c615c",
+      "candidate_tag": "2026.06.22-sha-2207d7f",
+      "candidate_image": "supabase/studio:2026.06.22-sha-2207d7f",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 707,
+          "key": "originImageName",
+          "image": "supabase/studio:2026.02.16-sha-26c615c",
+          "repository": "supabase/studio",
+          "tag": "2026.02.16-sha-26c615c",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 727,
+          "key": "image",
+          "image": "supabase/studio:2026.02.16-sha-26c615c",
+          "repository": "supabase/studio",
+          "tag": "2026.02.16-sha-26c615c",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/supavisor:2.7.4",
+      "repository": "supabase/supavisor",
+      "current_tag": "2.7.4",
+      "candidate_tag": "2.9.7",
+      "candidate_image": "supabase/supavisor:2.9.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1766,
+          "key": "originImageName",
+          "image": "supabase/supavisor:2.7.4",
+          "repository": "supabase/supavisor",
+          "tag": "2.7.4",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1786,
+          "key": "image",
+          "image": "supabase/supavisor:2.7.4",
+          "repository": "supabase/supavisor",
+          "tag": "2.7.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "timberio/vector:0.53.0-alpine",
+      "repository": "timberio/vector",
+      "current_tag": "0.53.0-alpine",
+      "candidate_tag": "0.56.0-alpine",
+      "candidate_image": "timberio/vector:0.56.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1700,
+          "key": "originImageName",
+          "image": "timberio/vector:0.53.0-alpine",
+          "repository": "timberio/vector",
+          "tag": "0.53.0-alpine",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/supabase/index.yaml",
+          "line": 1720,
+          "key": "image",
+          "image": "timberio/vector:0.53.0-alpine",
+          "repository": "timberio/vector",
+          "tag": "0.53.0-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "surveyking",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/surveyking/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "surveyking",
+      "image": "surveyking/surveyking:v1.9.0",
+      "repository": "surveyking/surveyking",
+      "current_tag": "v1.9.0",
+      "candidate_tag": "v1.12.0",
+      "candidate_image": "surveyking/surveyking:v1.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/surveyking/index.yaml",
+          "line": 170,
+          "key": "originImageName",
+          "image": "surveyking/surveyking:v1.9.0",
+          "repository": "surveyking/surveyking",
+          "tag": "v1.9.0",
+          "digest": null
+        },
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/surveyking/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "surveyking/surveyking:v1.9.0",
+          "repository": "surveyking/surveyking",
+          "tag": "v1.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tailchat",
+      "image": "minio/minio",
+      "repository": "minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tailchat/index.yaml",
+          "line": 267,
+          "key": "originImageName",
+          "image": "minio/minio",
+          "repository": "minio/minio",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tailchat/index.yaml",
+          "line": 289,
+          "key": "image",
+          "image": "minio/minio",
+          "repository": "minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tailchat",
+      "image": "moonrailgun/tailchat:1.11.5",
+      "repository": "moonrailgun/tailchat",
+      "current_tag": "1.11.5",
+      "candidate_tag": "1.11.11",
+      "candidate_image": "moonrailgun/tailchat:1.11.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tailchat/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "moonrailgun/tailchat:1.11.5",
+          "repository": "moonrailgun/tailchat",
+          "tag": "1.11.5",
+          "digest": null
+        },
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tailchat/index.yaml",
+          "line": 86,
+          "key": "image",
+          "image": "moonrailgun/tailchat:1.11.5",
+          "repository": "moonrailgun/tailchat",
+          "tag": "1.11.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "teable",
+      "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+      "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "teable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/teable/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "teable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/teable/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "teable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/teable/index.yaml",
+          "line": 96,
+          "key": "image",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "teable",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "teable",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/teable/index.yaml",
+          "line": 348,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tentix",
+      "image": "limbo2342/tentix:dev-2025-10-23-x.3",
+      "repository": "limbo2342/tentix",
+      "current_tag": "dev-2025-10-23-x.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tentix",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tentix/index.yaml",
+          "line": 211,
+          "key": "image",
+          "image": "limbo2342/tentix:dev-2025-10-23-x.3",
+          "repository": "limbo2342/tentix",
+          "tag": "dev-2025-10-23-x.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tentix",
+      "image": "limbo2342/tentix:migrate.10.22.x1",
+      "repository": "limbo2342/tentix",
+      "current_tag": "migrate.10.22.x1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tentix",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tentix/index.yaml",
+          "line": 188,
+          "key": "image",
+          "image": "limbo2342/tentix:migrate.10.22.x1",
+          "repository": "limbo2342/tentix",
+          "tag": "migrate.10.22.x1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tianji",
+      "image": "moonrailgun/tianji:1.18.5",
+      "repository": "moonrailgun/tianji",
+      "current_tag": "1.18.5",
+      "candidate_tag": "1.32.7",
+      "candidate_image": "moonrailgun/tianji:1.32.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tianji/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "moonrailgun/tianji:1.18.5",
+          "repository": "moonrailgun/tianji",
+          "tag": "1.18.5",
+          "digest": null
+        },
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tianji/index.yaml",
+          "line": 74,
+          "key": "image",
+          "image": "moonrailgun/tianji:1.18.5",
+          "repository": "moonrailgun/tianji",
+          "tag": "1.18.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tianji",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tianji/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tolgee",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tolgee/index.yaml",
+          "line": 195,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tolgee",
+      "image": "tolgee/tolgee:v3.113.0",
+      "repository": "tolgee/tolgee",
+      "current_tag": "v3.113.0",
+      "candidate_tag": "v3.205.5",
+      "candidate_image": "tolgee/tolgee:v3.205.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tolgee/index.yaml",
+          "line": 219,
+          "key": "originImageName",
+          "image": "tolgee/tolgee:v3.113.0",
+          "repository": "tolgee/tolgee",
+          "tag": "v3.113.0",
+          "digest": null
+        },
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tolgee/index.yaml",
+          "line": 244,
+          "key": "image",
+          "image": "tolgee/tolgee:v3.113.0",
+          "repository": "tolgee/tolgee",
+          "tag": "v3.113.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 305,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 568,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "postgrest/postgrest:v12.0.2",
+      "repository": "postgrest/postgrest",
+      "current_tag": "v12.0.2",
+      "candidate_tag": "v13.0.8",
+      "candidate_image": "postgrest/postgrest:v13.0.8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 455,
+          "key": "originImageName",
+          "image": "postgrest/postgrest:v12.0.2",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.0.2",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 475,
+          "key": "image",
+          "image": "postgrest/postgrest:v12.0.2",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "tooljet/tooljet-ce:v3.20.170-lts",
+      "repository": "tooljet/tooljet-ce",
+      "current_tag": "v3.20.170-lts",
+      "candidate_tag": "v3.20.184-lts",
+      "candidate_image": "tooljet/tooljet-ce:v3.20.184-lts",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 548,
+          "key": "originImageName",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tooljet/index.yaml",
+          "line": 616,
+          "key": "image",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tududi",
+      "image": "chrisvel/tududi:1.1.0",
+      "repository": "chrisvel/tududi",
+      "current_tag": "1.1.0",
+      "candidate_tag": "1.1.1",
+      "candidate_image": "chrisvel/tududi:1.1.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tududi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tududi/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "chrisvel/tududi:1.1.0",
+          "repository": "chrisvel/tududi",
+          "tag": "1.1.0",
+          "digest": null
+        },
+        {
+          "template": "tududi",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/tududi/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "chrisvel/tududi:1.1.0",
+          "repository": "chrisvel/tududi",
+          "tag": "1.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "busybox:latest",
+      "repository": "busybox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 337,
+          "key": "image",
+          "image": "busybox:latest",
+          "repository": "busybox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "twentycrm/twenty:v1.12.0",
+      "repository": "twentycrm/twenty",
+      "current_tag": "v1.12.0",
+      "candidate_tag": "v2.15.0",
+      "candidate_image": "twentycrm/twenty:v2.15.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 316,
+          "key": "originImageName",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 349,
+          "key": "image",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 452,
+          "key": "originImageName",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/twenty/index.yaml",
+          "line": 472,
+          "key": "image",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "axllent/mailpit:v1.30.1",
+      "repository": "axllent/mailpit",
+      "current_tag": "v1.30.1",
+      "candidate_tag": "v1.30.2",
+      "candidate_image": "axllent/mailpit:v1.30.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 824,
+          "key": "originImageName",
+          "image": "axllent/mailpit:v1.30.1",
+          "repository": "axllent/mailpit",
+          "tag": "v1.30.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 846,
+          "key": "image",
+          "image": "axllent/mailpit:v1.30.1",
+          "repository": "axllent/mailpit",
+          "tag": "v1.30.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "baptistearno/typebot-builder:3.17.1",
+      "repository": "baptistearno/typebot-builder",
+      "current_tag": "3.17.1",
+      "candidate_tag": "3.17.2",
+      "candidate_image": "baptistearno/typebot-builder:3.17.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 431,
+          "key": "originImageName",
+          "image": "baptistearno/typebot-builder:3.17.1",
+          "repository": "baptistearno/typebot-builder",
+          "tag": "3.17.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 484,
+          "key": "image",
+          "image": "baptistearno/typebot-builder:3.17.1",
+          "repository": "baptistearno/typebot-builder",
+          "tag": "3.17.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "baptistearno/typebot-viewer:3.17.1",
+      "repository": "baptistearno/typebot-viewer",
+      "current_tag": "3.17.1",
+      "candidate_tag": "3.17.2",
+      "candidate_image": "baptistearno/typebot-viewer:3.17.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 656,
+          "key": "originImageName",
+          "image": "baptistearno/typebot-viewer:3.17.1",
+          "repository": "baptistearno/typebot-viewer",
+          "tag": "3.17.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 709,
+          "key": "image",
+          "image": "baptistearno/typebot-viewer:3.17.1",
+          "repository": "baptistearno/typebot-viewer",
+          "tag": "3.17.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 453,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typebot/index.yaml",
+          "line": 678,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typesense",
+      "image": "typesense/typesense:29.0",
+      "repository": "typesense/typesense",
+      "current_tag": "29.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typesense",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typesense/index.yaml",
+          "line": 41,
+          "key": "originImageName",
+          "image": "typesense/typesense:29.0",
+          "repository": "typesense/typesense",
+          "tag": "29.0",
+          "digest": null
+        },
+        {
+          "template": "typesense",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typesense/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "typesense/typesense:29.0",
+          "repository": "typesense/typesense",
+          "tag": "29.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typo3",
+      "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+      "repository": "martinhelmich/typo3",
+      "current_tag": "13.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typo3/index.yaml",
+          "line": 230,
+          "key": "originImageName",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        },
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typo3/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        },
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typo3/index.yaml",
+          "line": 398,
+          "key": "image",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        }
+      ]
+    },
+    {
+      "template": "typo3",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/typo3/index.yaml",
+          "line": 154,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ubuntu-sshd",
+      "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+      "repository": "takeyamajp/ubuntu-sshd",
+      "current_tag": "ubuntu22.04",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ubuntu-sshd",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ubuntu-sshd/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+          "repository": "takeyamajp/ubuntu-sshd",
+          "tag": "ubuntu22.04",
+          "digest": null
+        },
+        {
+          "template": "ubuntu-sshd",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/ubuntu-sshd/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+          "repository": "takeyamajp/ubuntu-sshd",
+          "tag": "ubuntu22.04",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "umami",
+      "image": "ghcr.io/umami-software/umami:3.0.2",
+      "repository": "ghcr.io/umami-software/umami",
+      "current_tag": "3.0.2",
+      "candidate_tag": "3.1.0",
+      "candidate_image": "ghcr.io/umami-software/umami:3.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "umami",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/umami/index.yaml",
+          "line": 58,
+          "key": "originImageName",
+          "image": "ghcr.io/umami-software/umami:3.0.2",
+          "repository": "ghcr.io/umami-software/umami",
+          "tag": "3.0.2",
+          "digest": null
+        },
+        {
+          "template": "umami",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/umami/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "ghcr.io/umami-software/umami:3.0.2",
+          "repository": "ghcr.io/umami-software/umami",
+          "tag": "3.0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "umami",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "umami",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/umami/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "uptime-kuma",
+      "image": "louislam/uptime-kuma:1.23.13",
+      "repository": "louislam/uptime-kuma",
+      "current_tag": "1.23.13",
+      "candidate_tag": "2.4.0",
+      "candidate_image": "louislam/uptime-kuma:2.4.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "uptime-kuma",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/uptime-kuma/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "louislam/uptime-kuma:1.23.13",
+          "repository": "louislam/uptime-kuma",
+          "tag": "1.23.13",
+          "digest": null
+        },
+        {
+          "template": "uptime-kuma",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/uptime-kuma/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "louislam/uptime-kuma:1.23.13",
+          "repository": "louislam/uptime-kuma",
+          "tag": "1.23.13",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "vaultwarden",
+      "image": "vaultwarden/server:latest",
+      "repository": "vaultwarden/server",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "vaultwarden",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/vaultwarden/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "vaultwarden/server:latest",
+          "repository": "vaultwarden/server",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "vaultwarden",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/vaultwarden/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "vaultwarden/server:latest",
+          "repository": "vaultwarden/server",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "waha",
+      "image": "devlikeapro/waha:chrome-2026.5.1",
+      "repository": "devlikeapro/waha",
+      "current_tag": "chrome-2026.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "waha",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/waha/index.yaml",
+          "line": 162,
+          "key": "originImageName",
+          "image": "devlikeapro/waha:chrome-2026.5.1",
+          "repository": "devlikeapro/waha",
+          "tag": "chrome-2026.5.1",
+          "digest": null
+        },
+        {
+          "template": "waha",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/waha/index.yaml",
+          "line": 230,
+          "key": "image",
+          "image": "devlikeapro/waha:chrome-2026.5.1",
+          "repository": "devlikeapro/waha",
+          "tag": "chrome-2026.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "waha",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "waha",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/waha/index.yaml",
+          "line": 186,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "webos",
+      "image": "fs185085781/webos:v1.4.1",
+      "repository": "fs185085781/webos",
+      "current_tag": "v1.4.1",
+      "candidate_tag": "v1.4.4",
+      "candidate_image": "fs185085781/webos:v1.4.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "webos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/webos/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "fs185085781/webos:v1.4.1",
+          "repository": "fs185085781/webos",
+          "tag": "v1.4.1",
+          "digest": null
+        },
+        {
+          "template": "webos",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/webos/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "fs185085781/webos:v1.4.1",
+          "repository": "fs185085781/webos",
+          "tag": "v1.4.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wechat",
+      "image": "ricwang/docker-wechat:4.0.0.30",
+      "repository": "ricwang/docker-wechat",
+      "current_tag": "4.0.0.30",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "wechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wechat/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "ricwang/docker-wechat:4.0.0.30",
+          "repository": "ricwang/docker-wechat",
+          "tag": "4.0.0.30",
+          "digest": null
+        },
+        {
+          "template": "wechat",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wechat/index.yaml",
+          "line": 70,
+          "key": "image",
+          "image": "ricwang/docker-wechat:4.0.0.30",
+          "repository": "ricwang/docker-wechat",
+          "tag": "4.0.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wechat2rss",
+      "image": "ttttmr/wechat2rss:latest",
+      "repository": "ttttmr/wechat2rss",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "wechat2rss",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wechat2rss/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "ttttmr/wechat2rss:latest",
+          "repository": "ttttmr/wechat2rss",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "wechat2rss",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wechat2rss/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "ttttmr/wechat2rss:latest",
+          "repository": "ttttmr/wechat2rss",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wewe-rss",
+      "image": "cooderl/wewe-rss:v2.6.1",
+      "repository": "cooderl/wewe-rss",
+      "current_tag": "v2.6.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wewe-rss/index.yaml",
+          "line": 174,
+          "key": "originImageName",
+          "image": "cooderl/wewe-rss:v2.6.1",
+          "repository": "cooderl/wewe-rss",
+          "tag": "v2.6.1",
+          "digest": null
+        },
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wewe-rss/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "cooderl/wewe-rss:v2.6.1",
+          "repository": "cooderl/wewe-rss",
+          "tag": "v2.6.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wewe-rss",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wewe-rss/index.yaml",
+          "line": 134,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/woocommerce/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "wordpress:6.9.1-php8.3-apache",
+      "repository": "wordpress",
+      "current_tag": "6.9.1-php8.3-apache",
+      "candidate_tag": "7.0.0-php8.5-apache",
+      "candidate_image": "wordpress:7.0.0-php8.5-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/woocommerce/index.yaml",
+          "line": 194,
+          "key": "originImageName",
+          "image": "wordpress:6.9.1-php8.3-apache",
+          "repository": "wordpress",
+          "tag": "6.9.1-php8.3-apache",
+          "digest": null
+        },
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/woocommerce/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "wordpress:6.9.1-php8.3-apache",
+          "repository": "wordpress",
+          "tag": "6.9.1-php8.3-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "wordpress:cli-2.9.0-php8.3",
+      "repository": "wordpress",
+      "current_tag": "cli-2.9.0-php8.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/woocommerce/index.yaml",
+          "line": 214,
+          "key": "image",
+          "image": "wordpress:cli-2.9.0-php8.3",
+          "repository": "wordpress",
+          "tag": "cli-2.9.0-php8.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wordpress",
+      "image": "wordpress:6.5.4",
+      "repository": "wordpress",
+      "current_tag": "6.5.4",
+      "candidate_tag": "7.0.0",
+      "candidate_image": "wordpress:7.0.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wordpress",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wordpress/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "wordpress:6.5.4",
+          "repository": "wordpress",
+          "tag": "6.5.4",
+          "digest": null
+        },
+        {
+          "template": "wordpress",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wordpress/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "wordpress:6.5.4",
+          "repository": "wordpress",
+          "tag": "6.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+      "repository": "ghcr.io/canner/wren-ai-service",
+      "current_tag": "0.15.17",
+      "candidate_tag": "0.29.3",
+      "candidate_image": "ghcr.io/canner/wren-ai-service:0.29.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 206,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "repository": "ghcr.io/canner/wren-ai-service",
+          "tag": "0.15.17",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 228,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "repository": "ghcr.io/canner/wren-ai-service",
+          "tag": "0.15.17",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-bootstrap:0.1.5",
+      "repository": "ghcr.io/canner/wren-bootstrap",
+      "current_tag": "0.1.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 313,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-bootstrap:0.1.5",
+          "repository": "ghcr.io/canner/wren-bootstrap",
+          "tag": "0.1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+      "repository": "ghcr.io/canner/wren-engine-ibis",
+      "current_tag": "0.14.3",
+      "candidate_tag": "0.25.0",
+      "candidate_image": "ghcr.io/canner/wren-engine-ibis:0.25.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 383,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine-ibis",
+          "tag": "0.14.3",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 405,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine-ibis",
+          "tag": "0.14.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-engine:0.14.3",
+      "repository": "ghcr.io/canner/wren-engine",
+      "current_tag": "0.14.3",
+      "candidate_tag": "0.24.6",
+      "candidate_image": "ghcr.io/canner/wren-engine:0.24.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 291,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-engine:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine",
+          "tag": "0.14.3",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 325,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-engine:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine",
+          "tag": "0.14.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-ui:0.20.1",
+      "repository": "ghcr.io/canner/wren-ui",
+      "current_tag": "0.20.1",
+      "candidate_tag": "0.32.2",
+      "candidate_image": "ghcr.io/canner/wren-ui:0.32.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 644,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-ui:0.20.1",
+          "repository": "ghcr.io/canner/wren-ui",
+          "tag": "0.20.1",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 666,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-ui:0.20.1",
+          "repository": "ghcr.io/canner/wren-ui",
+          "tag": "0.20.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "qdrant/qdrant:v1.13.4",
+      "repository": "qdrant/qdrant",
+      "current_tag": "v1.13.4",
+      "candidate_tag": "v1.18.2",
+      "candidate_image": "qdrant/qdrant:v1.18.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 466,
+          "key": "originImageName",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 488,
+          "key": "image",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 516,
+          "key": "image",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/wrenai/index.yaml",
+          "line": 864,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "yourls",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/yourls/index.yaml",
+          "line": 140,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "yourls",
+      "image": "yourls:1.10.1",
+      "repository": "yourls",
+      "current_tag": "1.10.1",
+      "candidate_tag": "1.10.4",
+      "candidate_image": "yourls:1.10.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/yourls/index.yaml",
+          "line": 178,
+          "key": "originImageName",
+          "image": "yourls:1.10.1",
+          "repository": "yourls",
+          "tag": "1.10.1",
+          "digest": null
+        },
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/yourls/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "yourls:1.10.1",
+          "repository": "yourls",
+          "tag": "1.10.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zitadel",
+      "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+      "repository": "ghcr.io/zitadel/zitadel",
+      "current_tag": "v4.10.1",
+      "candidate_tag": "v4.15.3",
+      "candidate_image": "ghcr.io/zitadel/zitadel:v4.15.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zitadel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zitadel/index.yaml",
+          "line": 135,
+          "key": "originImageName",
+          "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "repository": "ghcr.io/zitadel/zitadel",
+          "tag": "v4.10.1",
+          "digest": null
+        },
+        {
+          "template": "zitadel",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zitadel/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "repository": "ghcr.io/zitadel/zitadel",
+          "tag": "v4.10.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zot",
+      "image": "ghcr.io/project-zot/zot:v2.1.14",
+      "repository": "ghcr.io/project-zot/zot",
+      "current_tag": "v2.1.14",
+      "candidate_tag": "v2.1.17",
+      "candidate_image": "ghcr.io/project-zot/zot:v2.1.17",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zot/index.yaml",
+          "line": 144,
+          "key": "originImageName",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zot/index.yaml",
+          "line": 234,
+          "key": "image",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zot/index.yaml",
+          "line": 296,
+          "key": "originImageName",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zot/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zot",
+      "image": "httpd:2.4.63-alpine3.22",
+      "repository": "httpd",
+      "current_tag": "2.4.63-alpine3.22",
+      "candidate_tag": "2.4.68-alpine3.24",
+      "candidate_image": "httpd:2.4.68-alpine3.24",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zot",
+          "path": "/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/zot/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "httpd:2.4.63-alpine3.22",
+          "repository": "httpd",
+          "tag": "2.4.63-alpine3.22",
+          "digest": null
+        }
+      ]
+    }
+  ]
+}

--- a/.sealos/update-reports/template-version-updates.md
+++ b/.sealos/update-reports/template-version-updates.md
@@ -1,0 +1,2759 @@
+# Sealos Template Version Update Report
+
+Generated: 2026-06-24 12:58:32 UTC
+Repo: `/Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates`
+
+## Summary
+
+| Action | Count |
+|--------|-------|
+| update | 262 |
+| manual | 215 |
+| blocked | 19 |
+| skip | 60 |
+
+## Candidates
+
+| Template | Current image | Candidate | Action | Confidence | Reason | Evidence |
+|----------|---------------|-----------|--------|------------|--------|----------|
+| AllinSSL | `docker.io/allinssl/allinssl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| AllinSSL | `docker.io/allinssl/allinssl:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| OpenDeepWiki | `${{ inputs.wiki_image }}` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| OpenDeepWiki | `${{ inputs.wiki_web_image }}` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| Reactive-Resume | `amruthpillai/reactive-resume:v4.1.2` | `amruthpillai/reactive-resume:v5.1.9` | update | high | newer compatible semver tag found | crane ls |
+| Reactive-Resume | `bitnamilegacy/postgresql:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| Reactive-Resume | `ghcr.io/browserless/chromium:v2.11.0` | `ghcr.io/browserless/chromium:v2.54.1` | update | high | newer compatible semver tag found | crane ls |
+| Reactive-Resume | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| Reactive-Resume | `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z` |  | manual | low | unsupported tag family | tag parser |
+| Readeck | `codeberg.org/readeck/readeck:0.16.0` | `codeberg.org/readeck/readeck:0.22.3` | update | high | newer compatible semver tag found | crane ls |
+| Ruiqi-Waf | `limbo2342/ruiqi-waf:sha-32b359f` |  | manual | low | unsupported tag family | tag parser |
+| ace-step | `ghcr.io/ace-step/ace-step-1.5:v0.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| affine | `ghcr.io/toeverything/affine:0.26.6` | `ghcr.io/toeverything/affine:0.26.7` | update | high | newer compatible semver tag found | crane ls |
+| affine | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| agora | `agoracn/token:0.1.2023053011` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `airbyte/bootloader:0.63.11` | `airbyte/bootloader:2.1.0` | update | high | newer compatible semver tag found | crane ls |
+| airbyte | `airbyte/connector-builder-server:0.63.11` | `airbyte/connector-builder-server:2.0.1` | update | high | newer compatible semver tag found | crane ls |
+| airbyte | `airbyte/cron:0.63.11` | `airbyte/cron:2.1.0` | update | high | newer compatible semver tag found | crane ls |
+| airbyte | `airbyte/server:0.63.11` | `airbyte/server:2.1.0` | update | high | newer compatible semver tag found | crane ls |
+| airbyte | `airbyte/webapp:0.63.11` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| airbyte | `airbyte/worker:0.63.11` | `airbyte/worker:2.1.0` | update | high | newer compatible semver tag found | crane ls |
+| airbyte | `docker.io/apecloud/spilo:16.4.0` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `temporalio/auto-setup:1.23.0` | `temporalio/auto-setup:1.29.7` | update | high | newer compatible semver tag found | crane ls |
+| anki-sync-server | `ghcr.io/yangchuansheng/anki-sync-server:24.06.3` |  | manual | low | unsupported tag family | tag parser |
+| apitable | `apitable/backend-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600` |  | manual | low | digest-only image requires manual release check | image digest |
+| apitable | `apitable/imageproxy-server:v0.13.4-alpha_build13` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b` |  | manual | low | digest-only image requires manual release check | image digest |
+| apitable | `apitable/init-db:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/room-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/web-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| apitable | `mysql:8.0.32` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| apitable | `nginx:1.27.5-alpine` | `nginx:1.31.2-alpine` | update | high | newer compatible semver tag found | crane ls |
+| apitable | `rabbitmq:3.11.9-management` | `rabbitmq:4.3.2-management` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_cloud:0.15.22` | `appflowyinc/appflowy_cloud:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_web:0.14.9` | `appflowyinc/appflowy_web:0.15.4` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_worker:0.15.22` | `appflowyinc/appflowy_worker:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/gotrue:0.15.22` | `appflowyinc/gotrue:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| appsmith | `appsmith/appsmith-ce:v1.29` |  | manual | low | unsupported tag family | tag parser |
+| artalk | `artalk/artalk-go:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| asktable | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| asktable | `registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| asktable | `registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| authentik | `ghcr.io/goauthentik/server:2025.12.3` | `ghcr.io/goauthentik/server:2026.5.3` | update | high | newer compatible semver tag found | crane ls |
+| authentik | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| banana-slides | `anoinex/banana-slides-backend:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| banana-slides | `anoinex/banana-slides-frontend:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| billionmail | `alpine/openssl:3.5.4` | `alpine/openssl:3.5.7` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692` | `billionmail/core:4.9.5` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `python:3.12.12-alpine` | `python:3.14.6-alpine` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `roundcube/roundcubemail:1.6.11-fpm-alpine` | `roundcube/roundcubemail:1.7.1-fpm-alpine` | update | high | newer compatible semver tag found | crane ls |
+| blossom | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| blossom | `jasminexzzz/blossom:1.16.0` |  | skip | high | no newer compatible tag found | crane ls |
+| btpanel | `btpanel/baota:nas` |  | manual | low | unsupported tag family | tag parser |
+| budibase | `budibase/apps:3.15.0` | `budibase/apps:3.39.21` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `budibase/couchdb:v3.3.3-sqs-v2.1.1` |  | skip | high | no newer compatible tag found | crane ls |
+| budibase | `budibase/proxy:3.15.0` | `budibase/proxy:3.39.21` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `budibase/worker:3.15.0` | `budibase/worker:3.39.21` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb-scheduler:1.6.11` |  | skip | high | no newer compatible tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb-ui:1.6.11` |  | skip | high | no newer compatible tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb:1.6.11` |  | skip | high | no newer compatible tag found | crane ls |
+| bunkerweb | `docker.io/library/busybox:1.36.1` | `docker.io/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| bunkerweb | `docker.io/traefik/whoami:v1.11.0` |  | skip | high | no newer compatible tag found | crane ls |
+| bytebase | `bytebase/bytebase:3.6.1` | `bytebase/bytebase:3.19.1` | update | high | newer compatible semver tag found | crane ls |
+| calcom | `calcom.docker.scarf.sh/calcom/cal.com:v6.2.0` |  | skip | high | no newer compatible tag found | crane ls |
+| calcom | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| cap | `ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad` |  | manual | low | digest-only image requires manual release check | image digest |
+| cap | `ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57` |  | manual | low | digest-only image requires manual release check | image digest |
+| cap | `mysql:8.0.46-debian` |  | skip | high | no newer compatible tag found | crane ls |
+| casdoor | `casbin/casdoor:v1.702.0` | `casbin/casdoor:v2.190.0` | update | high | newer compatible semver tag found | crane ls |
+| casdoor | `casbin/casdoor:v2.32.0` | `casbin/casdoor:v2.190.0` | update | high | newer compatible semver tag found | crane ls |
+| casdoor | `mysql:8.0` |  | manual | low | unsupported tag family | tag parser |
+| casdoor | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| changedetection | `ghcr.io/dgtlmoon/changedetection.io:0.50.43` | `ghcr.io/dgtlmoon/changedetection.io:0.55.7` | update | high | newer compatible semver tag found | crane ls |
+| chatany | `licoy/chatany:v3.5.0` |  | skip | high | no newer compatible tag found | crane ls |
+| chatbot-ui | `ghcr.io/mckaywrigley/chatbot-ui:main` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| chatgpt-next-web | `yidadaa/chatgpt-next-web:v2.12.4` | `yidadaa/chatgpt-next-web:v2.16.1` | update | high | newer compatible semver tag found | crane ls |
+| chatgpt-on-wechat | `zhayujie/chatgpt-on-wechat:1.6.8` | `zhayujie/chatgpt-on-wechat:2.1.2` | update | high | newer compatible semver tag found | crane ls |
+| chatgpt-web | `chenzhaoyu94/chatgpt-web` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| chatnio | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| chatnio | `programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d` |  | manual | low | digest-only image requires manual release check | image digest |
+| chatwoot | `chatwoot/chatwoot:v4.7.0` | `chatwoot/chatwoot:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| chatwoot | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| chrome | `lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95` |  | manual | low | unsupported tag family | tag parser |
+| cloudreve | `arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| cloudreve | `cloudreve/cloudreve` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| cobalt | `ghcr.io/imputnet/cobalt:7.13.3` | `ghcr.io/imputnet/cobalt:11.7.1` | update | high | newer compatible semver tag found | crane ls |
+| code-server | `codercom/code-server:4.90.3-39` | `codercom/code-server:4.125.0-39` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `alpine/curl:8.12.1` | `alpine/curl:8.20.0` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3` |  | manual | low | digest-only image requires manual release check | image digest |
+| coze-studio | `bitnamilegacy/elasticsearch:8.18.0` | `bitnamilegacy/elasticsearch:9.1.2` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0` |  | manual | low | digest-only image requires manual release check | image digest |
+| coze-studio | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `cozedev/coze-studio-server:0.5.1` |  | skip | high | no newer compatible tag found | crane ls |
+| coze-studio | `cozedev/coze-studio-web:0.5.1` |  | skip | high | no newer compatible tag found | crane ls |
+| coze-studio | `milvusdb/milvus:v2.5.10` | `milvusdb/milvus:v2.6.18` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1` |  | manual | low | unsupported tag family | tag parser |
+| coze-studio | `mysql:8.0.36` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `nsqio/nsq:v1.2.1` | `nsqio/nsq:v1.3.0` | update | high | newer compatible semver tag found | crane ls |
+| crmeb | `ghcr.io/yangchuansheng/crmeb:v5.4.0` |  | skip | high | no newer compatible tag found | crane ls |
+| crmeb | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| crmeb | `nginx:alpine3.20` |  | manual | low | unsupported tag family | tag parser |
+| cronicle | `soulteary/cronicle:0.9.46` | `soulteary/cronicle:0.9.80` | update | high | newer compatible semver tag found | crane ls |
+| dataease | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| dataease | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| dataease | `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12` | `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25` | update | high | newer compatible semver tag found | crane ls |
+| dbgate | `dbgate/dbgate:5.3.1-alpine` | `dbgate/dbgate:7.2.1-alpine` | update | high | newer compatible semver tag found | crane ls |
+| deeplx | `ghcr.io/owo-network/deeplx:v0.9.5` | `ghcr.io/owo-network/deeplx:v1.2.2` | update | high | newer compatible semver tag found | crane ls |
+| derper | `bitnamilegacy/kubectl:1.28.9` | `bitnamilegacy/kubectl:1.33.4` | update | high | newer compatible semver tag found | crane ls |
+| derper | `ghcr.io/yangchuansheng/derper:v1.99.0-pre` | `ghcr.io/yangchuansheng/derper:v1.101.0-pre` | update | high | newer compatible semver tag found | crane ls |
+| dify | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-api:1.11.2` | `langgenius/dify-api:1.14.2` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-plugin-daemon:0.5.2-local` | `langgenius/dify-plugin-daemon:0.6.2-local` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-sandbox:0.2.12` | `langgenius/dify-sandbox:0.2.15` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-web:1.11.2` | `langgenius/dify-web:1.14.2` | update | high | newer compatible semver tag found | crane ls |
+| dify | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| dify | `semitechnologies/weaviate:1.27.0` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| directus | `directus/directus:11.17.4` | `directus/directus:12.0.2` | update | high | newer compatible semver tag found | crane ls |
+| directus | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| directus | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| directus | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| docker-stacks | `jupyter/scipy-notebook:2023-10-20` |  | skip | high | no newer compatible tag found | crane ls |
+| docuseal | `docuseal/docuseal:3.0.1` | `docuseal/docuseal:3.1.1` | update | high | newer compatible semver tag found | crane ls |
+| docuseal | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| dolibarr | `dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865` |  | skip | high | no newer compatible tag found | crane ls |
+| dolibarr | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| drawdb | `ghcr.io/drawdb-io/drawdb:v1.5.0` | `ghcr.io/drawdb-io/drawdb:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| drizzle-studio | `ghcr.io/drizzle-team/gateway:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| eaglercraft-server | `ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1` |  | skip | high | no newer compatible tag found | crane ls |
+| edgequake | `ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2` | `ghcr.io/raphaelmansuy/edgequake-frontend:0.12.11` | update | high | newer compatible semver tag found | crane ls |
+| edgequake | `ghcr.io/raphaelmansuy/edgequake:0.12.2` | `ghcr.io/raphaelmansuy/edgequake:0.12.11` | update | high | newer compatible semver tag found | crane ls |
+| edgequake | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| elasticsearch | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| elasticsearch | `docker.elastic.co/elasticsearch/elasticsearch:9.4.1` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| emqx | `emqx/emqx:5.8.9` | `emqx/emqx:6.2.1` | update | high | newer compatible semver tag found | crane ls |
+| enshrouded | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| enshrouded | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| enshrouded | `registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2` |  | manual | low | unsupported tag family | tag parser |
+| erpnext | `frappe/erpnext:v16.21.1` | `frappe/erpnext:v16.25.0` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `mariadb:11.4.7` | `mariadb:12.3.2` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| ever-gauzy | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| ever-gauzy | `ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4` |  | manual | low | digest-only image requires manual release check | image digest |
+| ever-gauzy | `ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493` |  | manual | low | digest-only image requires manual release check | image digest |
+| ever-gauzy | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| evolution-api | `evoapicloud/evolution-api:v2.3.7` |  | skip | high | no newer compatible tag found | crane ls |
+| evolution-api | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| evolution-api | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| evolution-api | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| excalidraw | `excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f` |  | manual | low | digest-only image requires manual release check | image digest |
+| fast-poster | `fastposter/fastposter:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| fastgpt | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.25` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.25` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.3` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-api-server:5.0.5` | `featbit/featbit-api-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-data-analytics-server:5.0.5` | `featbit/featbit-data-analytics-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-evaluation-server:5.0.5` | `featbit/featbit-evaluation-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-ui:5.0.5` | `featbit/featbit-ui:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| filecodebox | `lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2` |  | manual | low | digest-only image requires manual release check | image digest |
+| fireboom | `fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f` |  | manual | low | digest-only image requires manual release check | image digest |
+| firefox | `jlesage/firefox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| flarum | `crazymax/flarum:1.8.10` |  | skip | high | no newer compatible tag found | crane ls |
+| flarum | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| flowise | `flowiseai/flowise:3.0.5` | `flowiseai/flowise:3.1.2` | update | high | newer compatible semver tag found | crane ls |
+| flowise | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| formbricks | `ghcr.io/formbricks/formbricks:4.9.7` | `ghcr.io/formbricks/formbricks:5.1.4` | update | high | newer compatible semver tag found | crane ls |
+| formbricks | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| frp | `bitnamilegacy/kubectl:1.28.9` | `bitnamilegacy/kubectl:1.33.4` | update | high | newer compatible semver tag found | crane ls |
+| frp | `snowdreamtech/frps:0.59` |  | manual | low | unsupported tag family | tag parser |
+| full-stack-fastapi | `ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0` |  | skip | high | no newer compatible tag found | crane ls |
+| full-stack-fastapi | `ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0` |  | skip | high | no newer compatible tag found | crane ls |
+| full-stack-fastapi | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| ghost | `ghost:6.44.1-alpine` | `ghost:6.46.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| ghost | `public.ecr.aws/docker/library/mysql:8.0.30` | `public.ecr.aws/docker/library/mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| ghost | `public.ecr.aws/docker/library/node:22-alpine` |  | manual | low | unsupported tag family | tag parser |
+| gitea | `gitea/gitea:1.22.0-rootless` | `gitea/gitea:1.26.4-rootless` | update | high | newer compatible semver tag found | crane ls |
+| glance | `glanceapp/glance` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| glance | `glanceapp/glance:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| glitchtip | `glitchtip/glitchtip:v4.1.5` | `glitchtip/glitchtip:v6.0.3` | update | high | newer compatible semver tag found | crane ls |
+| glitchtip | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| gpt-academic | `ghcr.io/binary-husky/gpt_academic_nolocal:master` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| grafana-otel | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| grafana-otel | `grafana/grafana:12.3.0` | `grafana/grafana:13.1.0` | update | high | newer compatible semver tag found | crane ls |
+| grafana-otel | `otel/opentelemetry-collector:0.99.0` | `otel/opentelemetry-collector:0.154.0` | update | high | newer compatible semver tag found | crane ls |
+| grafana-otel | `prom/prometheus:v3.8.0` | `prom/prometheus:v3.12.0` | update | high | newer compatible semver tag found | crane ls |
+| halo | `halohub/halo:2.18.0` | `halohub/halo:2.25.4` | update | high | newer compatible semver tag found | crane ls |
+| halo | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| happy-server | `ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe` |  | manual | low | digest-only image requires manual release check | image digest |
+| happy-server | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| harbor | `goharbor/harbor-core:v2.14.4` | `goharbor/harbor-core:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-jobservice:v2.14.4` | `goharbor/harbor-jobservice:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-portal:v2.14.4` | `goharbor/harbor-portal:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-registryctl:v2.14.4` | `goharbor/harbor-registryctl:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/registry-photon:v2.14.4` | `goharbor/registry-photon:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/trivy-adapter-photon:v2.14.4` | `goharbor/trivy-adapter-photon:v2.15.1` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| hasura | `hasura/graphql-data-connector:v2.48.11` | `hasura/graphql-data-connector:v2.49.3` | update | high | newer compatible semver tag found | crane ls |
+| hasura | `hasura/graphql-engine:v2.48.11` | `hasura/graphql-engine:v2.49.3` | update | high | newer compatible semver tag found | crane ls |
+| headscale | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| headscale | `ghcr.io/tale/headplane:0.6.3` |  | skip | high | no newer compatible tag found | crane ls |
+| headscale | `headscale/headscale:0.29.0-beta.1-debug` |  | skip | high | no newer compatible tag found | crane ls |
+| headscale | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| heyform | `heyform/community-edition:v3.0.0-rc.7` |  | skip | high | no newer compatible tag found | crane ls |
+| illa-builder | `illasoft/illa-builder:v4.8.2` | `illasoft/illa-builder:v4.8.5` | update | high | newer compatible semver tag found | crane ls |
+| immich | `ghcr.io/immich-app/immich-machine-learning:v2.7.5` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| immich | `ghcr.io/immich-app/immich-server:v2.7.5` |  | skip | high | no newer compatible tag found | crane ls |
+| immich | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| influxdb | `docker.io/library/influxdb:2.9.1` |  | skip | high | no newer compatible tag found | crane ls |
+| inpaint-web | `yangchuansheng/inpaint-web` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| insforge | `apecloud/kubeblocks-tools:0.9.3` | `apecloud/kubeblocks-tools:1.0.2` | update | high | newer compatible semver tag found | crane ls |
+| insforge | `ghcr.io/insforge/deno-runtime:2.0.6` |  | skip | high | no newer compatible tag found | crane ls |
+| insforge | `ghcr.io/insforge/insforge-oss:v2.1.8` | `ghcr.io/insforge/insforge-oss:v2.2.2` | update | high | newer compatible semver tag found | crane ls |
+| insforge | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| insforge | `postgrest/postgrest:v12.2.12` | `postgrest/postgrest:v13.0.8` | update | high | newer compatible semver tag found | crane ls |
+| it-tools | `ghcr.io/corentinth/it-tools:2024.5.13-a0bc346` |  | skip | high | no newer compatible tag found | crane ls |
+| jsoncrack | `shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef` |  | manual | low | digest-only image requires manual release check | image digest |
+| kanboard | `kanboard/kanboard:v1.2.50` | `kanboard/kanboard:v1.2.52` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `ghcr.io/usekaneo/api:1.1.8` | `ghcr.io/usekaneo/api:2.7.7` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `ghcr.io/usekaneo/web:1.1.8` | `ghcr.io/usekaneo/web:2.7.7` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| keycloak | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| keycloak | `quay.io/keycloak/keycloak:26.3.2` | `quay.io/keycloak/keycloak:26.6.3` | update | high | newer compatible semver tag found | crane ls |
+| keystone | `node:22.22.1-alpine` | `node:26.3.1-alpine` | update | high | newer compatible semver tag found | crane ls |
+| keystone | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| kitten-tts | `ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2` |  | manual | low | unsupported tag family | tag parser |
+| kodcloud | `kodcloud/kodbox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| kuboard | `eipwork/kuboard:v3` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| kuvasz | `kuvaszmonitoring/kuvasz:3.11.0` | `kuvaszmonitoring/kuvasz:4.0.1` | update | high | newer compatible semver tag found | crane ls |
+| kuvasz | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/laf-server:sha-ef30cd9` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/laf-web:sha-e9d012d` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/runtime-node-init:sha-67b3cd6` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/runtime-node:sha-67b3cd6` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/library/nginx:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| laf | `quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z` |  | manual | low | unsupported tag family | tag parser |
+| laf | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| laf | `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z` |  | manual | low | unsupported tag family | tag parser |
+| laf | `quay.io/prometheus/prometheus:v2.45.0` | `quay.io/prometheus/prometheus:v3.12.0` | update | high | newer compatible semver tag found | crane ls |
+| langflow | `langflowai/langflow:1.9.5` | `langflowai/langflow:1.10.1` | update | high | newer compatible semver tag found | crane ls |
+| langflow | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `clickhouse/clickhouse-server:25.4.2` | `clickhouse/clickhouse-server:26.5.3` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `docker.io/langfuse/langfuse-worker:3.180.0` | `docker.io/langfuse/langfuse-worker:3.196.0` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `docker.io/langfuse/langfuse:3.180.0` | `docker.io/langfuse/langfuse:3.196.0` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `minio/minio:RELEASE.2025-09-07T16-13-09Z` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| librechat | `getmeili/meilisearch:v1.5` |  | manual | low | unsupported tag family | tag parser |
+| librechat | `ghcr.io/danny-avila/librechat:v0.7.3` | `ghcr.io/danny-avila/librechat:v0.8.6` | update | high | newer compatible semver tag found | crane ls |
+| liebianbao | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| liebianbao | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| liebianbao | `docker.io/labring4docker/php-custom:7.2-fpm` |  | manual | low | unsupported tag family | tag parser |
+| liebianbao | `labring4docker/php-custom:7.2-fpm` |  | manual | low | unsupported tag family | tag parser |
+| liebianbao | `nginx:1.25.2` | `nginx:1.31.2` | update | high | newer compatible semver tag found | crane ls |
+| listmonk | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| listmonk | `listmonk/listmonk:v6.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| listmonk | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| llama2-chinese | `luanshaotong/text-generation-webui-cpu:dev` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| llama3-8b-chinese | `registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m` |  | manual | low | unsupported tag family | tag parser |
+| llmgateway | `ghcr.io/theopenco/llmgateway-api:v1.3.0` | `ghcr.io/theopenco/llmgateway-api:v1.5.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-docs:v1.3.0` | `ghcr.io/theopenco/llmgateway-docs:v1.5.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-gateway:v1.3.0` | `ghcr.io/theopenco/llmgateway-gateway:v1.5.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-ui:v1.3.0` | `ghcr.io/theopenco/llmgateway-ui:v1.5.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-worker:v1.3.0` | `ghcr.io/theopenco/llmgateway-worker:v1.5.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| llmgateway | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| lobe-chat | `lobehub/lobe-chat:1.143.3` |  | skip | high | no newer compatible tag found | crane ls |
+| lobe-chat-db | `lobehub/lobe-chat-database:1.143.2` | `lobehub/lobe-chat-database:1.143.3` | update | high | newer compatible semver tag found | crane ls |
+| lobe-chat-db | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| logto | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| logto | `svhd/logto:1.40.1` |  | skip | high | no newer compatible tag found | crane ls |
+| loki | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| loki | `docker.io/grafana/loki:3.7.2` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| mage-ai | `mageai/mageai:0.9.79` |  | skip | high | no newer compatible tag found | crane ls |
+| mage-ai | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `ghcr.io/mastodon/mastodon-streaming:v4.5.11` | `ghcr.io/mastodon/mastodon-streaming:v4.6.0` | update | high | newer compatible semver tag found | crane ls |
+| mastodon | `ghcr.io/mastodon/mastodon:v4.5.11` | `ghcr.io/mastodon/mastodon:v4.6.0` | update | high | newer compatible semver tag found | crane ls |
+| mastodon | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `public.ecr.aws/docker/library/redis:7-alpine` |  | manual | low | unsupported tag family | tag parser |
+| matomo | `matomo:5.10.0-apache` | `matomo:5.11.2-apache` | update | high | newer compatible semver tag found | crane ls |
+| matomo | `mysql:8.0.44` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| matrixgorilla | `${{ defaults.app_name }}-api` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| matrixgorilla | `${{ defaults.app_name }}-web` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| matrixgorilla | `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| matrixgorilla | `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mautic | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| mautic | `mautic/mautic:7.1.2-apache` |  | skip | high | no newer compatible tag found | crane ls |
+| mautic | `mysql:8.4.2` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| mazanoke | `ghcr.io/civilblur/mazanoke:v1.1.6` |  | skip | high | no newer compatible tag found | crane ls |
+| meilisearch | `eyeix/meilisearch-ui:v0.15.1-lite` |  | skip | high | no newer compatible tag found | crane ls |
+| meilisearch | `getmeili/meilisearch:v1.45.1` | `getmeili/meilisearch:v1.48.1` | update | high | newer compatible semver tag found | crane ls |
+| memos | `ghcr.io/usememos/memos:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| metabase | `metabase/metabase:v0.61.3` | `metabase/metabase:v0.62.3` | update | high | newer compatible semver tag found | crane ls |
+| metabase | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| midjourney-ui | `erictik/midjourney-ui:1.1.47` |  | skip | high | no newer compatible tag found | crane ls |
+| mindoc | `registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1` |  | manual | low | unsupported tag family | tag parser |
+| mindoc | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| mindsdb | `mindsdb/mindsdb:v26.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| mindsdb | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| minecraft | `alpine:3.22.4` | `alpine:3.24.1` | update | high | newer compatible semver tag found | crane ls |
+| minecraft | `itzg/minecraft-server:2026.5.3-java25` | `itzg/minecraft-server:2026.6.1-java8` | update | high | newer compatible semver tag found | crane ls |
+| minio | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mlflow | `ghcr.io/mlflow/mlflow:v3.12.0` | `ghcr.io/mlflow/mlflow:v3.14.0` | update | high | newer compatible semver tag found | crane ls |
+| mlflow | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| moneyprinterturbo | `ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mongo-express | `mongo-express:1.0.2-20-alpine3.19` |  | skip | high | no newer compatible tag found | crane ls |
+| n8n | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| n8n | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| n8n | `n8nio/n8n:2.22.4` | `n8nio/n8n:2.28.1` | update | high | newer compatible semver tag found | crane ls |
+| n8n | `n8nio/runners:2.22.4` | `n8nio/runners:2.28.1` | update | high | newer compatible semver tag found | crane ls |
+| n8n | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| nacos | `mysql:8.0.44` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| nacos | `nacos/nacos-server:v3.2.2` |  | skip | high | no newer compatible tag found | crane ls |
+| nakama | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| nakama | `heroiclabs/nakama:3.39.0` |  | skip | high | no newer compatible tag found | crane ls |
+| nakama | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| netbird | `netbirdio/dashboard:v2.38.1` | `netbirdio/dashboard:v2.80.0` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/management:0.71.4` | `netbirdio/management:0.73.2` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/relay:0.71.4` | `netbirdio/relay:0.73.2` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/signal:0.71.4` | `netbirdio/signal:0.73.2` | update | high | newer compatible semver tag found | crane ls |
+| new-api | `calciumion/new-api:v0.13.2` |  | skip | high | no newer compatible tag found | crane ls |
+| new-api | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| nexus | `alpine:3.22.2` | `alpine:3.24.1` | update | high | newer compatible semver tag found | crane ls |
+| nexus | `sonatype/nexus3:3.92.3` | `sonatype/nexus3:3.93.1` | update | high | newer compatible semver tag found | crane ls |
+| nocodb | `nocodb/nocodb:2026.05.2` | `nocodb/nocodb:2026.06.1` | update | medium | newer compatible date tag found | crane ls |
+| node-red | `nodered/node-red:4.1.10` | `nodered/node-red:5.0.0` | update | high | newer compatible semver tag found | crane ls |
+| nofx | `alpine/openssl:3.5.4` | `alpine/openssl:3.5.7` | update | high | newer compatible semver tag found | crane ls |
+| nofx | `ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7` |  | manual | low | digest-only image requires manual release check | image digest |
+| nofx | `ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887` |  | manual | low | digest-only image requires manual release check | image digest |
+| nofx | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| notifuse | `notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb` |  | manual | low | unsupported tag family | tag parser |
+| notifuse | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| nsfw | `ethandai4869/nsfw-auth` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| one-api | `ghcr.io/songquanpeng/one-api:v0.6.10` |  | skip | high | no newer compatible tag found | crane ls |
+| open-design | `docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13` |  | manual | low | digest-only image requires manual release check | image digest |
+| open-design | `nginxinc/nginx-unprivileged:1.25-alpine-slim` |  | manual | low | unsupported tag family | tag parser |
+| open-webui | `ghcr.io/open-webui/open-webui:v0.5.4` | `ghcr.io/open-webui/open-webui:v0.9.6` | update | high | newer compatible semver tag found | crane ls |
+| openagents | `ghcr.io/openagents-org/openagents:sha-48764c0` |  | manual | low | unsupported tag family | tag parser |
+| openai-proxy | `unickcheng/openai-proxy` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| opencart | `ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94` |  | manual | low | unsupported tag family | tag parser |
+| openclaw | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| openclaw | `ghcr.io/openclaw/openclaw:2026.3.8` | `ghcr.io/openclaw/openclaw:2026.6.10` | update | high | newer compatible semver tag found | crane ls |
+| openlist | `openlistteam/openlist:v4.0.9-aria2` | `openlistteam/openlist:v4.2.2-aria2` | update | high | newer compatible semver tag found | crane ls |
+| openobserve | `public.ecr.aws/zinclabs/openobserve:v0.90.3` | `public.ecr.aws/zinclabs/openobserve:v0.91.0` | update | high | newer compatible semver tag found | crane ls |
+| outline | `outlinewiki/outline:1.8.0-1` | `outlinewiki/outline:1.8.2-0` | update | high | newer compatible semver tag found | crane ls |
+| outline | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| overleaf | `sharelatex/sharelatex:6.1.2` | `sharelatex/sharelatex:6.2.0` | update | high | newer compatible semver tag found | crane ls |
+| pageplug | `cloudtogouser/pageplug-ce:v1.9.35` | `cloudtogouser/pageplug-ce:v1.9.37` | update | high | newer compatible semver tag found | crane ls |
+| palacms | `ghcr.io/palacms/palacms:v3.0.0-beta.1` |  | blocked | low | 2026/06/24 20:57:57 No matching credentials were found for "ghcr.io"
+Error: reading tags for ghcr.io/palacms/palacms: GET https://ghcr.io/token?scope=repository%3Apalacms%2Fpalacms%3Apull&service=ghcr.io: DENIED: requested access to the resource is denied | crane ls |
+| palworld | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld | `hurlenko/filebrowser` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld | `thijsvanloef/palworld-server-docker` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-autobackup | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-export | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-export | `hurlenko/filebrowser` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-management | `registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18` |  | skip | high | no newer compatible tag found | crane ls |
+| pangolin | `docker.io/fosrl/pangolin:1.15.2` | `docker.io/fosrl/pangolin:1.19.2` | update | high | newer compatible semver tag found | crane ls |
+| paperclip | `ghcr.io/paperclipai/paperclip:sha-b8725c5` |  | manual | low | unsupported tag family | tag parser |
+| paperclip | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| paperclip | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| paperless-ngx | `ghcr.io/paperless-ngx/paperless-ngx:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| paperless-ngx | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| payload | `ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c` |  | skip | high | no newer compatible tag found | crane ls |
+| payload | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| pdf2zh | `byaidu/pdf2zh:1.9.6` | `byaidu/pdf2zh:1.9.11` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/backend:2.1.2` | `penpotapp/backend:2.16.1` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/exporter:2.1.2` | `penpotapp/exporter:2.16.1` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/frontend:2.1.2` | `penpotapp/frontend:2.16.1` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| perplexica | `itzcrazykns1337/perplexica:v1.10.2` | `itzcrazykns1337/perplexica:v1.12.0` | update | high | newer compatible semver tag found | crane ls |
+| perplexica | `searxng/searxng:2025.2.20-28d1240fc` |  | skip | high | no newer compatible tag found | crane ls |
+| pgadmin4 | `dpage/pgadmin4:8.9` |  | manual | low | unsupported tag family | tag parser |
+| photoprism | `photoprism/photoprism:240711` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| phpmyadmin | `phpmyadmin:5.2.1` | `phpmyadmin:5.2.3` | update | high | newer compatible semver tag found | crane ls |
+| plane | `makeplane/plane-admin:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-backend:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-frontend:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-space:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| planka | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| planka | `ghcr.io/plankanban/planka:2.1.1` |  | skip | high | no newer compatible tag found | crane ls |
+| planka | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| plausible | `clickhouse/clickhouse-server:23.3.7.5-alpine` |  | manual | low | unsupported tag family | tag parser |
+| plausible | `plausible/analytics:v2.0` |  | manual | low | unsupported tag family | tag parser |
+| pocket-id | `ghcr.io/pocket-id/pocket-id:v2.2.0` | `ghcr.io/pocket-id/pocket-id:v2.9.0` | update | high | newer compatible semver tag found | crane ls |
+| pocketbase | `adrianmusante/pocketbase:0.29.3` | `adrianmusante/pocketbase:0.39.4` | update | high | newer compatible semver tag found | crane ls |
+| pocketbase | `busybox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| posthog | `clickhouse/clickhouse-server:25.8.12.129` |  | manual | low | unsupported tag family | tag parser |
+| posthog | `docker.redpanda.com/redpandadata/redpanda:v25.1.9` | `docker.redpanda.com/redpandadata/redpanda:v26.1.10` | update | high | newer compatible semver tag found | crane ls |
+| posthog | `ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| posthog | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| posthog | `zookeeper:3.9.3` | `zookeeper:3.9.5` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `elasticsearch:7.17.27` | `elasticsearch:9.4.2` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `ghcr.io/gitroomhq/postiz-app:v2.21.8` | `ghcr.io/gitroomhq/postiz-app:v2.21.10` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| postiz | `temporalio/auto-setup:1.28.1` | `temporalio/auto-setup:1.29.7` | update | high | newer compatible semver tag found | crane ls |
+| presenton | `ghcr.io/presenton/presenton:v0.8.2-beta` | `ghcr.io/presenton/presenton:v0.8.9-beta` | update | high | newer compatible semver tag found | crane ls |
+| prestashop | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| prestashop | `prestashop/prestashop:9.1.3-apache` | `prestashop/prestashop:9.1.4-apache` | update | high | newer compatible semver tag found | crane ls |
+| privatebin | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| privatebin | `frooodle/privatebin:0.26.1-fat` |  | blocked | low | Error: reading tags for index.docker.io/frooodle/privatebin: GET https://index.docker.io/v2/frooodle/privatebin/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:frooodle/privatebin Type:repository]] | crane ls |
+| privatebin | `ghcr.io/privatebin/fs:1.7.4` | `ghcr.io/privatebin/fs:2.0.4` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `ghcr.io/pterodactyl/panel:v1.12.4` | `ghcr.io/pterodactyl/panel:v1.14.0` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `public.ecr.aws/docker/library/mysql:8.0.30` | `public.ecr.aws/docker/library/mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| qinglong | `whyour/qinglong:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| quay | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| quay | `python:3.12.8-alpine3.20` | `python:3.14.6-alpine3.24` | update | high | newer compatible semver tag found | crane ls |
+| quay | `quay.io/projectquay/quay:v3.9.8` | `quay.io/projectquay/quay:v3.17.3` | update | high | newer compatible semver tag found | crane ls |
+| redisinsight | `redislabs/redisinsight:2.52` |  | manual | low | unsupported tag family | tag parser |
+| refly | `mautic/mautic:5.2.3-fpm` | `mautic/mautic:7.1.2-fpm` | update | high | newer compatible semver tag found | crane ls |
+| refly | `reflyai/elasticsearch:7.10.2` |  | skip | high | no newer compatible tag found | crane ls |
+| refly | `reflyai/qdrant:v1.13.1` |  | skip | high | no newer compatible tag found | crane ls |
+| refly | `reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400` |  | manual | low | unsupported tag family | tag parser |
+| refly | `reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400` |  | manual | low | unsupported tag family | tag parser |
+| refly | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| registry | `joxit/docker-registry-ui:2.5.6-debian` | `joxit/docker-registry-ui:2.6.0-debian` | update | high | newer compatible semver tag found | crane ls |
+| registry | `registry:2.8.3` | `registry:3.1.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat | `mongo:6.0` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat | `registry.rocket.chat/rocketchat/rocket.chat:7.9.0` | `registry.rocket.chat/rocketchat/rocket.chat:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `mongo:6.0` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat-micro | `nats:2.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat-micro | `natsio/nats-server-config-reloader:0.6.3` | `natsio/nats-server-config-reloader:0.23.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/account-service:7.9.0` | `rocketchat/account-service:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/authorization-service:7.9.0` | `rocketchat/authorization-service:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/ddp-streamer-service:7.9.0` | `rocketchat/ddp-streamer-service:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/presence-service:7.9.0` | `rocketchat/presence-service:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/rocket.chat:7.9.0` | `rocketchat/rocket.chat:8.5.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/stream-hub-service:7.9.0` | `rocketchat/stream-hub-service:7.13.9` | update | high | newer compatible semver tag found | crane ls |
+| rsshub | `browserless/chrome:1.61.1-chrome-stable` |  | skip | high | no newer compatible tag found | crane ls |
+| rsshub | `diygod/rsshub:2024-07-06` | `diygod/rsshub:2026-06-24` | update | medium | newer compatible date tag found | crane ls |
+| rustdesk | `rustdesk/rustdesk-server-s6:1.1.15` |  | skip | high | no newer compatible tag found | crane ls |
+| rustfs | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| rustfs | `rustfs/rustfs:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| rybbit | `clickhouse/clickhouse-server:25.4.2` | `clickhouse/clickhouse-server:26.5.3` | update | high | newer compatible semver tag found | crane ls |
+| rybbit | `ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba` |  | manual | low | unsupported tag family | tag parser |
+| rybbit | `ghcr.io/rybbit-io/rybbit-client:sha-aa404ba` |  | manual | low | unsupported tag family | tag parser |
+| rybbit | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| s-pdf | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| s-pdf | `ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat` | `ghcr.io/stirling-tools/stirling-pdf:2.13.1-fat` | update | high | newer compatible semver tag found | crane ls |
+| s-pdf | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| samarium | `ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867` |  | skip | high | no newer compatible tag found | crane ls |
+| signoz | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| signoz | `busybox:1.28` |  | manual | low | unsupported tag family | tag parser |
+| signoz | `clickhouse/clickhouse-server:25.5.6` | `clickhouse/clickhouse-server:26.5.3` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/signoz-otel-collector:v0.144.2` | `signoz/signoz-otel-collector:v0.144.5` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/signoz:v0.117.0` | `signoz/signoz:v0.130.1` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/zookeeper:3.7.1` | `signoz/zookeeper:3.9.3` | update | high | newer compatible semver tag found | crane ls |
+| sillytavern | `ghcr.io/sillytavern/sillytavern:1.18.0` |  | skip | high | no newer compatible tag found | crane ls |
+| skardi | `ghcr.io/skardilabs/skardi/skardi-server:0.3.0` | `ghcr.io/skardilabs/skardi/skardi-server:0.4.0` | update | high | newer compatible semver tag found | crane ls |
+| stalwart | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| stalwart | `stalwartlabs/stalwart:v0.16.7` | `stalwartlabs/stalwart:v0.16.10` | update | high | newer compatible semver tag found | crane ls |
+| steel-browser | `ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1` |  | manual | low | digest-only image requires manual release check | image digest |
+| strapi | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| strapi | `vshadbolt/strapi:5.33.0` | `vshadbolt/strapi:5.48.1` | update | high | newer compatible semver tag found | crane ls |
+| sub2api | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| sub2api | `weishaw/sub2api:0.1.104` | `weishaw/sub2api:0.1.138` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `darthsim/imgproxy:v3.30.1` | `darthsim/imgproxy:v4.0.5` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `kong:2.8.1` | `kong:3.9.3` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| supabase | `postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9` |  | manual | low | digest-only image requires manual release check | image digest |
+| supabase | `supabase/edge-runtime:v1.70.3` | `supabase/edge-runtime:v1.74.2` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/gotrue:v2.186.0` | `supabase/gotrue:v2.191.0` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/logflare:1.31.2` | `supabase/logflare:1.45.4` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/postgres-meta:v0.95.2` | `supabase/postgres-meta:v0.96.6` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/realtime:v2.76.5` | `supabase/realtime:v2.111.4` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/storage-api:v1.37.8` | `supabase/storage-api:v1.61.2` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/studio:2026.02.16-sha-26c615c` | `supabase/studio:2026.06.22-sha-2207d7f` | update | medium | newer compatible date tag found | crane ls |
+| supabase | `supabase/supavisor:2.7.4` | `supabase/supavisor:2.9.7` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `timberio/vector:0.53.0-alpine` | `timberio/vector:0.56.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| surveyking | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| surveyking | `surveyking/surveyking:v1.9.0` | `surveyking/surveyking:v1.12.0` | update | high | newer compatible semver tag found | crane ls |
+| tailchat | `minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| tailchat | `moonrailgun/tailchat:1.11.5` | `moonrailgun/tailchat:1.11.11` | update | high | newer compatible semver tag found | crane ls |
+| teable | `registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| teable | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tentix | `limbo2342/tentix:dev-2025-10-23-x.3` |  | manual | low | unsupported tag family | tag parser |
+| tentix | `limbo2342/tentix:migrate.10.22.x1` |  | manual | low | unsupported tag family | tag parser |
+| tianji | `moonrailgun/tianji:1.18.5` | `moonrailgun/tianji:1.32.7` | update | high | newer compatible semver tag found | crane ls |
+| tianji | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tolgee | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tolgee | `tolgee/tolgee:v3.113.0` | `tolgee/tolgee:v3.205.5` | update | high | newer compatible semver tag found | crane ls |
+| tooljet | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| tooljet | `postgrest/postgrest:v12.0.2` | `postgrest/postgrest:v13.0.8` | update | high | newer compatible semver tag found | crane ls |
+| tooljet | `tooljet/tooljet-ce:v3.20.170-lts` | `tooljet/tooljet-ce:v3.20.184-lts` | update | high | newer compatible semver tag found | crane ls |
+| tududi | `chrisvel/tududi:1.1.0` | `chrisvel/tududi:1.1.1` | update | high | newer compatible semver tag found | crane ls |
+| twenty | `busybox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| twenty | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| twenty | `twentycrm/twenty:v1.12.0` | `twentycrm/twenty:v2.15.0` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `axllent/mailpit:v1.30.1` | `axllent/mailpit:v1.30.2` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `baptistearno/typebot-builder:3.17.1` | `baptistearno/typebot-builder:3.17.2` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `baptistearno/typebot-viewer:3.17.1` | `baptistearno/typebot-viewer:3.17.2` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| typebot | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| typesense | `typesense/typesense:29.0` |  | manual | low | unsupported tag family | tag parser |
+| typo3 | `martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25` |  | manual | low | unsupported tag family | tag parser |
+| typo3 | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| ubuntu-sshd | `takeyamajp/ubuntu-sshd:ubuntu22.04` |  | manual | low | unsupported tag family | tag parser |
+| umami | `ghcr.io/umami-software/umami:3.0.2` | `ghcr.io/umami-software/umami:3.1.0` | update | high | newer compatible semver tag found | crane ls |
+| umami | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| uptime-kuma | `louislam/uptime-kuma:1.23.13` | `louislam/uptime-kuma:2.4.0` | update | high | newer compatible semver tag found | crane ls |
+| vaultwarden | `vaultwarden/server:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| waha | `devlikeapro/waha:chrome-2026.5.1` |  | manual | low | unsupported tag family | tag parser |
+| waha | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| webos | `fs185085781/webos:v1.4.1` | `fs185085781/webos:v1.4.4` | update | high | newer compatible semver tag found | crane ls |
+| wechat | `ricwang/docker-wechat:4.0.0.30` |  | manual | low | unsupported tag family | tag parser |
+| wechat2rss | `ttttmr/wechat2rss:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| wewe-rss | `cooderl/wewe-rss:v2.6.1` |  | skip | high | no newer compatible tag found | crane ls |
+| wewe-rss | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `wordpress:6.9.1-php8.3-apache` | `wordpress:7.0.0-php8.5-apache` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `wordpress:cli-2.9.0-php8.3` |  | manual | low | unsupported tag family | tag parser |
+| wordpress | `wordpress:6.5.4` | `wordpress:7.0.0` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-ai-service:0.15.17` | `ghcr.io/canner/wren-ai-service:0.29.3` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-bootstrap:0.1.5` |  | skip | high | no newer compatible tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-engine-ibis:0.14.3` | `ghcr.io/canner/wren-engine-ibis:0.25.0` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-engine:0.14.3` | `ghcr.io/canner/wren-engine:0.24.6` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-ui:0.20.1` | `ghcr.io/canner/wren-ui:0.32.2` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `qdrant/qdrant:v1.13.4` | `qdrant/qdrant:v1.18.2` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| yourls | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| yourls | `yourls:1.10.1` | `yourls:1.10.4` | update | high | newer compatible semver tag found | crane ls |
+| zitadel | `ghcr.io/zitadel/zitadel:v4.10.1` | `ghcr.io/zitadel/zitadel:v4.15.3` | update | high | newer compatible semver tag found | crane ls |
+| zot | `ghcr.io/project-zot/zot:v2.1.14` | `ghcr.io/project-zot/zot:v2.1.17` | update | high | newer compatible semver tag found | crane ls |
+| zot | `httpd:2.4.63-alpine3.22` | `httpd:2.4.68-alpine3.24` | update | high | newer compatible semver tag found | crane ls |
+
+## Record Locations
+
+### AllinSSL: `docker.io/allinssl/allinssl`
+- `originImageName` at `template/AllinSSL/index.yaml:52`
+
+### AllinSSL: `docker.io/allinssl/allinssl:latest`
+- `image` at `template/AllinSSL/index.yaml:70`
+
+### OpenDeepWiki: `${{ inputs.wiki_image }}`
+- `originImageName` at `template/OpenDeepWiki/index.yaml:132`
+- `image` at `template/OpenDeepWiki/index.yaml:159`
+
+### OpenDeepWiki: `${{ inputs.wiki_web_image }}`
+- `originImageName` at `template/OpenDeepWiki/index.yaml:302`
+- `image` at `template/OpenDeepWiki/index.yaml:327`
+
+### Reactive-Resume: `amruthpillai/reactive-resume:v4.1.2`
+- `image` at `template/Reactive-Resume/index.yaml:351`
+
+### Reactive-Resume: `bitnamilegacy/postgresql:latest`
+- `image` at `template/Reactive-Resume/index.yaml:541`
+- `image` at `template/Reactive-Resume/index.yaml:563`
+
+### Reactive-Resume: `ghcr.io/browserless/chromium:v2.11.0`
+- `image` at `template/Reactive-Resume/index.yaml:290`
+
+### Reactive-Resume: `quay.io/minio/minio`
+- `originImageName` at `template/Reactive-Resume/index.yaml:165`
+
+### Reactive-Resume: `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z`
+- `image` at `template/Reactive-Resume/index.yaml:198`
+
+### Readeck: `codeberg.org/readeck/readeck:0.16.0`
+- `originImageName` at `template/Readeck/index.yaml:36`
+- `image` at `template/Readeck/index.yaml:64`
+
+### Ruiqi-Waf: `limbo2342/ruiqi-waf:sha-32b359f`
+- `image` at `template/Ruiqi-Waf/index.yaml:164`
+
+### ace-step: `ghcr.io/ace-step/ace-step-1.5:v0.1.0`
+- `originImageName` at `template/ace-step/index.yaml:91`
+- `image` at `template/ace-step/index.yaml:114`
+
+### affine: `ghcr.io/toeverything/affine:0.26.6`
+- `image` at `template/affine/index.yaml:358`
+- `originImageName` at `template/affine/index.yaml:420`
+- `image` at `template/affine/index.yaml:486`
+
+### affine: `postgres:16-alpine`
+- `image` at `template/affine/index.yaml:254`
+- `image` at `template/affine/index.yaml:318`
+- `image` at `template/affine/index.yaml:445`
+
+### agora: `agoracn/token:0.1.2023053011`
+- `originImageName` at `template/agora/index.yaml:49`
+- `image` at `template/agora/index.yaml:69`
+
+### airbyte: `airbyte/bootloader:0.63.11`
+- `image` at `template/airbyte/index.yaml:371`
+
+### airbyte: `airbyte/connector-builder-server:0.63.11`
+- `originImageName` at `template/airbyte/index.yaml:422`
+- `image` at `template/airbyte/index.yaml:443`
+
+### airbyte: `airbyte/cron:0.63.11`
+- `originImageName` at `template/airbyte/index.yaml:1126`
+- `image` at `template/airbyte/index.yaml:1147`
+
+### airbyte: `airbyte/server:0.63.11`
+- `originImageName` at `template/airbyte/index.yaml:521`
+- `image` at `template/airbyte/index.yaml:544`
+
+### airbyte: `airbyte/webapp:0.63.11`
+- `originImageName` at `template/airbyte/index.yaml:1359`
+- `image` at `template/airbyte/index.yaml:1380`
+
+### airbyte: `airbyte/worker:0.63.11`
+- `originImageName` at `template/airbyte/index.yaml:813`
+- `image` at `template/airbyte/index.yaml:834`
+
+### airbyte: `docker.io/apecloud/spilo:16.4.0`
+- `image` at `template/airbyte/index.yaml:328`
+
+### airbyte: `temporalio/auto-setup:1.23.0`
+- `originImageName` at `template/airbyte/index.yaml:1260`
+- `image` at `template/airbyte/index.yaml:1281`
+
+### anki-sync-server: `ghcr.io/yangchuansheng/anki-sync-server:24.06.3`
+- `originImageName` at `template/anki-sync-server/index.yaml:45`
+- `image` at `template/anki-sync-server/index.yaml:68`
+
+### apitable: `apitable/backend-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:965`
+- `image` at `template/apitable/index.yaml:1013`
+
+### apitable: `apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600`
+- `originImageName` at `template/apitable/index.yaml:1458`
+- `image` at `template/apitable/index.yaml:1503`
+
+### apitable: `apitable/imageproxy-server:v0.13.4-alpha_build13`
+- `originImageName` at `template/apitable/index.yaml:1587`
+- `image` at `template/apitable/index.yaml:1609`
+
+### apitable: `apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b`
+- `originImageName` at `template/apitable/index.yaml:865`
+- `image` at `template/apitable/index.yaml:923`
+
+### apitable: `apitable/init-db:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:761`
+- `image` at `template/apitable/index.yaml:819`
+
+### apitable: `apitable/room-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:1170`
+- `image` at `template/apitable/index.yaml:1218`
+
+### apitable: `apitable/web-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:1378`
+- `image` at `template/apitable/index.yaml:1400`
+
+### apitable: `busybox:1.36.1`
+- `image` at `template/apitable/index.yaml:988`
+- `image` at `template/apitable/index.yaml:1193`
+- `image` at `template/apitable/index.yaml:1480`
+
+### apitable: `mysql:8.0.32`
+- `originImageName` at `template/apitable/index.yaml:579`
+- `image` at `template/apitable/index.yaml:596`
+- `image` at `template/apitable/index.yaml:779`
+- `image` at `template/apitable/index.yaml:883`
+
+### apitable: `nginx:1.27.5-alpine`
+- `originImageName` at `template/apitable/index.yaml:1672`
+- `image` at `template/apitable/index.yaml:1694`
+
+### apitable: `rabbitmq:3.11.9-management`
+- `originImageName` at `template/apitable/index.yaml:649`
+- `image` at `template/apitable/index.yaml:674`
+
+### appflowy: `appflowyinc/appflowy_cloud:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:491`
+- `image` at `template/appflowy/index.yaml:511`
+
+### appflowy: `appflowyinc/appflowy_web:0.14.9`
+- `originImageName` at `template/appflowy/index.yaml:820`
+- `image` at `template/appflowy/index.yaml:840`
+
+### appflowy: `appflowyinc/appflowy_worker:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:692`
+- `image` at `template/appflowy/index.yaml:712`
+
+### appflowy: `appflowyinc/gotrue:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:356`
+- `image` at `template/appflowy/index.yaml:376`
+
+### appflowy: `postgres:16.4-alpine`
+- `image` at `template/appflowy/index.yaml:205`
+
+### appsmith: `appsmith/appsmith-ce:v1.29`
+- `originImageName` at `template/appsmith/index.yaml:36`
+- `image` at `template/appsmith/index.yaml:59`
+
+### artalk: `artalk/artalk-go:latest`
+- `originImageName` at `template/artalk/index.yaml:43`
+- `image` at `template/artalk/index.yaml:66`
+
+### asktable: `postgres:14-alpine`
+- `image` at `template/asktable/index.yaml:71`
+
+### asktable: `registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest`
+- `image` at `template/asktable/index.yaml:113`
+
+### asktable: `registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest`
+- `image` at `template/asktable/index.yaml:209`
+
+### authentik: `ghcr.io/goauthentik/server:2025.12.3`
+- `originImageName` at `template/authentik/index.yaml:175`
+- `image` at `template/authentik/index.yaml:195`
+- `originImageName` at `template/authentik/index.yaml:290`
+- `image` at `template/authentik/index.yaml:310`
+
+### authentik: `postgres:16.4-alpine`
+- `image` at `template/authentik/index.yaml:130`
+
+### banana-slides: `anoinex/banana-slides-backend:latest`
+- `originImageName` at `template/banana-slides/index.yaml:112`
+- `image` at `template/banana-slides/index.yaml:132`
+
+### banana-slides: `anoinex/banana-slides-frontend:latest`
+- `originImageName` at `template/banana-slides/index.yaml:212`
+- `image` at `template/banana-slides/index.yaml:231`
+
+### billionmail: `alpine/openssl:3.5.4`
+- `image` at `template/billionmail/index.yaml:6468`
+
+### billionmail: `alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8`
+- `image` at `template/billionmail/index.yaml:6692`
+- `image` at `template/billionmail/index.yaml:6723`
+- `image` at `template/billionmail/index.yaml:6755`
+
+### billionmail: `billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692`
+- `originImageName` at `template/billionmail/index.yaml:6434`
+- `image` at `template/billionmail/index.yaml:7033`
+
+### billionmail: `billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab`
+- `image` at `template/billionmail/index.yaml:6822`
+
+### billionmail: `billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342`
+- `image` at `template/billionmail/index.yaml:6901`
+
+### billionmail: `billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058`
+- `image` at `template/billionmail/index.yaml:6775`
+
+### billionmail: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/billionmail/index.yaml:153`
+- `image` at `template/billionmail/index.yaml:6509`
+
+### billionmail: `python:3.12.12-alpine`
+- `image` at `template/billionmail/index.yaml:6672`
+
+### billionmail: `roundcube/roundcubemail:1.6.11-fpm-alpine`
+- `image` at `template/billionmail/index.yaml:6974`
+
+### blossom: `docker.io/arey/mysql-client:latest`
+- `image` at `template/blossom/index.yaml:315`
+
+### blossom: `jasminexzzz/blossom:1.16.0`
+- `originImageName` at `template/blossom/index.yaml:46`
+- `image` at `template/blossom/index.yaml:69`
+
+### btpanel: `btpanel/baota:nas`
+- `originImageName` at `template/btpanel/index.yaml:38`
+- `image` at `template/btpanel/index.yaml:56`
+
+### budibase: `budibase/apps:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:429`
+- `image` at `template/budibase/index.yaml:449`
+
+### budibase: `budibase/couchdb:v3.3.3-sqs-v2.1.1`
+- `originImageName` at `template/budibase/index.yaml:254`
+- `image` at `template/budibase/index.yaml:290`
+
+### budibase: `budibase/proxy:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:821`
+- `image` at `template/budibase/index.yaml:841`
+
+### budibase: `budibase/worker:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:625`
+- `image` at `template/budibase/index.yaml:645`
+
+### budibase: `busybox:1.37.0`
+- `image` at `template/budibase/index.yaml:276`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb-scheduler:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:607`
+- `image` at `template/bunkerweb/index.yaml:680`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb-ui:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:855`
+- `image` at `template/bunkerweb/index.yaml:937`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:418`
+- `image` at `template/bunkerweb/index.yaml:511`
+
+### bunkerweb: `docker.io/library/busybox:1.36.1`
+- `image` at `template/bunkerweb/index.yaml:487`
+- `image` at `template/bunkerweb/index.yaml:633`
+- `image` at `template/bunkerweb/index.yaml:656`
+
+### bunkerweb: `docker.io/library/postgres:16.4-alpine`
+- `image` at `template/bunkerweb/index.yaml:174`
+- `image` at `template/bunkerweb/index.yaml:446`
+- `image` at `template/bunkerweb/index.yaml:881`
+
+### bunkerweb: `docker.io/traefik/whoami:v1.11.0`
+- `originImageName` at `template/bunkerweb/index.yaml:349`
+- `image` at `template/bunkerweb/index.yaml:369`
+
+### bytebase: `bytebase/bytebase:3.6.1`
+- `originImageName` at `template/bytebase/index.yaml:45`
+- `image` at `template/bytebase/index.yaml:68`
+
+### calcom: `calcom.docker.scarf.sh/calcom/cal.com:v6.2.0`
+- `originImageName` at `template/calcom/index.yaml:217`
+- `image` at `template/calcom/index.yaml:237`
+
+### calcom: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/calcom/index.yaml:173`
+
+### cap: `ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad`
+- `originImageName` at `template/cap/index.yaml:342`
+- `image` at `template/cap/index.yaml:362`
+
+### cap: `ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57`
+- `originImageName` at `template/cap/index.yaml:207`
+- `image` at `template/cap/index.yaml:227`
+
+### cap: `mysql:8.0.46-debian`
+- `image` at `template/cap/index.yaml:165`
+
+### casdoor: `casbin/casdoor:v1.702.0`
+- `image` at `template/casdoor/index.yaml:425`
+
+### casdoor: `casbin/casdoor:v2.32.0`
+- `originImageName` at `template/casdoor/index.yaml:334`
+- `image` at `template/casdoor/index.yaml:355`
+
+### casdoor: `mysql:8.0`
+- `image` at `template/casdoor/index.yaml:165`
+
+### casdoor: `postgres:14-alpine`
+- `image` at `template/casdoor/index.yaml:308`
+
+### changedetection: `ghcr.io/dgtlmoon/changedetection.io:0.50.43`
+- `originImageName` at `template/changedetection/index.yaml:43`
+- `image` at `template/changedetection/index.yaml:64`
+
+### chatany: `licoy/chatany:v3.5.0`
+- `originImageName` at `template/chatany/index.yaml:81`
+- `image` at `template/chatany/index.yaml:106`
+
+### chatbot-ui: `ghcr.io/mckaywrigley/chatbot-ui:main`
+- `originImageName` at `template/chatbot-ui/index.yaml:41`
+- `image` at `template/chatbot-ui/index.yaml:66`
+
+### chatgpt-next-web: `yidadaa/chatgpt-next-web:v2.12.4`
+- `originImageName` at `template/chatgpt-next-web/index.yaml:89`
+- `image` at `template/chatgpt-next-web/index.yaml:114`
+
+### chatgpt-on-wechat: `zhayujie/chatgpt-on-wechat:1.6.8`
+- `originImageName` at `template/chatgpt-on-wechat/index.yaml:78`
+- `image` at `template/chatgpt-on-wechat/index.yaml:98`
+
+### chatgpt-web: `chenzhaoyu94/chatgpt-web`
+- `originImageName` at `template/chatgpt-web/index.yaml:83`
+- `image` at `template/chatgpt-web/index.yaml:108`
+
+### chatnio: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/chatnio/index.yaml:290`
+
+### chatnio: `programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d`
+- `originImageName` at `template/chatnio/index.yaml:37`
+- `image` at `template/chatnio/index.yaml:60`
+
+### chatwoot: `chatwoot/chatwoot:v4.7.0`
+- `image` at `template/chatwoot/index.yaml:171`
+- `originImageName` at `template/chatwoot/index.yaml:383`
+- `image` at `template/chatwoot/index.yaml:404`
+- `originImageName` at `template/chatwoot/index.yaml:507`
+- `image` at `template/chatwoot/index.yaml:528`
+
+### chatwoot: `postgres:14-alpine`
+- `image` at `template/chatwoot/index.yaml:141`
+
+### chrome: `lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95`
+- `originImageName` at `template/chrome/index.yaml:75`
+- `image` at `template/chrome/index.yaml:104`
+
+### cloudreve: `arey/mysql-client:latest`
+- `image` at `template/cloudreve/index.yaml:77`
+
+### cloudreve: `cloudreve/cloudreve`
+- `originImageName` at `template/cloudreve/index.yaml:54`
+- `image` at `template/cloudreve/index.yaml:109`
+
+### cobalt: `ghcr.io/imputnet/cobalt:7.13.3`
+- `originImageName` at `template/cobalt/index.yaml:62`
+- `image` at `template/cobalt/index.yaml:83`
+
+### code-server: `codercom/code-server:4.90.3-39`
+- `originImageName` at `template/code-server/index.yaml:45`
+- `image` at `template/code-server/index.yaml:72`
+
+### coze-studio: `alpine/curl:8.12.1`
+- `image` at `template/coze-studio/index.yaml:1042`
+
+### coze-studio: `alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3`
+- `image` at `template/coze-studio/index.yaml:915`
+
+### coze-studio: `bitnamilegacy/elasticsearch:8.18.0`
+- `originImageName` at `template/coze-studio/index.yaml:633`
+- `image` at `template/coze-studio/index.yaml:666`
+
+### coze-studio: `bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0`
+- `originImageName` at `template/coze-studio/index.yaml:518`
+- `image` at `template/coze-studio/index.yaml:551`
+
+### coze-studio: `busybox:1.36.1`
+- `image` at `template/coze-studio/index.yaml:540`
+- `image` at `template/coze-studio/index.yaml:655`
+- `image` at `template/coze-studio/index.yaml:908`
+- `image` at `template/coze-studio/index.yaml:982`
+- `image` at `template/coze-studio/index.yaml:989`
+- `image` at `template/coze-studio/index.yaml:996`
+- `image` at `template/coze-studio/index.yaml:1148`
+
+### coze-studio: `cozedev/coze-studio-server:0.5.1`
+- `originImageName` at `template/coze-studio/index.yaml:888`
+- `image` at `template/coze-studio/index.yaml:1156`
+
+### coze-studio: `cozedev/coze-studio-web:0.5.1`
+- `originImageName` at `template/coze-studio/index.yaml:1361`
+- `image` at `template/coze-studio/index.yaml:1379`
+
+### coze-studio: `milvusdb/milvus:v2.5.10`
+- `originImageName` at `template/coze-studio/index.yaml:755`
+- `image` at `template/coze-studio/index.yaml:775`
+
+### coze-studio: `minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1`
+- `image` at `template/coze-studio/index.yaml:1003`
+
+### coze-studio: `mysql:8.0.36`
+- `image` at `template/coze-studio/index.yaml:937`
+
+### coze-studio: `nsqio/nsq:v1.2.1`
+- `originImageName` at `template/coze-studio/index.yaml:378`
+- `image` at `template/coze-studio/index.yaml:394`
+- `originImageName` at `template/coze-studio/index.yaml:447`
+- `image` at `template/coze-studio/index.yaml:463`
+
+### crmeb: `ghcr.io/yangchuansheng/crmeb:v5.4.0`
+- `originImageName` at `template/crmeb/index.yaml:350`
+- `image` at `template/crmeb/index.yaml:373`
+- `image` at `template/crmeb/index.yaml:404`
+
+### crmeb: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/crmeb/index.yaml:129`
+
+### crmeb: `nginx:alpine3.20`
+- `image` at `template/crmeb/index.yaml:381`
+
+### cronicle: `soulteary/cronicle:0.9.46`
+- `originImageName` at `template/cronicle/index.yaml:34`
+- `image` at `template/cronicle/index.yaml:62`
+
+### dataease: `busybox:1.36.1`
+- `image` at `template/dataease/index.yaml:63`
+
+### dataease: `docker.io/arey/mysql-client:latest`
+- `image` at `template/dataease/index.yaml:358`
+
+### dataease: `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12`
+- `originImageName` at `template/dataease/index.yaml:39`
+- `image` at `template/dataease/index.yaml:113`
+
+### dbgate: `dbgate/dbgate:5.3.1-alpine`
+- `originImageName` at `template/dbgate/index.yaml:50`
+- `image` at `template/dbgate/index.yaml:78`
+
+### deeplx: `ghcr.io/owo-network/deeplx:v0.9.5`
+- `originImageName` at `template/deeplx/index.yaml:40`
+- `image` at `template/deeplx/index.yaml:65`
+
+### derper: `bitnamilegacy/kubectl:1.28.9`
+- `image` at `template/derper/index.yaml:196`
+
+### derper: `ghcr.io/yangchuansheng/derper:v1.99.0-pre`
+- `originImageName` at `template/derper/index.yaml:110`
+- `image` at `template/derper/index.yaml:132`
+
+### dify: `busybox:1.37.0`
+- `image` at `template/dify/index.yaml:112`
+
+### dify: `langgenius/dify-api:1.11.2`
+- `originImageName` at `template/dify/index.yaml:54`
+- `image` at `template/dify/index.yaml:131`
+- `image` at `template/dify/index.yaml:273`
+
+### dify: `langgenius/dify-plugin-daemon:0.5.2-local`
+- `originImageName` at `template/dify/index.yaml:681`
+- `image` at `template/dify/index.yaml:740`
+
+### dify: `langgenius/dify-sandbox:0.2.12`
+- `originImageName` at `template/dify/index.yaml:601`
+- `image` at `template/dify/index.yaml:624`
+
+### dify: `langgenius/dify-web:1.11.2`
+- `originImageName` at `template/dify/index.yaml:414`
+- `image` at `template/dify/index.yaml:470`
+
+### dify: `postgres:14-alpine`
+- `image` at `template/dify/index.yaml:77`
+- `image` at `template/dify/index.yaml:434`
+- `image` at `template/dify/index.yaml:704`
+- `image` at `template/dify/index.yaml:965`
+
+### dify: `semitechnologies/weaviate:1.27.0`
+- `originImageName` at `template/dify/index.yaml:1120`
+- `image` at `template/dify/index.yaml:1141`
+
+### directus: `directus/directus:11.17.4`
+- `originImageName` at `template/directus/index.yaml:332`
+- `image` at `template/directus/index.yaml:449`
+
+### directus: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/directus/index.yaml:357`
+
+### directus: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/directus/index.yaml:165`
+- `image` at `template/directus/index.yaml:380`
+
+### directus: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/directus/index.yaml:421`
+
+### docker-stacks: `jupyter/scipy-notebook:2023-10-20`
+- `originImageName` at `template/docker-stacks/index.yaml:36`
+- `image` at `template/docker-stacks/index.yaml:57`
+
+### docuseal: `docuseal/docuseal:3.0.1`
+- `originImageName` at `template/docuseal/index.yaml:184`
+- `image` at `template/docuseal/index.yaml:207`
+
+### docuseal: `postgres:16-alpine`
+- `image` at `template/docuseal/index.yaml:139`
+
+### dolibarr: `dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865`
+- `originImageName` at `template/dolibarr/index.yaml:213`
+- `image` at `template/dolibarr/index.yaml:234`
+
+### dolibarr: `mysql:8.0.30`
+- `image` at `template/dolibarr/index.yaml:161`
+
+### drawdb: `ghcr.io/drawdb-io/drawdb:v1.5.0`
+- `originImageName` at `template/drawdb/index.yaml:60`
+- `image` at `template/drawdb/index.yaml:81`
+
+### drizzle-studio: `ghcr.io/drizzle-team/gateway:latest`
+- `originImageName` at `template/drizzle-studio/index.yaml:42`
+- `image` at `template/drizzle-studio/index.yaml:63`
+
+### eaglercraft-server: `ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1`
+- `originImageName` at `template/eaglercraft-server/index.yaml:40`
+- `image` at `template/eaglercraft-server/index.yaml:67`
+
+### edgequake: `ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2`
+- `originImageName` at `template/edgequake/index.yaml:380`
+- `image` at `template/edgequake/index.yaml:400`
+
+### edgequake: `ghcr.io/raphaelmansuy/edgequake:0.12.2`
+- `originImageName` at `template/edgequake/index.yaml:282`
+- `image` at `template/edgequake/index.yaml:302`
+
+### edgequake: `postgres:16-alpine`
+- `image` at `template/edgequake/index.yaml:163`
+
+### elasticsearch: `busybox:1.37.0`
+- `image` at `template/elasticsearch/index.yaml:63`
+
+### elasticsearch: `docker.elastic.co/elasticsearch/elasticsearch:9.4.1`
+- `originImageName` at `template/elasticsearch/index.yaml:37`
+- `image` at `template/elasticsearch/index.yaml:84`
+
+### emqx: `emqx/emqx:5.8.9`
+- `originImageName` at `template/emqx/index.yaml:57`
+- `image` at `template/emqx/index.yaml:91`
+
+### enshrouded: `alpine`
+- `image` at `template/enshrouded/index.yaml:90`
+
+### enshrouded: `bitnamilegacy/kubectl`
+- `image` at `template/enshrouded/index.yaml:102`
+- `image` at `template/enshrouded/index.yaml:211`
+
+### enshrouded: `registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2`
+- `originImageName` at `template/enshrouded/index.yaml:68`
+- `image` at `template/enshrouded/index.yaml:143`
+
+### erpnext: `frappe/erpnext:v16.21.1`
+- `image` at `template/erpnext/index.yaml:374`
+- `image` at `template/erpnext/index.yaml:530`
+- `originImageName` at `template/erpnext/index.yaml:666`
+- `image` at `template/erpnext/index.yaml:731`
+- `originImageName` at `template/erpnext/index.yaml:786`
+- `image` at `template/erpnext/index.yaml:882`
+- `originImageName` at `template/erpnext/index.yaml:962`
+- `image` at `template/erpnext/index.yaml:1027`
+- `originImageName` at `template/erpnext/index.yaml:1118`
+- `image` at `template/erpnext/index.yaml:1214`
+- `originImageName` at `template/erpnext/index.yaml:1275`
+- `image` at `template/erpnext/index.yaml:1371`
+- `originImageName` at `template/erpnext/index.yaml:1432`
+- `image` at `template/erpnext/index.yaml:1497`
+
+### erpnext: `mariadb:11.4.7`
+- `originImageName` at `template/erpnext/index.yaml:66`
+- `image` at `template/erpnext/index.yaml:89`
+
+### erpnext: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/erpnext/index.yaml:319`
+- `image` at `template/erpnext/index.yaml:475`
+- `image` at `template/erpnext/index.yaml:687`
+- `image` at `template/erpnext/index.yaml:710`
+- `image` at `template/erpnext/index.yaml:807`
+- `image` at `template/erpnext/index.yaml:861`
+- `image` at `template/erpnext/index.yaml:983`
+- `image` at `template/erpnext/index.yaml:1006`
+- `image` at `template/erpnext/index.yaml:1139`
+- `image` at `template/erpnext/index.yaml:1193`
+- `image` at `template/erpnext/index.yaml:1296`
+- `image` at `template/erpnext/index.yaml:1350`
+- `image` at `template/erpnext/index.yaml:1453`
+- `image` at `template/erpnext/index.yaml:1476`
+
+### erpnext: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/erpnext/index.yaml:342`
+- `image` at `template/erpnext/index.yaml:498`
+- `image` at `template/erpnext/index.yaml:830`
+- `image` at `template/erpnext/index.yaml:1162`
+- `image` at `template/erpnext/index.yaml:1319`
+
+### ever-gauzy: `busybox:1.36.1`
+- `image` at `template/ever-gauzy/index.yaml:208`
+
+### ever-gauzy: `ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4`
+- `originImageName` at `template/ever-gauzy/index.yaml:186`
+- `image` at `template/ever-gauzy/index.yaml:271`
+
+### ever-gauzy: `ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493`
+- `originImageName` at `template/ever-gauzy/index.yaml:516`
+- `image` at `template/ever-gauzy/index.yaml:537`
+
+### ever-gauzy: `postgres:16.4-alpine`
+- `image` at `template/ever-gauzy/index.yaml:149`
+- `image` at `template/ever-gauzy/index.yaml:228`
+
+### evolution-api: `evoapicloud/evolution-api:v2.3.7`
+- `originImageName` at `template/evolution-api/index.yaml:315`
+- `image` at `template/evolution-api/index.yaml:424`
+
+### evolution-api: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/evolution-api/index.yaml:340`
+
+### evolution-api: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/evolution-api/index.yaml:152`
+- `image` at `template/evolution-api/index.yaml:361`
+
+### evolution-api: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/evolution-api/index.yaml:393`
+
+### excalidraw: `excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f`
+- `originImageName` at `template/excalidraw/index.yaml:36`
+- `image` at `template/excalidraw/index.yaml:63`
+
+### fast-poster: `fastposter/fastposter:latest`
+- `originImageName` at `template/fast-poster/index.yaml:34`
+- `image` at `template/fast-poster/index.yaml:52`
+
+### fastgpt: `postgres:16-alpine`
+- `image` at `template/fastgpt/index.yaml:369`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:1013`
+- `image` at `template/fastgpt/index.yaml:1033`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:1126`
+- `image` at `template/fastgpt/index.yaml:1146`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt/index.yaml:852`
+- `image` at `template/fastgpt/index.yaml:872`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:562`
+- `image` at `template/fastgpt/index.yaml:582`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt/index.yaml:1238`
+- `image` at `template/fastgpt/index.yaml:1258`
+
+### fastgpt-milvus: `postgres:16-alpine`
+- `image` at `template/fastgpt-milvus/index.yaml:1176`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:678`
+- `image` at `template/fastgpt-milvus/index.yaml:704`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:774`
+- `image` at `template/fastgpt-milvus/index.yaml:800`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:417`
+- `image` at `template/fastgpt-milvus/index.yaml:443`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:136`
+- `image` at `template/fastgpt-milvus/index.yaml:156`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:580`
+- `image` at `template/fastgpt-milvus/index.yaml:606`
+
+### fastgpt-pro: `postgres:16-alpine`
+- `image` at `template/fastgpt-pro/index.yaml:370`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1161`
+- `image` at `template/fastgpt-pro/index.yaml:1181`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1274`
+- `image` at `template/fastgpt-pro/index.yaml:1294`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1000`
+- `image` at `template/fastgpt-pro/index.yaml:1020`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:855`
+- `image` at `template/fastgpt-pro/index.yaml:875`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:563`
+- `image` at `template/fastgpt-pro/index.yaml:583`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1386`
+- `image` at `template/fastgpt-pro/index.yaml:1406`
+
+### featbit-standard: `featbit/featbit-api-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1118`
+- `image` at `template/featbit-standard/index.yaml:1179`
+
+### featbit-standard: `featbit/featbit-data-analytics-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1247`
+- `image` at `template/featbit-standard/index.yaml:1308`
+
+### featbit-standard: `featbit/featbit-evaluation-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1370`
+- `image` at `template/featbit-standard/index.yaml:1431`
+
+### featbit-standard: `featbit/featbit-ui:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1497`
+- `image` at `template/featbit-standard/index.yaml:1519`
+
+### featbit-standard: `postgres:16-alpine`
+- `image` at `template/featbit-standard/index.yaml:240`
+- `image` at `template/featbit-standard/index.yaml:1140`
+- `image` at `template/featbit-standard/index.yaml:1269`
+- `image` at `template/featbit-standard/index.yaml:1392`
+
+### filecodebox: `lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2`
+- `originImageName` at `template/filecodebox/index.yaml:126`
+- `image` at `template/filecodebox/index.yaml:147`
+
+### fireboom: `fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f`
+- `originImageName` at `template/fireboom/index.yaml:38`
+- `image` at `template/fireboom/index.yaml:61`
+
+### firefox: `jlesage/firefox:latest`
+- `originImageName` at `template/firefox/index.yaml:37`
+- `image` at `template/firefox/index.yaml:60`
+
+### flarum: `crazymax/flarum:1.8.10`
+- `originImageName` at `template/flarum/index.yaml:129`
+- `image` at `template/flarum/index.yaml:202`
+
+### flarum: `mysql:8.0.30`
+- `image` at `template/flarum/index.yaml:155`
+
+### flowise: `flowiseai/flowise:3.0.5`
+- `originImageName` at `template/flowise/index.yaml:195`
+- `image` at `template/flowise/index.yaml:257`
+
+### flowise: `postgres:14-alpine`
+- `image` at `template/flowise/index.yaml:157`
+- `image` at `template/flowise/index.yaml:217`
+
+### formbricks: `ghcr.io/formbricks/formbricks:4.9.7`
+- `originImageName` at `template/formbricks/index.yaml:344`
+- `image` at `template/formbricks/index.yaml:370`
+- `image` at `template/formbricks/index.yaml:426`
+
+### formbricks: `postgres:16-alpine`
+- `image` at `template/formbricks/index.yaml:165`
+
+### frp: `bitnamilegacy/kubectl:1.28.9`
+- `image` at `template/frp/index.yaml:299`
+
+### frp: `snowdreamtech/frps:0.59`
+- `originImageName` at `template/frp/index.yaml:79`
+- `image` at `template/frp/index.yaml:104`
+
+### full-stack-fastapi: `ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0`
+- `image` at `template/full-stack-fastapi/index.yaml:232`
+- `originImageName` at `template/full-stack-fastapi/index.yaml:300`
+- `image` at `template/full-stack-fastapi/index.yaml:320`
+
+### full-stack-fastapi: `ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0`
+- `originImageName` at `template/full-stack-fastapi/index.yaml:429`
+- `image` at `template/full-stack-fastapi/index.yaml:449`
+
+### full-stack-fastapi: `postgres:14-alpine`
+- `image` at `template/full-stack-fastapi/index.yaml:183`
+
+### ghost: `ghost:6.44.1-alpine`
+- `originImageName` at `template/ghost/index.yaml:250`
+- `image` at `template/ghost/index.yaml:339`
+
+### ghost: `public.ecr.aws/docker/library/mysql:8.0.30`
+- `image` at `template/ghost/index.yaml:155`
+- `image` at `template/ghost/index.yaml:300`
+
+### ghost: `public.ecr.aws/docker/library/node:22-alpine`
+- `image` at `template/ghost/index.yaml:277`
+
+### gitea: `gitea/gitea:1.22.0-rootless`
+- `originImageName` at `template/gitea/index.yaml:36`
+- `image` at `template/gitea/index.yaml:63`
+
+### glance: `glanceapp/glance`
+- `originImageName` at `template/glance/index.yaml:146`
+
+### glance: `glanceapp/glance:latest`
+- `image` at `template/glance/index.yaml:164`
+
+### glitchtip: `glitchtip/glitchtip:v4.1.5`
+- `originImageName` at `template/glitchtip/index.yaml:61`
+- `image` at `template/glitchtip/index.yaml:86`
+- `image` at `template/glitchtip/index.yaml:175`
+- `image` at `template/glitchtip/index.yaml:265`
+
+### glitchtip: `senzing/postgresql-client:2.2.4`
+- `image` at `template/glitchtip/index.yaml:623`
+
+### gpt-academic: `ghcr.io/binary-husky/gpt_academic_nolocal:master`
+- `originImageName` at `template/gpt-academic/index.yaml:63`
+- `image` at `template/gpt-academic/index.yaml:88`
+
+### grafana-otel: `busybox`
+- `image` at `template/grafana-otel/index.yaml:242`
+- `image` at `template/grafana-otel/index.yaml:372`
+
+### grafana-otel: `grafana/grafana:12.3.0`
+- `originImageName` at `template/grafana-otel/index.yaml:351`
+- `image` at `template/grafana-otel/index.yaml:384`
+
+### grafana-otel: `otel/opentelemetry-collector:0.99.0`
+- `originImageName` at `template/grafana-otel/index.yaml:70`
+- `image` at `template/grafana-otel/index.yaml:91`
+
+### grafana-otel: `prom/prometheus:v3.8.0`
+- `originImageName` at `template/grafana-otel/index.yaml:221`
+- `image` at `template/grafana-otel/index.yaml:254`
+
+### halo: `halohub/halo:2.18.0`
+- `originImageName` at `template/halo/index.yaml:48`
+- `image` at `template/halo/index.yaml:71`
+
+### halo: `senzing/postgresql-client:2.2.4`
+- `image` at `template/halo/index.yaml:271`
+
+### happy-server: `ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe`
+- `originImageName` at `template/happy-server/index.yaml:704`
+- `image` at `template/happy-server/index.yaml:724`
+
+### happy-server: `postgres:16.4-alpine`
+- `image` at `template/happy-server/index.yaml:523`
+
+### harbor: `goharbor/harbor-core:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:606`
+- `image` at `template/harbor/index.yaml:628`
+
+### harbor: `goharbor/harbor-jobservice:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:739`
+- `image` at `template/harbor/index.yaml:762`
+
+### harbor: `goharbor/harbor-portal:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:840`
+- `image` at `template/harbor/index.yaml:862`
+
+### harbor: `goharbor/harbor-registryctl:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:1041`
+- `image` at `template/harbor/index.yaml:1063`
+
+### harbor: `goharbor/registry-photon:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:903`
+- `image` at `template/harbor/index.yaml:926`
+
+### harbor: `goharbor/trivy-adapter-photon:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:1121`
+- `image` at `template/harbor/index.yaml:1146`
+
+### harbor: `postgres:16.4`
+- `image` at `template/harbor/index.yaml:163`
+
+### hasura: `hasura/graphql-data-connector:v2.48.11`
+- `originImageName` at `template/hasura/index.yaml:215`
+- `image` at `template/hasura/index.yaml:235`
+
+### hasura: `hasura/graphql-engine:v2.48.11`
+- `originImageName` at `template/hasura/index.yaml:121`
+- `image` at `template/hasura/index.yaml:141`
+
+### headscale: `alpine`
+- `image` at `template/headscale/index.yaml:945`
+
+### headscale: `ghcr.io/tale/headplane:0.6.3`
+- `image` at `template/headscale/index.yaml:1042`
+
+### headscale: `headscale/headscale:0.29.0-beta.1-debug`
+- `originImageName` at `template/headscale/index.yaml:879`
+- `image` at `template/headscale/index.yaml:998`
+
+### headscale: `postgres:16-alpine`
+- `image` at `template/headscale/index.yaml:140`
+- `image` at `template/headscale/index.yaml:906`
+
+### heyform: `heyform/community-edition:v3.0.0-rc.7`
+- `originImageName` at `template/heyform/index.yaml:271`
+- `image` at `template/heyform/index.yaml:293`
+
+### illa-builder: `illasoft/illa-builder:v4.8.2`
+- `originImageName` at `template/illa-builder/index.yaml:38`
+- `image` at `template/illa-builder/index.yaml:61`
+
+### immich: `ghcr.io/immich-app/immich-machine-learning:v2.7.5`
+- `originImageName` at `template/immich/index.yaml:506`
+- `image` at `template/immich/index.yaml:529`
+
+### immich: `ghcr.io/immich-app/immich-server:v2.7.5`
+- `originImageName` at `template/immich/index.yaml:319`
+- `image` at `template/immich/index.yaml:388`
+
+### immich: `postgres:16-alpine`
+- `image` at `template/immich/index.yaml:255`
+- `image` at `template/immich/index.yaml:342`
+
+### influxdb: `docker.io/library/influxdb:2.9.1`
+- `originImageName` at `template/influxdb/index.yaml:47`
+- `image` at `template/influxdb/index.yaml:71`
+
+### inpaint-web: `yangchuansheng/inpaint-web`
+- `originImageName` at `template/inpaint-web/index.yaml:35`
+- `image` at `template/inpaint-web/index.yaml:60`
+
+### insforge: `apecloud/kubeblocks-tools:0.9.3`
+- `image` at `template/insforge/index.yaml:265`
+- `image` at `template/insforge/index.yaml:352`
+
+### insforge: `ghcr.io/insforge/deno-runtime:2.0.6`
+- `originImageName` at `template/insforge/index.yaml:767`
+- `image` at `template/insforge/index.yaml:787`
+
+### insforge: `ghcr.io/insforge/insforge-oss:v2.1.8`
+- `originImageName` at `template/insforge/index.yaml:420`
+- `image` at `template/insforge/index.yaml:500`
+
+### insforge: `postgres:16-alpine`
+- `image` at `template/insforge/index.yaml:441`
+
+### insforge: `postgrest/postgrest:v12.2.12`
+- `originImageName` at `template/insforge/index.yaml:675`
+- `image` at `template/insforge/index.yaml:695`
+
+### it-tools: `ghcr.io/corentinth/it-tools:2024.5.13-a0bc346`
+- `originImageName` at `template/it-tools/index.yaml:36`
+- `image` at `template/it-tools/index.yaml:61`
+
+### jsoncrack: `shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef`
+- `originImageName` at `template/jsoncrack/index.yaml:37`
+- `image` at `template/jsoncrack/index.yaml:65`
+
+### kanboard: `kanboard/kanboard:v1.2.50`
+- `originImageName` at `template/kanboard/index.yaml:121`
+- `image` at `template/kanboard/index.yaml:141`
+
+### kaneo: `ghcr.io/usekaneo/api:1.1.8`
+- `originImageName` at `template/kaneo/index.yaml:170`
+- `image` at `template/kaneo/index.yaml:190`
+
+### kaneo: `ghcr.io/usekaneo/web:1.1.8`
+- `originImageName` at `template/kaneo/index.yaml:234`
+- `image` at `template/kaneo/index.yaml:254`
+
+### kaneo: `postgres:14-alpine`
+- `image` at `template/kaneo/index.yaml:132`
+
+### keycloak: `postgres:14-alpine`
+- `image` at `template/keycloak/index.yaml:152`
+
+### keycloak: `quay.io/keycloak/keycloak:26.3.2`
+- `originImageName` at `template/keycloak/index.yaml:177`
+- `image` at `template/keycloak/index.yaml:198`
+
+### keystone: `node:22.22.1-alpine`
+- `originImageName` at `template/keystone/index.yaml:479`
+- `image` at `template/keystone/index.yaml:544`
+- `image` at `template/keystone/index.yaml:620`
+
+### keystone: `postgres:16.4-alpine`
+- `image` at `template/keystone/index.yaml:149`
+
+### kitten-tts: `ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2`
+- `originImageName` at `template/kitten-tts/index.yaml:44`
+- `image` at `template/kitten-tts/index.yaml:65`
+- `image` at `template/kitten-tts/index.yaml:76`
+
+### kodcloud: `kodcloud/kodbox:latest`
+- `originImageName` at `template/kodcloud/index.yaml:44`
+- `image` at `template/kodcloud/index.yaml:67`
+
+### kuboard: `eipwork/kuboard:v3`
+- `originImageName` at `template/kuboard/index.yaml:39`
+- `image` at `template/kuboard/index.yaml:62`
+
+### kuvasz: `kuvaszmonitoring/kuvasz:3.11.0`
+- `originImageName` at `template/kuvasz/index.yaml:201`
+- `image` at `template/kuvasz/index.yaml:277`
+
+### kuvasz: `postgres:16.4-alpine`
+- `image` at `template/kuvasz/index.yaml:143`
+- `image` at `template/kuvasz/index.yaml:231`
+
+### laf: `docker.io/lafyun/laf-server:sha-ef30cd9`
+- `image` at `template/laf/index.yaml:209`
+
+### laf: `docker.io/lafyun/laf-web:sha-e9d012d`
+- `image` at `template/laf/index.yaml:328`
+
+### laf: `docker.io/lafyun/runtime-node-init:sha-67b3cd6`
+- `image` at `template/laf/index.yaml:1418`
+
+### laf: `docker.io/lafyun/runtime-node:sha-67b3cd6`
+- `image` at `template/laf/index.yaml:1396`
+
+### laf: `docker.io/library/nginx:latest`
+- `image` at `template/laf/index.yaml:1441`
+
+### laf: `quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z`
+- `image` at `template/laf/index.yaml:1094`
+- `image` at `template/laf/index.yaml:1148`
+
+### laf: `quay.io/minio/minio`
+- `originImageName` at `template/laf/index.yaml:975`
+
+### laf: `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z`
+- `image` at `template/laf/index.yaml:1008`
+
+### laf: `quay.io/prometheus/prometheus:v2.45.0`
+- `image` at `template/laf/index.yaml:519`
+
+### langflow: `langflowai/langflow:1.9.5`
+- `originImageName` at `template/langflow/index.yaml:219`
+- `image` at `template/langflow/index.yaml:247`
+
+### langflow: `postgres:16-alpine`
+- `image` at `template/langflow/index.yaml:157`
+
+### langfuse: `clickhouse/clickhouse-server:25.4.2`
+- `originImageName` at `template/langfuse/index.yaml:385`
+- `image` at `template/langfuse/index.yaml:409`
+
+### langfuse: `docker.io/langfuse/langfuse-worker:3.180.0`
+- `originImageName` at `template/langfuse/index.yaml:528`
+- `image` at `template/langfuse/index.yaml:622`
+
+### langfuse: `docker.io/langfuse/langfuse:3.180.0`
+- `originImageName` at `template/langfuse/index.yaml:786`
+- `image` at `template/langfuse/index.yaml:839`
+
+### langfuse: `minio/minio:RELEASE.2025-09-07T16-13-09Z`
+- `originImageName` at `template/langfuse/index.yaml:1042`
+- `image` at `template/langfuse/index.yaml:1065`
+
+### langfuse: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/langfuse/index.yaml:184`
+- `image` at `template/langfuse/index.yaml:550`
+
+### langfuse: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/langfuse/index.yaml:591`
+- `image` at `template/langfuse/index.yaml:808`
+
+### librechat: `getmeili/meilisearch:v1.5`
+- `originImageName` at `template/librechat/index.yaml:260`
+- `image` at `template/librechat/index.yaml:283`
+
+### librechat: `ghcr.io/danny-avila/librechat:v0.7.3`
+- `originImageName` at `template/librechat/index.yaml:52`
+- `image` at `template/librechat/index.yaml:75`
+
+### liebianbao: `busybox:1.36.1`
+- `image` at `template/liebianbao/index.yaml:99`
+
+### liebianbao: `docker.io/arey/mysql-client:latest`
+- `image` at `template/liebianbao/index.yaml:712`
+
+### liebianbao: `docker.io/labring4docker/php-custom:7.2-fpm`
+- `image` at `template/liebianbao/index.yaml:135`
+
+### liebianbao: `labring4docker/php-custom:7.2-fpm`
+- `originImageName` at `template/liebianbao/index.yaml:78`
+
+### liebianbao: `nginx:1.25.2`
+- `image` at `template/liebianbao/index.yaml:253`
+
+### listmonk: `busybox:1.37.0`
+- `image` at `template/listmonk/index.yaml:252`
+
+### listmonk: `listmonk/listmonk:v6.1.0`
+- `originImageName` at `template/listmonk/index.yaml:224`
+- `image` at `template/listmonk/index.yaml:274`
+- `image` at `template/listmonk/index.yaml:343`
+
+### listmonk: `postgres:16.4-alpine`
+- `image` at `template/listmonk/index.yaml:151`
+
+### llama2-chinese: `luanshaotong/text-generation-webui-cpu:dev`
+- `originImageName` at `template/llama2-chinese/index.yaml:64`
+- `image` at `template/llama2-chinese/index.yaml:89`
+
+### llama3-8b-chinese: `registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m`
+- `originImageName` at `template/llama3-8b-chinese/index.yaml:35`
+- `image` at `template/llama3-8b-chinese/index.yaml:59`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-api:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:357`
+- `image` at `template/llmgateway/index.yaml:442`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-docs:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:1195`
+- `image` at `template/llmgateway/index.yaml:1217`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-gateway:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:590`
+- `image` at `template/llmgateway/index.yaml:716`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-ui:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:1066`
+- `image` at `template/llmgateway/index.yaml:1087`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-worker:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:874`
+- `image` at `template/llmgateway/index.yaml:1001`
+
+### llmgateway: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/llmgateway/index.yaml:157`
+- `image` at `template/llmgateway/index.yaml:378`
+- `image` at `template/llmgateway/index.yaml:611`
+- `image` at `template/llmgateway/index.yaml:652`
+- `image` at `template/llmgateway/index.yaml:896`
+- `image` at `template/llmgateway/index.yaml:937`
+
+### llmgateway: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/llmgateway/index.yaml:419`
+- `image` at `template/llmgateway/index.yaml:693`
+- `image` at `template/llmgateway/index.yaml:978`
+
+### lobe-chat: `lobehub/lobe-chat:1.143.3`
+- `originImageName` at `template/lobe-chat/index.yaml:61`
+- `image` at `template/lobe-chat/index.yaml:87`
+
+### lobe-chat-db: `lobehub/lobe-chat-database:1.143.2`
+- `originImageName` at `template/lobe-chat-db/index.yaml:212`
+- `image` at `template/lobe-chat-db/index.yaml:237`
+
+### lobe-chat-db: `postgres:14-alpine`
+- `image` at `template/lobe-chat-db/index.yaml:172`
+
+### logto: `postgres:16.4-alpine`
+- `image` at `template/logto/index.yaml:127`
+
+### logto: `svhd/logto:1.40.1`
+- `originImageName` at `template/logto/index.yaml:179`
+- `image` at `template/logto/index.yaml:204`
+- `image` at `template/logto/index.yaml:253`
+
+### loki: `busybox:1.37.0`
+- `image` at `template/loki/index.yaml:57`
+
+### loki: `docker.io/grafana/loki:3.7.2`
+- `originImageName` at `template/loki/index.yaml:36`
+- `image` at `template/loki/index.yaml:77`
+
+### mage-ai: `mageai/mageai:0.9.79`
+- `originImageName` at `template/mage-ai/index.yaml:211`
+- `image` at `template/mage-ai/index.yaml:233`
+- `image` at `template/mage-ai/index.yaml:283`
+
+### mage-ai: `postgres:16.4-alpine`
+- `image` at `template/mage-ai/index.yaml:150`
+
+### mastodon: `ghcr.io/mastodon/mastodon-streaming:v4.5.11`
+- `originImageName` at `template/mastodon/index.yaml:937`
+- `image` at `template/mastodon/index.yaml:1004`
+
+### mastodon: `ghcr.io/mastodon/mastodon:v4.5.11`
+- `image` at `template/mastodon/index.yaml:455`
+- `originImageName` at `template/mastodon/index.yaml:572`
+- `image` at `template/mastodon/index.yaml:639`
+- `originImageName` at `template/mastodon/index.yaml:753`
+- `image` at `template/mastodon/index.yaml:817`
+
+### mastodon: `postgres:16.4-alpine`
+- `image` at `template/mastodon/index.yaml:333`
+
+### mastodon: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/mastodon/index.yaml:598`
+- `image` at `template/mastodon/index.yaml:776`
+- `image` at `template/mastodon/index.yaml:963`
+
+### mastodon: `public.ecr.aws/docker/library/redis:7-alpine`
+- `image` at `template/mastodon/index.yaml:434`
+
+### matomo: `matomo:5.10.0-apache`
+- `originImageName` at `template/matomo/index.yaml:179`
+- `image` at `template/matomo/index.yaml:201`
+
+### matomo: `mysql:8.0.44`
+- `image` at `template/matomo/index.yaml:135`
+
+### matrixgorilla: `${{ defaults.app_name }}-api`
+- `originImageName` at `template/matrixgorilla/index.yaml:79`
+
+### matrixgorilla: `${{ defaults.app_name }}-web`
+- `originImageName` at `template/matrixgorilla/index.yaml:35`
+
+### matrixgorilla: `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest`
+- `image` at `template/matrixgorilla/index.yaml:101`
+
+### matrixgorilla: `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest`
+- `image` at `template/matrixgorilla/index.yaml:58`
+
+### mautic: `busybox:1.36.1`
+- `image` at `template/mautic/index.yaml:473`
+- `image` at `template/mautic/index.yaml:597`
+
+### mautic: `mautic/mautic:7.1.2-apache`
+- `originImageName` at `template/mautic/index.yaml:242`
+- `image` at `template/mautic/index.yaml:266`
+- `image` at `template/mautic/index.yaml:316`
+- `image` at `template/mautic/index.yaml:343`
+- `originImageName` at `template/mautic/index.yaml:440`
+- `image` at `template/mautic/index.yaml:492`
+- `originImageName` at `template/mautic/index.yaml:564`
+- `image` at `template/mautic/index.yaml:616`
+
+### mautic: `mysql:8.4.2`
+- `image` at `template/mautic/index.yaml:141`
+
+### mazanoke: `ghcr.io/civilblur/mazanoke:v1.1.6`
+- `originImageName` at `template/mazanoke/index.yaml:37`
+- `image` at `template/mazanoke/index.yaml:63`
+
+### meilisearch: `eyeix/meilisearch-ui:v0.15.1-lite`
+- `originImageName` at `template/meilisearch/index.yaml:133`
+- `image` at `template/meilisearch/index.yaml:153`
+
+### meilisearch: `getmeili/meilisearch:v1.45.1`
+- `originImageName` at `template/meilisearch/index.yaml:44`
+- `image` at `template/meilisearch/index.yaml:68`
+
+### memos: `ghcr.io/usememos/memos:latest`
+- `originImageName` at `template/memos/index.yaml:39`
+- `image` at `template/memos/index.yaml:62`
+
+### metabase: `metabase/metabase:v0.61.3`
+- `originImageName` at `template/metabase/index.yaml:171`
+- `image` at `template/metabase/index.yaml:194`
+
+### metabase: `postgres:16-alpine`
+- `image` at `template/metabase/index.yaml:128`
+
+### midjourney-ui: `erictik/midjourney-ui:1.1.47`
+- `originImageName` at `template/midjourney-ui/index.yaml:57`
+- `image` at `template/midjourney-ui/index.yaml:82`
+
+### mindoc: `registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1`
+- `originImageName` at `template/mindoc/index.yaml:274`
+- `image` at `template/mindoc/index.yaml:299`
+
+### mindoc: `senzing/postgresql-client:2.2.4`
+- `image` at `template/mindoc/index.yaml:133`
+
+### mindsdb: `mindsdb/mindsdb:v26.1.0`
+- `originImageName` at `template/mindsdb/index.yaml:253`
+- `image` at `template/mindsdb/index.yaml:323`
+- `image` at `template/mindsdb/index.yaml:365`
+
+### mindsdb: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/mindsdb/index.yaml:156`
+- `image` at `template/mindsdb/index.yaml:276`
+
+### minecraft: `alpine:3.22.4`
+- `image` at `template/minecraft/index.yaml:71`
+
+### minecraft: `itzg/minecraft-server:2026.5.3-java25`
+- `originImageName` at `template/minecraft/index.yaml:48`
+- `image` at `template/minecraft/index.yaml:91`
+
+### minio: `quay.io/minio/minio`
+- `originImageName` at `template/minio/index.yaml:57`
+- `image` at `template/minio/index.yaml:80`
+
+### mlflow: `ghcr.io/mlflow/mlflow:v3.12.0`
+- `originImageName` at `template/mlflow/index.yaml:201`
+- `image` at `template/mlflow/index.yaml:270`
+
+### mlflow: `senzing/postgresql-client:2.2.4`
+- `image` at `template/mlflow/index.yaml:151`
+- `image` at `template/mlflow/index.yaml:222`
+
+### moneyprinterturbo: `ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200`
+- `originImageName` at `template/moneyprinterturbo/index.yaml:37`
+- `image` at `template/moneyprinterturbo/index.yaml:60`
+
+### mongo-express: `mongo-express:1.0.2-20-alpine3.19`
+- `originImageName` at `template/mongo-express/index.yaml:127`
+- `image` at `template/mongo-express/index.yaml:147`
+
+### n8n: `alpine`
+- `image` at `template/n8n/index.yaml:362`
+
+### n8n: `busybox:1.36`
+- `image` at `template/n8n/index.yaml:605`
+
+### n8n: `n8nio/n8n:2.22.4`
+- `originImageName` at `template/n8n/index.yaml:337`
+- `image` at `template/n8n/index.yaml:370`
+- `originImageName` at `template/n8n/index.yaml:583`
+- `image` at `template/n8n/index.yaml:624`
+
+### n8n: `n8nio/runners:2.22.4`
+- `originImageName` at `template/n8n/index.yaml:522`
+- `image` at `template/n8n/index.yaml:544`
+- `originImageName` at `template/n8n/index.yaml:711`
+- `image` at `template/n8n/index.yaml:733`
+
+### n8n: `postgres:16-alpine`
+- `image` at `template/n8n/index.yaml:296`
+
+### nacos: `mysql:8.0.44`
+- `image` at `template/nacos/index.yaml:347`
+
+### nacos: `nacos/nacos-server:v3.2.2`
+- `originImageName` at `template/nacos/index.yaml:410`
+- `image` at `template/nacos/index.yaml:432`
+- `originImageName` at `template/nacos/index.yaml:545`
+- `image` at `template/nacos/index.yaml:567`
+
+### nakama: `busybox:1.36`
+- `image` at `template/nakama/index.yaml:261`
+
+### nakama: `heroiclabs/nakama:3.39.0`
+- `originImageName` at `template/nakama/index.yaml:237`
+- `image` at `template/nakama/index.yaml:327`
+- `image` at `template/nakama/index.yaml:370`
+
+### nakama: `postgres:16-alpine`
+- `image` at `template/nakama/index.yaml:187`
+- `image` at `template/nakama/index.yaml:278`
+
+### netbird: `netbirdio/dashboard:v2.38.1`
+- `originImageName` at `template/netbird/index.yaml:150`
+- `image` at `template/netbird/index.yaml:170`
+
+### netbird: `netbirdio/management:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:217`
+- `image` at `template/netbird/index.yaml:238`
+
+### netbird: `netbirdio/relay:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:356`
+- `image` at `template/netbird/index.yaml:376`
+
+### netbird: `netbirdio/signal:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:295`
+- `image` at `template/netbird/index.yaml:316`
+
+### new-api: `calciumion/new-api:v0.13.2`
+- `originImageName` at `template/new-api/index.yaml:304`
+- `image` at `template/new-api/index.yaml:326`
+
+### new-api: `postgres:16.4`
+- `image` at `template/new-api/index.yaml:252`
+
+### nexus: `alpine:3.22.2`
+- `image` at `template/nexus/index.yaml:61`
+
+### nexus: `sonatype/nexus3:3.92.3`
+- `originImageName` at `template/nexus/index.yaml:37`
+- `image` at `template/nexus/index.yaml:79`
+
+### nocodb: `nocodb/nocodb:2026.05.2`
+- `originImageName` at `template/nocodb/index.yaml:132`
+- `image` at `template/nocodb/index.yaml:156`
+
+### node-red: `nodered/node-red:4.1.10`
+- `originImageName` at `template/node-red/index.yaml:36`
+- `image` at `template/node-red/index.yaml:61`
+
+### nofx: `alpine/openssl:3.5.4`
+- `image` at `template/nofx/index.yaml:210`
+
+### nofx: `ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7`
+- `originImageName` at `template/nofx/index.yaml:189`
+- `image` at `template/nofx/index.yaml:273`
+
+### nofx: `ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887`
+- `originImageName` at `template/nofx/index.yaml:427`
+- `image` at `template/nofx/index.yaml:448`
+
+### nofx: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/nofx/index.yaml:136`
+- `image` at `template/nofx/index.yaml:231`
+
+### notifuse: `notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb`
+- `originImageName` at `template/notifuse/index.yaml:175`
+- `image` at `template/notifuse/index.yaml:250`
+
+### notifuse: `postgres:16.4-alpine`
+- `image` at `template/notifuse/index.yaml:138`
+- `image` at `template/notifuse/index.yaml:196`
+
+### nsfw: `ethandai4869/nsfw-auth`
+- `originImageName` at `template/nsfw/index.yaml:40`
+- `image` at `template/nsfw/index.yaml:65`
+
+### one-api: `ghcr.io/songquanpeng/one-api:v0.6.10`
+- `originImageName` at `template/one-api/index.yaml:51`
+- `image` at `template/one-api/index.yaml:79`
+
+### open-design: `docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13`
+- `originImageName` at `template/open-design/index.yaml:101`
+- `image` at `template/open-design/index.yaml:130`
+
+### open-design: `nginxinc/nginx-unprivileged:1.25-alpine-slim`
+- `originImageName` at `template/open-design/index.yaml:222`
+- `image` at `template/open-design/index.yaml:248`
+
+### open-webui: `ghcr.io/open-webui/open-webui:v0.5.4`
+- `originImageName` at `template/open-webui/index.yaml:36`
+- `image` at `template/open-webui/index.yaml:59`
+- `image` at `template/open-webui/index.yaml:65`
+- `image` at `template/open-webui/index.yaml:74`
+
+### openagents: `ghcr.io/openagents-org/openagents:sha-48764c0`
+- `originImageName` at `template/openagents/index.yaml:52`
+- `image` at `template/openagents/index.yaml:73`
+
+### openai-proxy: `unickcheng/openai-proxy`
+- `originImageName` at `template/openai-proxy/index.yaml:38`
+- `image` at `template/openai-proxy/index.yaml:63`
+
+### opencart: `ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94`
+- `originImageName` at `template/opencart/index.yaml:139`
+- `image` at `template/opencart/index.yaml:160`
+
+### openclaw: `busybox:1.36`
+- `image` at `template/openclaw/index.yaml:85`
+
+### openclaw: `ghcr.io/openclaw/openclaw:2026.3.8`
+- `originImageName` at `template/openclaw/index.yaml:62`
+- `image` at `template/openclaw/index.yaml:102`
+- `image` at `template/openclaw/index.yaml:160`
+
+### openlist: `openlistteam/openlist:v4.0.9-aria2`
+- `originImageName` at `template/openlist/index.yaml:49`
+- `image` at `template/openlist/index.yaml:72`
+
+### openobserve: `public.ecr.aws/zinclabs/openobserve:v0.90.3`
+- `originImageName` at `template/openobserve/index.yaml:68`
+- `image` at `template/openobserve/index.yaml:97`
+
+### outline: `outlinewiki/outline:1.8.0-1`
+- `originImageName` at `template/outline/index.yaml:427`
+- `image` at `template/outline/index.yaml:448`
+
+### outline: `postgres:16.4`
+- `image` at `template/outline/index.yaml:384`
+
+### overleaf: `sharelatex/sharelatex:6.1.2`
+- `originImageName` at `template/overleaf/index.yaml:260`
+- `image` at `template/overleaf/index.yaml:284`
+
+### pageplug: `cloudtogouser/pageplug-ce:v1.9.35`
+- `originImageName` at `template/pageplug/index.yaml:38`
+- `image` at `template/pageplug/index.yaml:61`
+
+### palacms: `ghcr.io/palacms/palacms:v3.0.0-beta.1`
+- `originImageName` at `template/palacms/index.yaml:38`
+- `image` at `template/palacms/index.yaml:59`
+
+### palworld: `alpine`
+- `image` at `template/palworld/index.yaml:85`
+
+### palworld: `hurlenko/filebrowser`
+- `image` at `template/palworld/index.yaml:158`
+
+### palworld: `thijsvanloef/palworld-server-docker`
+- `originImageName` at `template/palworld/index.yaml:62`
+- `image` at `template/palworld/index.yaml:103`
+
+### palworld-autobackup: `bitnamilegacy/kubectl`
+- `image` at `template/palworld-autobackup/index.yaml:63`
+
+### palworld-export: `bitnamilegacy/kubectl`
+- `image` at `template/palworld-export/index.yaml:64`
+
+### palworld-export: `hurlenko/filebrowser`
+- `originImageName` at `template/palworld-export/index.yaml:42`
+- `image` at `template/palworld-export/index.yaml:76`
+
+### palworld-management: `registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18`
+- `originImageName` at `template/palworld-management/index.yaml:66`
+- `image` at `template/palworld-management/index.yaml:90`
+
+### pangolin: `docker.io/fosrl/pangolin:1.15.2`
+- `originImageName` at `template/pangolin/index.yaml:102`
+- `image` at `template/pangolin/index.yaml:122`
+
+### paperclip: `ghcr.io/paperclipai/paperclip:sha-b8725c5`
+- `originImageName` at `template/paperclip/index.yaml:231`
+- `image` at `template/paperclip/index.yaml:319`
+- `image` at `template/paperclip/index.yaml:470`
+- `image` at `template/paperclip/index.yaml:692`
+
+### paperclip: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/paperclip/index.yaml:257`
+
+### paperclip: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/paperclip/index.yaml:178`
+- `image` at `template/paperclip/index.yaml:278`
+
+### paperless-ngx: `ghcr.io/paperless-ngx/paperless-ngx:latest`
+- `originImageName` at `template/paperless-ngx/index.yaml:318`
+- `image` at `template/paperless-ngx/index.yaml:339`
+
+### paperless-ngx: `postgres:14-alpine`
+- `image` at `template/paperless-ngx/index.yaml:294`
+
+### payload: `ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c`
+- `originImageName` at `template/payload/index.yaml:178`
+- `image` at `template/payload/index.yaml:200`
+
+### payload: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/payload/index.yaml:134`
+
+### pdf2zh: `byaidu/pdf2zh:1.9.6`
+- `originImageName` at `template/pdf2zh/index.yaml:38`
+- `image` at `template/pdf2zh/index.yaml:63`
+
+### penpot: `penpotapp/backend:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:281`
+- `image` at `template/penpot/index.yaml:307`
+
+### penpot: `penpotapp/exporter:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:422`
+- `image` at `template/penpot/index.yaml:447`
+
+### penpot: `penpotapp/frontend:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:496`
+- `image` at `template/penpot/index.yaml:523`
+
+### penpot: `senzing/postgresql-client:2.2.4`
+- `image` at `template/penpot/index.yaml:132`
+
+### perplexica: `itzcrazykns1337/perplexica:v1.10.2`
+- `originImageName` at `template/perplexica/index.yaml:261`
+- `image` at `template/perplexica/index.yaml:284`
+
+### perplexica: `searxng/searxng:2025.2.20-28d1240fc`
+- `originImageName` at `template/perplexica/index.yaml:133`
+- `image` at `template/perplexica/index.yaml:158`
+
+### pgadmin4: `dpage/pgadmin4:8.9`
+- `originImageName` at `template/pgadmin4/index.yaml:45`
+- `image` at `template/pgadmin4/index.yaml:65`
+
+### photoprism: `photoprism/photoprism:240711`
+- `originImageName` at `template/photoprism/index.yaml:48`
+- `image` at `template/photoprism/index.yaml:71`
+
+### phpmyadmin: `phpmyadmin:5.2.1`
+- `originImageName` at `template/phpmyadmin/index.yaml:35`
+- `image` at `template/phpmyadmin/index.yaml:55`
+
+### plane: `makeplane/plane-admin:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:433`
+- `image` at `template/plane/index.yaml:458`
+
+### plane: `makeplane/plane-backend:v0.22-dev`
+- `image` at `template/plane/index.yaml:193`
+- `originImageName` at `template/plane/index.yaml:511`
+- `image` at `template/plane/index.yaml:536`
+- `originImageName` at `template/plane/index.yaml:678`
+- `image` at `template/plane/index.yaml:703`
+- `originImageName` at `template/plane/index.yaml:820`
+- `image` at `template/plane/index.yaml:845`
+
+### plane: `makeplane/plane-frontend:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:1037`
+- `image` at `template/plane/index.yaml:1062`
+
+### plane: `makeplane/plane-space:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:962`
+- `image` at `template/plane/index.yaml:987`
+
+### plane: `senzing/postgresql-client:2.2.4`
+- `image` at `template/plane/index.yaml:145`
+
+### planka: `busybox:1.36.1`
+- `image` at `template/planka/index.yaml:219`
+
+### planka: `ghcr.io/plankanban/planka:2.1.1`
+- `originImageName` at `template/planka/index.yaml:198`
+- `image` at `template/planka/index.yaml:249`
+
+### planka: `postgres:16-alpine`
+- `image` at `template/planka/index.yaml:153`
+
+### plausible: `clickhouse/clickhouse-server:23.3.7.5-alpine`
+- `originImageName` at `template/plausible/index.yaml:187`
+- `image` at `template/plausible/index.yaml:208`
+
+### plausible: `plausible/analytics:v2.0`
+- `originImageName` at `template/plausible/index.yaml:282`
+- `image` at `template/plausible/index.yaml:307`
+
+### pocket-id: `ghcr.io/pocket-id/pocket-id:v2.2.0`
+- `originImageName` at `template/pocket-id/index.yaml:40`
+- `image` at `template/pocket-id/index.yaml:60`
+
+### pocketbase: `adrianmusante/pocketbase:0.29.3`
+- `originImageName` at `template/pocketbase/index.yaml:58`
+- `image` at `template/pocketbase/index.yaml:87`
+
+### pocketbase: `busybox:latest`
+- `image` at `template/pocketbase/index.yaml:79`
+
+### posthog: `clickhouse/clickhouse-server:25.8.12.129`
+- `originImageName` at `template/posthog/index.yaml:1559`
+- `image` at `template/posthog/index.yaml:1579`
+
+### posthog: `docker.redpanda.com/redpandadata/redpanda:v25.1.9`
+- `originImageName` at `template/posthog/index.yaml:339`
+- `image` at `template/posthog/index.yaml:360`
+
+### posthog: `ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a`
+- `originImageName` at `template/posthog/index.yaml:968`
+- `image` at `template/posthog/index.yaml:1005`
+- `image` at `template/posthog/index.yaml:1068`
+
+### posthog: `ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b`
+- `originImageName` at `template/posthog/index.yaml:1302`
+- `image` at `template/posthog/index.yaml:1322`
+- `originImageName` at `template/posthog/index.yaml:1359`
+- `image` at `template/posthog/index.yaml:1379`
+
+### posthog: `ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65`
+- `image` at `template/posthog/index.yaml:988`
+- `originImageName` at `template/posthog/index.yaml:1414`
+- `image` at `template/posthog/index.yaml:1434`
+
+### posthog: `ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5`
+- `originImageName` at `template/posthog/index.yaml:600`
+- `image` at `template/posthog/index.yaml:620`
+- `originImageName` at `template/posthog/index.yaml:784`
+- `image` at `template/posthog/index.yaml:804`
+
+### posthog: `postgres:16.4`
+- `image` at `template/posthog/index.yaml:146`
+
+### posthog: `zookeeper:3.9.3`
+- `originImageName` at `template/posthog/index.yaml:481`
+- `image` at `template/posthog/index.yaml:502`
+
+### postiz: `busybox:1.36.1`
+- `image` at `template/postiz/index.yaml:326`
+- `image` at `template/postiz/index.yaml:531`
+
+### postiz: `elasticsearch:7.17.27`
+- `originImageName` at `template/postiz/index.yaml:305`
+- `image` at `template/postiz/index.yaml:341`
+
+### postiz: `ghcr.io/gitroomhq/postiz-app:v2.21.8`
+- `originImageName` at `template/postiz/index.yaml:510`
+- `image` at `template/postiz/index.yaml:583`
+
+### postiz: `postgres:16-alpine`
+- `image` at `template/postiz/index.yaml:129`
+
+### postiz: `temporalio/auto-setup:1.28.1`
+- `originImageName` at `template/postiz/index.yaml:400`
+- `image` at `template/postiz/index.yaml:420`
+
+### presenton: `ghcr.io/presenton/presenton:v0.8.2-beta`
+- `originImageName` at `template/presenton/index.yaml:37`
+- `image` at `template/presenton/index.yaml:59`
+
+### prestashop: `mysql:8.0.30`
+- `image` at `template/prestashop/index.yaml:141`
+
+### prestashop: `prestashop/prestashop:9.1.3-apache`
+- `originImageName` at `template/prestashop/index.yaml:216`
+- `image` at `template/prestashop/index.yaml:237`
+
+### privatebin: `alpine`
+- `image` at `template/privatebin/index.yaml:272`
+
+### privatebin: `frooodle/privatebin:0.26.1-fat`
+- `originImageName` at `template/privatebin/index.yaml:249`
+
+### privatebin: `ghcr.io/privatebin/fs:1.7.4`
+- `image` at `template/privatebin/index.yaml:280`
+
+### pterodactyl: `ghcr.io/pterodactyl/panel:v1.12.4`
+- `image` at `template/pterodactyl/index.yaml:399`
+- `originImageName` at `template/pterodactyl/index.yaml:545`
+- `image` at `template/pterodactyl/index.yaml:677`
+
+### pterodactyl: `public.ecr.aws/docker/library/mysql:8.0.30`
+- `image` at `template/pterodactyl/index.yaml:183`
+- `image` at `template/pterodactyl/index.yaml:568`
+- `image` at `template/pterodactyl/index.yaml:636`
+
+### pterodactyl: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/pterodactyl/index.yaml:368`
+- `image` at `template/pterodactyl/index.yaml:606`
+
+### qinglong: `whyour/qinglong:latest`
+- `originImageName` at `template/qinglong/index.yaml:38`
+- `image` at `template/qinglong/index.yaml:61`
+
+### quay: `postgres:16.4`
+- `image` at `template/quay/index.yaml:150`
+
+### quay: `python:3.12.8-alpine3.20`
+- `image` at `template/quay/index.yaml:541`
+
+### quay: `quay.io/projectquay/quay:v3.9.8`
+- `originImageName` at `template/quay/index.yaml:301`
+- `image` at `template/quay/index.yaml:332`
+
+### redisinsight: `redislabs/redisinsight:2.52`
+- `originImageName` at `template/redisinsight/index.yaml:34`
+- `image` at `template/redisinsight/index.yaml:54`
+
+### refly: `mautic/mautic:5.2.3-fpm`
+- `image` at `template/refly/index.yaml:409`
+
+### refly: `reflyai/elasticsearch:7.10.2`
+- `originImageName` at `template/refly/index.yaml:386`
+- `image` at `template/refly/index.yaml:417`
+
+### refly: `reflyai/qdrant:v1.13.1`
+- `originImageName` at `template/refly/index.yaml:305`
+- `image` at `template/refly/index.yaml:328`
+
+### refly: `reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400`
+- `originImageName` at `template/refly/index.yaml:479`
+- `image` at `template/refly/index.yaml:504`
+
+### refly: `reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400`
+- `originImageName` at `template/refly/index.yaml:824`
+- `image` at `template/refly/index.yaml:849`
+
+### refly: `senzing/postgresql-client:2.2.4`
+- `image` at `template/refly/index.yaml:165`
+
+### registry: `joxit/docker-registry-ui:2.5.6-debian`
+- `originImageName` at `template/registry/index.yaml:206`
+- `image` at `template/registry/index.yaml:230`
+
+### registry: `registry:2.8.3`
+- `originImageName` at `template/registry/index.yaml:35`
+- `image` at `template/registry/index.yaml:57`
+
+### rocketchat: `mongo:6.0`
+- `image` at `template/rocketchat/index.yaml:132`
+
+### rocketchat: `registry.rocket.chat/rocketchat/rocket.chat:7.9.0`
+- `originImageName` at `template/rocketchat/index.yaml:183`
+- `image` at `template/rocketchat/index.yaml:203`
+
+### rocketchat-micro: `mongo:6.0`
+- `image` at `template/rocketchat-micro/index.yaml:130`
+
+### rocketchat-micro: `nats:2.4-alpine`
+- `originImageName` at `template/rocketchat-micro/index.yaml:332`
+- `image` at `template/rocketchat-micro/index.yaml:367`
+
+### rocketchat-micro: `natsio/nats-server-config-reloader:0.6.3`
+- `image` at `template/rocketchat-micro/index.yaml:438`
+
+### rocketchat-micro: `rocketchat/account-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:517`
+- `image` at `template/rocketchat-micro/index.yaml:542`
+
+### rocketchat-micro: `rocketchat/authorization-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:606`
+- `image` at `template/rocketchat-micro/index.yaml:631`
+
+### rocketchat-micro: `rocketchat/ddp-streamer-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:695`
+- `image` at `template/rocketchat-micro/index.yaml:720`
+
+### rocketchat-micro: `rocketchat/presence-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:793`
+- `image` at `template/rocketchat-micro/index.yaml:818`
+
+### rocketchat-micro: `rocketchat/rocket.chat:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:224`
+- `image` at `template/rocketchat-micro/index.yaml:249`
+
+### rocketchat-micro: `rocketchat/stream-hub-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:882`
+- `image` at `template/rocketchat-micro/index.yaml:907`
+
+### rsshub: `browserless/chrome:1.61.1-chrome-stable`
+- `originImageName` at `template/rsshub/index.yaml:133`
+- `image` at `template/rsshub/index.yaml:157`
+
+### rsshub: `diygod/rsshub:2024-07-06`
+- `originImageName` at `template/rsshub/index.yaml:46`
+- `image` at `template/rsshub/index.yaml:71`
+
+### rustdesk: `rustdesk/rustdesk-server-s6:1.1.15`
+- `originImageName` at `template/rustdesk/index.yaml:45`
+- `image` at `template/rustdesk/index.yaml:69`
+
+### rustfs: `busybox`
+- `image` at `template/rustfs/index.yaml:83`
+
+### rustfs: `rustfs/rustfs:latest`
+- `originImageName` at `template/rustfs/index.yaml:54`
+- `image` at `template/rustfs/index.yaml:114`
+
+### rybbit: `clickhouse/clickhouse-server:25.4.2`
+- `originImageName` at `template/rybbit/index.yaml:234`
+- `image` at `template/rybbit/index.yaml:258`
+- `image` at `template/rybbit/index.yaml:419`
+
+### rybbit: `ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba`
+- `originImageName` at `template/rybbit/index.yaml:392`
+- `image` at `template/rybbit/index.yaml:464`
+
+### rybbit: `ghcr.io/rybbit-io/rybbit-client:sha-aa404ba`
+- `originImageName` at `template/rybbit/index.yaml:605`
+- `image` at `template/rybbit/index.yaml:632`
+
+### rybbit: `postgres:16.4-alpine`
+- `image` at `template/rybbit/index.yaml:135`
+- `image` at `template/rybbit/index.yaml:432`
+
+### s-pdf: `alpine`
+- `image` at `template/s-pdf/index.yaml:251`
+
+### s-pdf: `ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat`
+- `originImageName` at `template/s-pdf/index.yaml:228`
+- `image` at `template/s-pdf/index.yaml:259`
+
+### s-pdf: `postgres:14-alpine`
+- `image` at `template/s-pdf/index.yaml:203`
+
+### samarium: `ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867`
+- `originImageName` at `template/samarium/index.yaml:142`
+- `image` at `template/samarium/index.yaml:168`
+- `image` at `template/samarium/index.yaml:332`
+
+### signoz: `busybox`
+- `image` at `template/signoz/index.yaml:447`
+
+### signoz: `busybox:1.28`
+- `image` at `template/signoz/index.yaml:566`
+- `image` at `template/signoz/index.yaml:683`
+- `image` at `template/signoz/index.yaml:740`
+- `image` at `template/signoz/index.yaml:840`
+
+### signoz: `clickhouse/clickhouse-server:25.5.6`
+- `originImageName` at `template/signoz/index.yaml:524`
+- `image` at `template/signoz/index.yaml:548`
+- `image` at `template/signoz/index.yaml:570`
+
+### signoz: `signoz/signoz-otel-collector:v0.144.2`
+- `image` at `template/signoz/index.yaml:687`
+- `originImageName` at `template/signoz/index.yaml:821`
+- `image` at `template/signoz/index.yaml:844`
+
+### signoz: `signoz/signoz:v0.117.0`
+- `originImageName` at `template/signoz/index.yaml:719`
+- `image` at `template/signoz/index.yaml:744`
+
+### signoz: `signoz/zookeeper:3.7.1`
+- `originImageName` at `template/signoz/index.yaml:421`
+- `image` at `template/signoz/index.yaml:454`
+
+### sillytavern: `ghcr.io/sillytavern/sillytavern:1.18.0`
+- `originImageName` at `template/sillytavern/index.yaml:57`
+- `image` at `template/sillytavern/index.yaml:80`
+- `image` at `template/sillytavern/index.yaml:154`
+
+### skardi: `ghcr.io/skardilabs/skardi/skardi-server:0.3.0`
+- `originImageName` at `template/skardi/index.yaml:123`
+- `image` at `template/skardi/index.yaml:143`
+
+### stalwart: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/stalwart/index.yaml:156`
+- `image` at `template/stalwart/index.yaml:259`
+
+### stalwart: `stalwartlabs/stalwart:v0.16.7`
+- `originImageName` at `template/stalwart/index.yaml:234`
+- `image` at `template/stalwart/index.yaml:302`
+
+### steel-browser: `ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1`
+- `originImageName` at `template/steel-browser/index.yaml:38`
+- `image` at `template/steel-browser/index.yaml:62`
+
+### strapi: `postgres:14-alpine`
+- `image` at `template/strapi/index.yaml:164`
+
+### strapi: `vshadbolt/strapi:5.33.0`
+- `originImageName` at `template/strapi/index.yaml:611`
+- `image` at `template/strapi/index.yaml:632`
+- `image` at `template/strapi/index.yaml:706`
+
+### sub2api: `postgres:16-alpine`
+- `image` at `template/sub2api/index.yaml:218`
+
+### sub2api: `weishaw/sub2api:0.1.104`
+- `originImageName` at `template/sub2api/index.yaml:368`
+- `image` at `template/sub2api/index.yaml:397`
+
+### supabase: `darthsim/imgproxy:v3.30.1`
+- `originImageName` at `template/supabase/index.yaml:1353`
+- `image` at `template/supabase/index.yaml:1373`
+
+### supabase: `kong:2.8.1`
+- `originImageName` at `template/supabase/index.yaml:848`
+- `image` at `template/supabase/index.yaml:868`
+
+### supabase: `postgres:16.4`
+- `image` at `template/supabase/index.yaml:272`
+
+### supabase: `postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9`
+- `originImageName` at `template/supabase/index.yaml:1061`
+- `image` at `template/supabase/index.yaml:1081`
+
+### supabase: `supabase/edge-runtime:v1.70.3`
+- `originImageName` at `template/supabase/index.yaml:1492`
+- `image` at `template/supabase/index.yaml:1512`
+
+### supabase: `supabase/gotrue:v2.186.0`
+- `originImageName` at `template/supabase/index.yaml:934`
+- `image` at `template/supabase/index.yaml:954`
+
+### supabase: `supabase/logflare:1.31.2`
+- `originImageName` at `template/supabase/index.yaml:1594`
+- `image` at `template/supabase/index.yaml:1614`
+
+### supabase: `supabase/postgres-meta:v0.95.2`
+- `originImageName` at `template/supabase/index.yaml:1430`
+- `image` at `template/supabase/index.yaml:1450`
+
+### supabase: `supabase/realtime:v2.76.5`
+- `originImageName` at `template/supabase/index.yaml:1133`
+- `image` at `template/supabase/index.yaml:1153`
+
+### supabase: `supabase/storage-api:v1.37.8`
+- `originImageName` at `template/supabase/index.yaml:1234`
+- `image` at `template/supabase/index.yaml:1254`
+
+### supabase: `supabase/studio:2026.02.16-sha-26c615c`
+- `originImageName` at `template/supabase/index.yaml:707`
+- `image` at `template/supabase/index.yaml:727`
+
+### supabase: `supabase/supavisor:2.7.4`
+- `originImageName` at `template/supabase/index.yaml:1766`
+- `image` at `template/supabase/index.yaml:1786`
+
+### supabase: `timberio/vector:0.53.0-alpine`
+- `originImageName` at `template/supabase/index.yaml:1700`
+- `image` at `template/supabase/index.yaml:1720`
+
+### surveyking: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/surveyking/index.yaml:129`
+
+### surveyking: `surveyking/surveyking:v1.9.0`
+- `originImageName` at `template/surveyking/index.yaml:170`
+- `image` at `template/surveyking/index.yaml:193`
+
+### tailchat: `minio/minio`
+- `originImageName` at `template/tailchat/index.yaml:267`
+- `image` at `template/tailchat/index.yaml:289`
+
+### tailchat: `moonrailgun/tailchat:1.11.5`
+- `originImageName` at `template/tailchat/index.yaml:66`
+- `image` at `template/tailchat/index.yaml:86`
+
+### teable: `registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest`
+- `originImageName` at `template/teable/index.yaml:47`
+- `image` at `template/teable/index.yaml:69`
+- `image` at `template/teable/index.yaml:96`
+
+### teable: `senzing/postgresql-client:2.2.4`
+- `image` at `template/teable/index.yaml:348`
+
+### tentix: `limbo2342/tentix:dev-2025-10-23-x.3`
+- `image` at `template/tentix/index.yaml:211`
+
+### tentix: `limbo2342/tentix:migrate.10.22.x1`
+- `image` at `template/tentix/index.yaml:188`
+
+### tianji: `moonrailgun/tianji:1.18.5`
+- `originImageName` at `template/tianji/index.yaml:50`
+- `image` at `template/tianji/index.yaml:74`
+
+### tianji: `senzing/postgresql-client:2.2.4`
+- `image` at `template/tianji/index.yaml:259`
+
+### tolgee: `senzing/postgresql-client:2.2.4`
+- `image` at `template/tolgee/index.yaml:195`
+
+### tolgee: `tolgee/tolgee:v3.113.0`
+- `originImageName` at `template/tolgee/index.yaml:219`
+- `image` at `template/tolgee/index.yaml:244`
+
+### tooljet: `postgres:16-alpine`
+- `image` at `template/tooljet/index.yaml:257`
+- `image` at `template/tooljet/index.yaml:305`
+- `image` at `template/tooljet/index.yaml:568`
+
+### tooljet: `postgrest/postgrest:v12.0.2`
+- `originImageName` at `template/tooljet/index.yaml:455`
+- `image` at `template/tooljet/index.yaml:475`
+
+### tooljet: `tooljet/tooljet-ce:v3.20.170-lts`
+- `image` at `template/tooljet/index.yaml:333`
+- `originImageName` at `template/tooljet/index.yaml:548`
+- `image` at `template/tooljet/index.yaml:616`
+
+### tududi: `chrisvel/tududi:1.1.0`
+- `originImageName` at `template/tududi/index.yaml:50`
+- `image` at `template/tududi/index.yaml:73`
+
+### twenty: `busybox:latest`
+- `image` at `template/twenty/index.yaml:337`
+
+### twenty: `postgres:14-alpine`
+- `image` at `template/twenty/index.yaml:155`
+
+### twenty: `twentycrm/twenty:v1.12.0`
+- `originImageName` at `template/twenty/index.yaml:316`
+- `image` at `template/twenty/index.yaml:349`
+- `originImageName` at `template/twenty/index.yaml:452`
+- `image` at `template/twenty/index.yaml:472`
+
+### typebot: `axllent/mailpit:v1.30.1`
+- `originImageName` at `template/typebot/index.yaml:824`
+- `image` at `template/typebot/index.yaml:846`
+
+### typebot: `baptistearno/typebot-builder:3.17.1`
+- `originImageName` at `template/typebot/index.yaml:431`
+- `image` at `template/typebot/index.yaml:484`
+
+### typebot: `baptistearno/typebot-viewer:3.17.1`
+- `originImageName` at `template/typebot/index.yaml:656`
+- `image` at `template/typebot/index.yaml:709`
+
+### typebot: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/typebot/index.yaml:265`
+
+### typebot: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/typebot/index.yaml:453`
+- `image` at `template/typebot/index.yaml:678`
+
+### typesense: `typesense/typesense:29.0`
+- `originImageName` at `template/typesense/index.yaml:41`
+- `image` at `template/typesense/index.yaml:62`
+
+### typo3: `martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25`
+- `originImageName` at `template/typo3/index.yaml:230`
+- `image` at `template/typo3/index.yaml:254`
+- `image` at `template/typo3/index.yaml:398`
+
+### typo3: `mysql:8.0.30`
+- `image` at `template/typo3/index.yaml:154`
+
+### ubuntu-sshd: `takeyamajp/ubuntu-sshd:ubuntu22.04`
+- `originImageName` at `template/ubuntu-sshd/index.yaml:38`
+- `image` at `template/ubuntu-sshd/index.yaml:63`
+
+### umami: `ghcr.io/umami-software/umami:3.0.2`
+- `originImageName` at `template/umami/index.yaml:58`
+- `image` at `template/umami/index.yaml:83`
+
+### umami: `postgres:14-alpine`
+- `image` at `template/umami/index.yaml:257`
+
+### uptime-kuma: `louislam/uptime-kuma:1.23.13`
+- `originImageName` at `template/uptime-kuma/index.yaml:38`
+- `image` at `template/uptime-kuma/index.yaml:61`
+
+### vaultwarden: `vaultwarden/server:latest`
+- `originImageName` at `template/vaultwarden/index.yaml:38`
+- `image` at `template/vaultwarden/index.yaml:61`
+
+### waha: `devlikeapro/waha:chrome-2026.5.1`
+- `originImageName` at `template/waha/index.yaml:162`
+- `image` at `template/waha/index.yaml:230`
+
+### waha: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/waha/index.yaml:186`
+
+### webos: `fs185085781/webos:v1.4.1`
+- `originImageName` at `template/webos/index.yaml:37`
+- `image` at `template/webos/index.yaml:60`
+
+### wechat: `ricwang/docker-wechat:4.0.0.30`
+- `originImageName` at `template/wechat/index.yaml:47`
+- `image` at `template/wechat/index.yaml:70`
+
+### wechat2rss: `ttttmr/wechat2rss:latest`
+- `originImageName` at `template/wechat2rss/index.yaml:54`
+- `image` at `template/wechat2rss/index.yaml:73`
+
+### wewe-rss: `cooderl/wewe-rss:v2.6.1`
+- `originImageName` at `template/wewe-rss/index.yaml:174`
+- `image` at `template/wewe-rss/index.yaml:193`
+
+### wewe-rss: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/wewe-rss/index.yaml:134`
+
+### woocommerce: `mysql:8.0.30`
+- `image` at `template/woocommerce/index.yaml:150`
+
+### woocommerce: `wordpress:6.9.1-php8.3-apache`
+- `originImageName` at `template/woocommerce/index.yaml:194`
+- `image` at `template/woocommerce/index.yaml:333`
+
+### woocommerce: `wordpress:cli-2.9.0-php8.3`
+- `image` at `template/woocommerce/index.yaml:214`
+
+### wordpress: `wordpress:6.5.4`
+- `originImageName` at `template/wordpress/index.yaml:48`
+- `image` at `template/wordpress/index.yaml:71`
+
+### wrenai: `ghcr.io/canner/wren-ai-service:0.15.17`
+- `originImageName` at `template/wrenai/index.yaml:206`
+- `image` at `template/wrenai/index.yaml:228`
+
+### wrenai: `ghcr.io/canner/wren-bootstrap:0.1.5`
+- `image` at `template/wrenai/index.yaml:313`
+
+### wrenai: `ghcr.io/canner/wren-engine-ibis:0.14.3`
+- `originImageName` at `template/wrenai/index.yaml:383`
+- `image` at `template/wrenai/index.yaml:405`
+
+### wrenai: `ghcr.io/canner/wren-engine:0.14.3`
+- `originImageName` at `template/wrenai/index.yaml:291`
+- `image` at `template/wrenai/index.yaml:325`
+
+### wrenai: `ghcr.io/canner/wren-ui:0.20.1`
+- `originImageName` at `template/wrenai/index.yaml:644`
+- `image` at `template/wrenai/index.yaml:666`
+
+### wrenai: `qdrant/qdrant:v1.13.4`
+- `originImageName` at `template/wrenai/index.yaml:466`
+- `image` at `template/wrenai/index.yaml:488`
+- `image` at `template/wrenai/index.yaml:516`
+
+### wrenai: `senzing/postgresql-client:2.2.4`
+- `image` at `template/wrenai/index.yaml:864`
+
+### yourls: `mysql:8.0.30`
+- `image` at `template/yourls/index.yaml:140`
+
+### yourls: `yourls:1.10.1`
+- `originImageName` at `template/yourls/index.yaml:178`
+- `image` at `template/yourls/index.yaml:203`
+
+### zitadel: `ghcr.io/zitadel/zitadel:v4.10.1`
+- `originImageName` at `template/zitadel/index.yaml:135`
+- `image` at `template/zitadel/index.yaml:155`
+
+### zot: `ghcr.io/project-zot/zot:v2.1.14`
+- `originImageName` at `template/zot/index.yaml:144`
+- `image` at `template/zot/index.yaml:234`
+- `originImageName` at `template/zot/index.yaml:296`
+- `image` at `template/zot/index.yaml:316`
+
+### zot: `httpd:2.4.63-alpine3.22`
+- `image` at `template/zot/index.yaml:164`

--- a/template/pdf2zh/index.yaml
+++ b/template/pdf2zh/index.yaml
@@ -35,7 +35,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: byaidu/pdf2zh:1.9.6
+    originImageName: byaidu/pdf2zh:1.9.11
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -60,7 +60,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: byaidu/pdf2zh:1.9.6
+          image: byaidu/pdf2zh:1.9.11
           resources:
             requests:
               cpu: 20m
@@ -79,10 +79,12 @@ kind: Service
 metadata:
   name: ${{ defaults.app_name }}
   labels:
+    app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   ports:
-    - port: 7860
+    - name: http
+      port: 7860
   selector:
     app: ${{ defaults.app_name }}
 


### PR DESCRIPTION
## Summary

- Refresh PDFMathTranslate (`pdf2zh`) from `byaidu/pdf2zh:1.9.6` to `byaidu/pdf2zh:1.9.11`.
- Keep `originImageName` aligned with the workload container image.
- Add the missing Service `app` label and port name required by docker-to-sealos validation.
- Commit the scanner report and status evidence under `.sealos/update-reports/`.

## Branch and base

- Head: `yangchuansheng:codex/template-version-refresh-20260624`
- Base: `labring-actions/templates:kb-0.9`

## Update report

- Markdown: `.sealos/update-reports/template-version-updates.md`
- JSON: `.sealos/update-reports/template-version-updates.json`
- Status Markdown: `.sealos/update-reports/template-version-refresh-status.md`
- Status JSON: `.sealos/update-reports/template-version-refresh-status.json`

## Updated templates

- `template/pdf2zh/index.yaml`
  - `byaidu/pdf2zh:1.9.6` -> `byaidu/pdf2zh:1.9.11`

## Skipped or blocked templates

The status report records 13 skipped patch-level candidates whose focused docker-to-sealos validation currently fails on pre-existing template issues outside this image-refresh scope:

- `affine`
- `cronicle`
- `illa-builder`
- `kanboard`
- `lobe-chat-db`
- `outline`
- `pageplug`
- `presenton`
- `stalwart`
- `sub2api`
- `tailchat`
- `tududi`
- `webos`

The scanner report also keeps all manual, blocked, skip, cross-minor, cross-major, database, tooling, and multi-service bundle candidates as reviewer evidence.

## Validation

- `git diff --check upstream/kb-0.9...HEAD` passed.
- `git status --short` was clean after commit.
- `git diff --name-only upstream/kb-0.9...HEAD` is limited to `template/pdf2zh/index.yaml` and the intended `.sealos/update-reports/*` evidence files.
- `git log --oneline upstream/kb-0.9..HEAD` contains one intended commit: `d0c233e chore: refresh Sealos template image versions`.
- docker-to-sealos validation passed:
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/path_converter.py --self-test`
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_check_consistency.py`
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_compose_to_template.py`
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_check_must_coverage.py`
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/check_consistency.py --skill SKILL.md --references references --rules-file references/rules-registry.yaml --artifacts /Users/longnv/.codex/worktrees/template-version-refresh-20260624/templates/template/pdf2zh/index.yaml`
  - `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/check_must_coverage.py --skill SKILL.md --mapping references/must-rules-map.yaml --rules-file references/rules-registry.yaml`

## Validation gaps

- This templates checkout does not contain `scripts/check_consistency.py` or `scripts/quality_gate.py`, so repository-local validators were unavailable.
- Live deployment validation was not run because this is a patch-level image refresh plus static Service metadata normalization.
