### PR TITLE
fix(templates): refresh AFFiNE Airbyte and APITable

### DIFF
--- a/template/affine/index.yaml
+++ b/template/affine/index.yaml
@@ -199,7 +199,6 @@ metadata:
     clusterdefinition.kubeblocks.io/name: postgresql
     clusterversion.kubeblocks.io/name: postgresql-16.4.0
     sealos-db-provider-cr: ${{ defaults.app_name }}-pg
-  annotations: {}
   name: ${{ defaults.app_name }}-pg
 spec:
   affinity:
@@ -355,7 +354,7 @@ spec:
               done
       containers:
         - name: affine-migration
-          image: ghcr.io/toeverything/affine:0.26.6
+          image: ghcr.io/toeverything/affine:0.26.7
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -417,7 +416,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/toeverything/affine:0.26.6
+    originImageName: ghcr.io/toeverything/affine:0.26.7
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -460,11 +459,13 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: username
-            - name: PGPASSWORD
+            - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-pg-conn-credential
                   key: password
+            - name: PGPASSWORD
+              value: $(PG_PASSWORD)
           resources:
             limits:
               cpu: 100m
@@ -476,14 +477,17 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "waiting for affine database..."
+              until pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres >/dev/null 2>&1; do
+                echo "waiting for postgresql..."
+                sleep 2
+              done
               until psql -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USERNAME}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='affine';" | grep -q 1; do
-                echo "affine database missing, rechecking in 2s"
+                echo "waiting for affine database..."
                 sleep 2
               done
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/toeverything/affine:0.26.6
+          image: ghcr.io/toeverything/affine:0.26.7
           env:
             - name: AFFINE_CONFIG_PATH
               value: /root/.affine/config

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -39,15 +39,13 @@ spec:
       type: string
       value: ${{ random(32) }}
   inputs:
-    auth_admin_username:
-      description: "Initial Airbyte admin username."
+    auth_admin_email:
+      description: "Initial Airbyte admin email address."
       type: string
-      default: "admin"
       required: true
     auth_admin_password:
       description: "Initial Airbyte admin password."
       type: string
-      default: "${{ random(24) }}"
       required: true
 
 ---
@@ -116,15 +114,14 @@ spec:
   affinity:
     podAntiAffinity: Preferred
     tenancy: SharedNode
-  clusterDefinitionRef: postgresql
-  clusterVersionRef: postgresql-16.4.0
   componentSpecs:
     - name: postgresql
-      componentDefRef: postgresql
+      componentDef: postgresql
       disableExporter: true
       enabledLogs:
         - running
       replicas: 1
+      serviceVersion: "16.4.0"
       serviceAccountName: ${{ defaults.app_name }}-pg
       switchPolicy:
         type: Noop
@@ -147,6 +144,65 @@ spec:
   terminationPolicy: Delete
 
 ---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-pg-conn-sync
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-pg-conn-sync
+spec:
+  backoffLimit: 12
+  template:
+    spec:
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      containers:
+        - name: pg-conn-sync
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              account_secret="${APP_NAME}-pg-postgresql-account-postgres"
+              conn_secret="${APP_NAME}-pg-conn-credential"
+              host="${APP_NAME}-pg-postgresql-postgresql"
+              port="5432"
+              until kubectl get secret "${account_secret}" >/dev/null 2>&1; do
+                sleep 2
+              done
+              username="$(kubectl get secret "${account_secret}" -o jsonpath='{.data.username}' | base64 -d)"
+              password="$(kubectl get secret "${account_secret}" -o jsonpath='{.data.password}' | base64 -d)"
+              kubectl create secret generic "${conn_secret}" \
+                --from-literal=host="${host}" \
+                --from-literal=port="${port}" \
+                --from-literal=username="${username}" \
+                --from-literal=password="${password}" \
+                --from-literal=endpoint="${host}:${port}" \
+                --dry-run=client -o yaml | kubectl apply -f -
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -162,6 +218,7 @@ rules:
       - "*"
     resources:
       - jobs
+      - jobs/status
       - pods
       - pods/log
       - pods/exec
@@ -209,21 +266,32 @@ metadata:
     app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 data:
-  AIRBYTE_VERSION: "0.63.11"
+  AIRBYTE_VERSION: "2.1.0"
   AIRBYTE_EDITION: "community"
-  AIRBYTE_URL: ""
+  AIRBYTE_CLUSTER_TYPE: "hybrid"
+  CLUSTER_TYPE: "hybrid"
+  API_AUTHORIZATION_ENABLED: "false"
+  CONNECTOR_REGISTRY_SEED_PROVIDER: "remote"
+  ENTERPRISE_SOURCE_STUBS_URL: "https://connectors.airbyte.com/files/resources/connector_stubs/v1/connector_stubs.json"
+  MANIFEST_SERVER_API_HOST: "http://${{ defaults.app_name }}-server:8001"
+  AB_AUTH_SECRET_CREATION_ENABLED: "true"
+  AB_KUBERNETES_SECRET_NAME: "${{ defaults.app_name }}-auth-secrets"
+  AB_INSTANCE_ADMIN_PASSWORD_SECRET_KEY: "instance-admin-password"
+  AB_INSTANCE_ADMIN_CLIENT_ID_SECRET_KEY: "instance-admin-client-id"
+  AB_INSTANCE_ADMIN_CLIENT_SECRET_SECRET_KEY: "instance-admin-client-secret"
+  AB_JWT_SIGNATURE_SECRET_KEY: "jwt-signature-secret"
+  DATAPLANE_CLIENT_ID_SECRET_KEY: "dataplane-client-id"
+  DATAPLANE_CLIENT_SECRET_SECRET_KEY: "dataplane-client-secret"
+  IDENTITY_PROVIDER_TYPE: "simple"
+  AIRBYTE_URL: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}"
   AIRBYTE_SERVER_HOST: "${{ defaults.app_name }}-server:8001"
   API_URL: "/api/v1/"
-  CONNECTOR_BUILDER_API_URL: "/connector-builder-api"
   CONFIG_API_HOST: "http://${{ defaults.app_name }}-server:8001"
   CONFIG_ROOT: "/configs"
   CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.35.15.001"
   INTERNAL_API_HOST: "http://${{ defaults.app_name }}-server:8001"
-  WORKLOAD_API_HOST: "http://localhost"
-  KEYCLOAK_INTERNAL_HOST: "localhost"
-  CONNECTOR_BUILDER_API_HOST: "${{ defaults.app_name }}-connector-builder-server:80"
-  CONNECTOR_BUILDER_SERVER_API_HOST: "http://${{ defaults.app_name }}-connector-builder-server:80"
-  AIRBYTE_API_HOST: "http://localhost:8001/api/public"
+  WORKLOAD_API_HOST: "http://${{ defaults.app_name }}-server:8001"
+  AIRBYTE_API_HOST: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/api/public"
   JOB_MAIN_CONTAINER_CPU_LIMIT: ""
   JOB_MAIN_CONTAINER_CPU_REQUEST: ""
   JOB_MAIN_CONTAINER_MEMORY_LIMIT: ""
@@ -242,7 +310,7 @@ data:
   TEMPORAL_HOST: "${{ defaults.app_name }}-temporal:7233"
   TEMPORAL_WORKER_PORTS: "9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030"
   TRACKING_STRATEGY: "segment"
-  WEBAPP_URL: "http://${{ defaults.app_name }}-webapp:80"
+  WEBAPP_URL: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}"
   WORKER_ENVIRONMENT: "kubernetes"
   WORKSPACE_DOCKER_MOUNT: "airbyte_workspace"
   WORKSPACE_ROOT: "/workspace"
@@ -260,10 +328,93 @@ data:
   SHOULD_RUN_NOTIFY_WORKFLOWS: "true"
   MAX_NOTIFY_WORKERS: "5"
   WORKLOAD_LAUNCHER_PARALLELISM: "10"
+  CONTROL_PLANE_TOKEN_ENDPOINT: "http://${{ defaults.app_name }}-server:8001/api/v1/dataplanes/token"
+  JOB_KUBE_CONNECTOR_IMAGE_REGISTRY: ""
+  CONNECTOR_SIDECAR_IMAGE: "airbyte/connector-sidecar:2.1.0"
+  CONTAINER_ORCHESTRATOR_ENABLED: "true"
+  CONTAINER_ORCHESTRATOR_IMAGE: "airbyte/container-orchestrator:2.1.0"
+  WORKLOAD_INIT_IMAGE: "airbyte/workload-init-container:2.1.0"
+  CONTAINER_ORCHESTRATOR_SECRET_NAME: ""
+  CONTAINER_ORCHESTRATOR_SECRET_MOUNT_PATH: "/secrets/gcp-creds"
+  CONTAINER_ORCHESTRATOR_DATA_PLANE_CREDS_SECRET_MOUNT_PATH: "/secrets/dataplane-creds"
+  CONTAINER_ORCHESTRATOR_DATA_PLANE_CREDS_SECRET_NAME: ""
+  CONTAINER_ORCHESTRATOR_DATA_PLANE_CREDS_SECRET_KEY: "sa.json"
+  CONTAINER_ORCHESTRATOR_JAVA_OPTS: ""
+  KUBERNETES_CLIENT_MAX_IDLE_CONNECTIONS: "100"
+  KUBERNETES_CLIENT_MAX_RETRIES: ""
+  MAX_CHECK_WORKERS: "30"
+  MAX_SYNC_WORKERS: "30"
+  AWS_DEFAULT_REGION: ""
+  AWS_AUTHENTICATION_TYPE: "access-key"
+  JOB_KUBE_SERVICEACCOUNT: "${{ defaults.app_name }}-admin"
+  JOB_KUBE_NAMESPACE: ""
+  JOB_KUBE_LOCAL_VOLUME_ENABLED: "false"
+  JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_SECRET: ""
+  JOB_KUBE_ANNOTATIONS: ""
+  JOB_KUBE_LABELS: ""
+  JOB_KUBE_NODE_SELECTORS: ""
+  JOB_KUBE_TOLERATIONS: ""
   WORKLOAD_LAUNCHER_ENABLED: "false"
   WORKLOAD_API_SERVER_ENABLED: "false"
   PUB_SUB_ENABLED: "false"
   PUB_SUB_TOPIC_NAME: ""
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-cron
+  labels:
+    app: ${{ defaults.app_name }}-cron
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-cron
+data:
+  vn-optvn-airbytevn-cronvn-entrypointvn-sh: |
+    set -eu
+    until curl -fsS "${INTERNAL_API_HOST}/api/v1/health" >/dev/null 2>&1; do
+      sleep 3
+    done
+
+    patch_home="/tmp/airbyte-cron-app"
+    patch_jar="io.airbyte-airbyte-cron-${AIRBYTE_VERSION}.jar"
+    rm -rf "${patch_home}"
+    mkdir -p "${patch_home}/bin" "${patch_home}/lib"
+    cp /app/airbyte-app/bin/airbyte-cron "${patch_home}/bin/airbyte-cron"
+    chmod +x "${patch_home}/bin/airbyte-cron"
+    for file in /app/airbyte-app/lib/*; do
+      base="${file##*/}"
+      if [ "${base}" = "${patch_jar}" ]; then
+        continue
+      fi
+      ln -s "${file}" "${patch_home}/lib/${base}"
+    done
+    SRC="/app/airbyte-app/lib/${patch_jar}" DST="${patch_home}/lib/${patch_jar}" python - <<'PYCRON'
+    import os
+    import zipfile
+
+    src = os.environ["SRC"]
+    dst = os.environ["DST"]
+    remove = set([
+        "io/airbyte/cron/jobs/ConnectionEntitlementsValidator.class",
+        "io/airbyte/cron/jobs/ConnectionEntitlementsValidatorKt.class",
+        "io/airbyte/cron/jobs/ConnectionEntitlementsValidator$WhenMappings.class",
+        "io/airbyte/cron/jobs/$ConnectionEntitlementsValidator$Definition.class",
+        "io/airbyte/cron/jobs/$ConnectionEntitlementsValidator$Definition$Exec.class",
+        "META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference/io.airbyte.cron.jobs.$ConnectionEntitlementsValidator$Definition",
+    ])
+    removed = set()
+    with zipfile.ZipFile(src, "r") as zin:
+        with zipfile.ZipFile(dst, "w") as zout:
+            for item in zin.infolist():
+                if item.filename in remove:
+                    removed.add(item.filename)
+                    continue
+                zout.writestr(item, zin.read(item.filename))
+    missing = remove - removed
+    if missing:
+        raise RuntimeError("missing cron classes: " + ",".join(sorted(missing)))
+    PYCRON
+
+    exec /entrypoint.sh /bin/bash -c "${patch_home}/bin/airbyte-cron"
 
 ---
 apiVersion: v1
@@ -274,7 +425,7 @@ metadata:
     app: ${{ defaults.app_name }}-temporal
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-temporal
 data:
-  development.yaml: |
+  vn-etcvn-temporalvn-configvn-dynamicconfigvn-developmentvn-yaml: |
     frontend.enableClientVersionCheck:
       - value: true
         constraints: {}
@@ -310,6 +461,340 @@ data:
           MaximumAttempts: 0
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-auth-init
+  labels:
+    app: ${{ defaults.app_name }}-auth-init
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-auth-init
+data:
+  vn-scriptsvn-authvn-initvn-sh: |
+    set -eu
+    until pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" >/dev/null 2>&1; do
+      sleep 2
+    done
+
+    database_ready=0
+    cat >/tmp/airbyte-database-ready.sql <<'SQL'
+    SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'db-airbyte')::int;
+    SQL
+    for _ in $(seq 1 180); do
+      database_ready="$(
+        psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d postgres -v ON_ERROR_STOP=1 -At -f /tmp/airbyte-database-ready.sql
+      )"
+      if [ "${database_ready}" = "1" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ "${database_ready}" != "1" ]; then
+      echo "Airbyte database was not created in time" >&2
+      exit 1
+    fi
+
+    ready=0
+    cat >/tmp/airbyte-auth-tables-ready.sql <<'SQL'
+    SELECT (
+      to_regclass('public.organization') IS NOT NULL
+      AND to_regclass('public.workspace') IS NOT NULL
+      AND to_regclass('public."user"') IS NOT NULL
+    )::int;
+    SQL
+    for _ in $(seq 1 180); do
+      ready="$(
+        psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d db-airbyte -v ON_ERROR_STOP=1 -At -f /tmp/airbyte-auth-tables-ready.sql
+      )"
+      if [ "${ready}" = "1" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ "${ready}" != "1" ]; then
+      echo "Airbyte auth tables were not created in time" >&2
+      exit 1
+    fi
+
+    seeded=0
+    cat >/tmp/airbyte-default-records-ready.sql <<'SQL'
+    SELECT (
+      EXISTS (SELECT 1 FROM organization WHERE id = '00000000-0000-0000-0000-000000000000')
+      AND EXISTS (SELECT 1 FROM "user" WHERE id = '00000000-0000-0000-0000-000000000000')
+      AND EXISTS (SELECT 1 FROM workspace WHERE tombstone = false)
+    )::int;
+    SQL
+    for _ in $(seq 1 180); do
+      seeded="$(
+        psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d db-airbyte -v ON_ERROR_STOP=1 -At -f /tmp/airbyte-default-records-ready.sql
+      )"
+      if [ "${seeded}" = "1" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ "${seeded}" != "1" ]; then
+      echo "Airbyte default organization, user, or workspace was not seeded in time" >&2
+      exit 1
+    fi
+
+    psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d db-airbyte -v ON_ERROR_STOP=1 -v admin_email="${ADMIN_EMAIL}" <<'SQL'
+    UPDATE organization
+    SET email = :'admin_email',
+        name = COALESCE(NULLIF(name, ''), 'Default Organization')
+    WHERE id = '00000000-0000-0000-0000-000000000000';
+
+    UPDATE "user"
+    SET email = :'admin_email',
+        name = COALESCE(NULLIF(name, ''), 'Default User')
+    WHERE id = '00000000-0000-0000-0000-000000000000';
+
+    UPDATE workspace
+    SET email = :'admin_email',
+        initial_setup_complete = true,
+        display_setup_wizard = false
+    WHERE tombstone = false;
+    SQL
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-server
+  labels:
+    app: ${{ defaults.app_name }}-server
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-server
+data:
+  vn-scriptsvn-waitvn-authvn-statevn-sh: |
+    set -eu
+
+    check_job="${APP_NAME}-auth-state-check"
+    kubectl delete job "${check_job}" --ignore-not-found --wait=true
+    cat <<YAML | kubectl apply -f -
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${check_job}
+    spec:
+      backoffLimit: 3
+      ttlSecondsAfterFinished: 300
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          containers:
+            - name: auth-state-check
+              image: postgres:16.4-alpine
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+                seccompProfile:
+                  type: RuntimeDefault
+              command:
+                - /bin/sh
+                - /scripts/auth-state-check.sh
+              env:
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-pg-conn-credential
+                      key: host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-pg-conn-credential
+                      key: port
+                - name: DATABASE_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-pg-conn-credential
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-pg-conn-credential
+                      key: password
+                - name: ADMIN_EMAIL
+                  value: "${ADMIN_EMAIL}"
+              volumeMounts:
+                - name: server-scripts
+                  mountPath: /scripts/auth-state-check.sh
+                  subPath: vn-scriptsvn-authvn-statevn-checkvn-sh
+                  readOnly: true
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 12Mi
+          volumes:
+            - name: server-scripts
+              configMap:
+                name: ${APP_NAME}-server
+    YAML
+
+    if ! kubectl wait --for=condition=complete --timeout=600s "job/${check_job}"; then
+      kubectl logs "job/${check_job}" --tail=200 || true
+      exit 1
+    fi
+  vn-scriptsvn-authvn-statevn-checkvn-sh: |
+    set -eu
+    until pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" >/dev/null 2>&1; do
+      sleep 2
+    done
+
+    state_ready=0
+    for _ in $(seq 1 180); do
+      state_ready="$(
+        psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d db-airbyte -v ON_ERROR_STOP=1 -At -v admin_email="${ADMIN_EMAIL}" 2>/tmp/airbyte-auth-state-check.err <<'SQL' || true
+    SELECT (
+      EXISTS (
+        SELECT 1 FROM organization
+        WHERE id = '00000000-0000-0000-0000-000000000000'
+          AND email = :'admin_email'
+      )
+      AND EXISTS (
+        SELECT 1 FROM "user"
+        WHERE id = '00000000-0000-0000-0000-000000000000'
+          AND email = :'admin_email'
+      )
+      AND EXISTS (
+        SELECT 1 FROM workspace
+        WHERE tombstone = false
+          AND email = :'admin_email'
+          AND initial_setup_complete = true
+          AND display_setup_wizard = false
+      )
+    )::int;
+    SQL
+      )"
+      if [ "${state_ready}" = "1" ]; then
+        exit 0
+      fi
+      sleep 2
+    done
+    cat /tmp/airbyte-auth-state-check.err >&2 2>/dev/null || true
+    echo "Airbyte auth state was not ready in time" >&2
+    exit 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${{ defaults.app_name }}-pg-init
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      annotations:
+        sealos.io/service-account-token-reason: "Airbyte waits for the generated PostgreSQL connection secret."
+    spec:
+      serviceAccountName: ${{ defaults.app_name }}-pg
+      automountServiceAccountToken: true
+      initContainers:
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
+                sleep 2
+              done
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+      containers:
+        - name: pg-init
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: PGPASSWORD
+              value: $(PG_PASSWORD)
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres >/dev/null 2>&1; do
+                sleep 2
+              done
+              for _ in $(seq 1 180); do
+                if psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='db-airbyte'" | grep -q 1; then
+                  exit 0
+                fi
+                if createdb -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" db-airbyte 2>/tmp/createdb.err; then
+                  exit 0
+                fi
+                sleep 2
+              done
+              cat /tmp/createdb.err >&2 2>/dev/null || true
+              echo "Airbyte database was not created in time" >&2
+              exit 1
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 25Mi
+      restartPolicy: Never
+  ttlSecondsAfterFinished: 300
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -319,46 +804,65 @@ spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: 300
   template:
+    metadata:
+      annotations:
+        sealos.io/service-account-token-reason: "Airbyte bootloader initializes auth Kubernetes secrets."
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       restartPolicy: Never
       initContainers:
-        - name: init-db-airbyte
-          image: docker.io/apecloud/spilo:16.4.0
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
-              set -eu
-              until pg_isready -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}"; do
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
                 sleep 2
               done
-              if ! psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='db-airbyte'" | grep -q 1; then
-                psql -h "${DATABASE_HOST}" -p "${DATABASE_PORT}" -U "${DATABASE_USER}" -d postgres -c 'CREATE DATABASE "db-airbyte";'
-              fi
           env:
-            - name: DATABASE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: host
-            - name: DATABASE_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: port
-            - name: DATABASE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: username
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: ${{ defaults.app_name }}-pg-conn-credential
-                  key: password
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+        - name: wait-pg-init
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              kubectl wait --for=condition=complete --timeout=600s "job/${APP_NAME}-pg-init"
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
           resources:
             limits:
               cpu: 200m
@@ -368,8 +872,18 @@ spec:
               memory: 25Mi
       containers:
         - name: bootloader
-          image: airbyte/bootloader:0.63.11
+          image: airbyte/bootloader:2.1.0
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: AIRBYTE_VERSION
               valueFrom:
@@ -405,105 +919,156 @@ spec:
               value: db-airbyte
             - name: DATABASE_URL
               value: jdbc:postgresql://$(DATABASE_HOST):$(DATABASE_PORT)/db-airbyte
+            - name: AB_AUTH_SECRET_CREATION_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_AUTH_SECRET_CREATION_ENABLED
+            - name: AB_KUBERNETES_SECRET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_KUBERNETES_SECRET_NAME
+            - name: AB_INSTANCE_ADMIN_PASSWORD
+              value: ${{ inputs.auth_admin_password }}
+            - name: INITIAL_USER_EMAIL
+              value: ${{ inputs.auth_admin_email }}
+            - name: INITIAL_USER_PASSWORD
+              value: ${{ inputs.auth_admin_password }}
+            - name: AB_INSTANCE_ADMIN_PASSWORD_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_INSTANCE_ADMIN_PASSWORD_SECRET_KEY
+            - name: AB_INSTANCE_ADMIN_CLIENT_ID
+              value: "admin"
+            - name: AB_INSTANCE_ADMIN_CLIENT_ID_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_INSTANCE_ADMIN_CLIENT_ID_SECRET_KEY
+            - name: AB_INSTANCE_ADMIN_CLIENT_SECRET
+              value: ${{ defaults.workload_api_bearer_token }}
+            - name: AB_INSTANCE_ADMIN_CLIENT_SECRET_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_INSTANCE_ADMIN_CLIENT_SECRET_SECRET_KEY
+            - name: AB_JWT_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
+            - name: AB_JWT_SIGNATURE_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AB_JWT_SIGNATURE_SECRET_KEY
+            - name: DATAPLANE_CLIENT_ID_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: DATAPLANE_CLIENT_ID_SECRET_KEY
+            - name: DATAPLANE_CLIENT_SECRET_SECRET_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: DATAPLANE_CLIENT_SECRET_SECRET_KEY
           resources:
             limits:
               cpu: "1"
-              memory: 1536Mi
+              memory: 2048Mi
             requests:
-              cpu: 200m
-              memory: 512Mi
+              cpu: 100m
+              memory: 204Mi
 
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: ${{ defaults.app_name }}-connector-builder-server
-  annotations:
-    originImageName: airbyte/connector-builder-server:0.63.11
-    deploy.cloud.sealos.io/minReplicas: "1"
-    deploy.cloud.sealos.io/maxReplicas: "1"
-  labels:
-    app: ${{ defaults.app_name }}-connector-builder-server
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-connector-builder-server
+  name: ${{ defaults.app_name }}-auth-init
 spec:
-  revisionHistoryLimit: 1
-  replicas: 1
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}-connector-builder-server
+  completions: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
   template:
-    metadata:
-      labels:
-        app: ${{ defaults.app_name }}-connector-builder-server
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
-      automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}-connector-builder-server
-          image: airbyte/connector-builder-server:0.63.11
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      initContainers:
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
+                sleep 2
+              done
           env:
-            - name: AIRBYTE_VERSION
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+      containers:
+        - name: auth-init
+          image: postgres:16.4-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - /scripts/auth-init.sh
+          env:
+            - name: DATABASE_HOST
               valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: AIRBYTE_VERSION
-            - name: MICROMETER_METRICS_ENABLED
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: host
+            - name: DATABASE_PORT
               valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: MICROMETER_METRICS_ENABLED
-            - name: MICROMETER_METRICS_STATSD_FLAVOR
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: port
+            - name: DATABASE_USER
               valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: MICROMETER_METRICS_STATSD_FLAVOR
-            - name: SEGMENT_WRITE_KEY
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: PGPASSWORD
               valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: SEGMENT_WRITE_KEY
-            - name: STATSD_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: STATSD_HOST
-            - name: STATSD_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: STATSD_PORT
-            - name: TRACKING_STRATEGY
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: TRACKING_STRATEGY
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /v1/health
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /v1/health
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 10
-          startupProbe:
-            httpGet:
-              path: /v1/health
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 10
-            failureThreshold: 30
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
+            - name: ADMIN_EMAIL
+              value: ${{ inputs.auth_admin_email }}
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-auth-init-cm
+              mountPath: /scripts/auth-init.sh
+              subPath: vn-scriptsvn-authvn-initvn-sh
+              readOnly: true
           resources:
             limits:
               cpu: 200m
@@ -511,6 +1076,10 @@ spec:
             requests:
               cpu: 20m
               memory: 25Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-auth-init-cm
+          configMap:
+            name: ${{ defaults.app_name }}-auth-init
 
 ---
 apiVersion: apps/v1
@@ -518,7 +1087,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-server
   annotations:
-    originImageName: airbyte/server:0.63.11
+    originImageName: airbyte/server:2.1.0
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -539,10 +1108,61 @@ spec:
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
       automountServiceAccountToken: false
+      initContainers:
+        - name: wait-auth-state
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - /scripts/wait-auth-state.sh
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+            - name: ADMIN_EMAIL
+              value: ${{ inputs.auth_admin_email }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-server-kube-api
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+            - name: ${{ defaults.app_name }}-server-cm
+              mountPath: /scripts/wait-auth-state.sh
+              subPath: vn-scriptsvn-waitvn-authvn-statevn-sh
+              readOnly: true
+            - name: ${{ defaults.app_name }}-server-cm
+              mountPath: /scripts/auth-state-check.sh
+              subPath: vn-scriptsvn-authvn-statevn-checkvn-sh
+              readOnly: true
       containers:
         - name: ${{ defaults.app_name }}-server
-          image: airbyte/server:0.63.11
+          image: airbyte/server:2.1.0
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: AIRBYTE_API_HOST
               valueFrom:
@@ -559,6 +1179,62 @@ spec:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: AIRBYTE_EDITION
+            - name: AIRBYTE_CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AIRBYTE_CLUSTER_TYPE
+            - name: CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: CLUSTER_TYPE
+            - name: API_AUTHORIZATION_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: API_AUTHORIZATION_ENABLED
+            - name: CONNECTOR_REGISTRY_SEED_PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: CONNECTOR_REGISTRY_SEED_PROVIDER
+            - name: ENTERPRISE_SOURCE_STUBS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: ENTERPRISE_SOURCE_STUBS_URL
+            - name: MANIFEST_SERVER_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: MANIFEST_SERVER_API_HOST
+            - name: INTERNAL_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: INTERNAL_API_HOST
+            - name: AB_INSTANCE_ADMIN_PASSWORD
+              value: ${{ inputs.auth_admin_password }}
+            - name: INITIAL_USER_EMAIL
+              value: ${{ inputs.auth_admin_email }}
+            - name: INITIAL_USER_PASSWORD
+              value: ${{ inputs.auth_admin_password }}
+            - name: AB_INSTANCE_ADMIN_CLIENT_ID
+              value: "admin"
+            - name: AB_INSTANCE_ADMIN_CLIENT_SECRET
+              value: ${{ defaults.workload_api_bearer_token }}
+            - name: AB_JWT_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
+            - name: IDENTITY_PROVIDER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: IDENTITY_PROVIDER_TYPE
+            - name: AB_COOKIE_SECURE
+              value: "true"
+            - name: AB_COOKIE_SAME_SITE
+              value: "Strict"
             - name: AIRBYTE_URL
               valueFrom:
                 configMapKeyRef:
@@ -594,6 +1270,8 @@ spec:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: SERVER_MICRONAUT_ENVIRONMENTS
+            - name: AIRBYTE_SERVER_OPTS
+              value: "-Dlog4j2.statusLoggerLevel=OFF -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -XX:+EnableDynamicAgentLoading"
             - name: SEGMENT_WRITE_KEY
               valueFrom:
                 configMapKeyRef:
@@ -638,14 +1316,6 @@ spec:
               value: "INFO"
             - name: MICRONAUT_SECURITY_ENABLED
               value: "true"
-            - name: AIRBYTE_AUTH_INSTANCE_ADMIN_USERNAME
-              value: ${{ inputs.auth_admin_username }}
-            - name: AIRBYTE_AUTH_INSTANCE_ADMIN_PASSWORD
-              value: ${{ inputs.auth_admin_password }}
-            - name: MICRONAUT_SECURITY_TOKEN_JWT_SIGNATURES_SECRET_GENERATOR_SECRET
-              value: ${{ defaults.jwt_signature_secret }}
-            - name: MICRONAUT_SECURITY_TOKEN_JWT_GENERATOR_REFRESH_TOKEN_SECRET
-              value: ${{ defaults.jwt_refresh_secret }}
             - name: JOB_MAIN_CONTAINER_CPU_REQUEST
               valueFrom:
                 configMapKeyRef:
@@ -676,16 +1346,6 @@ spec:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION
-            - name: KEYCLOAK_INTERNAL_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: KEYCLOAK_INTERNAL_HOST
-            - name: CONNECTOR_BUILDER_SERVER_API_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: CONNECTOR_BUILDER_SERVER_API_HOST
             - name: AIRBYTE_API_AUTH_HEADER_NAME
               value: "X-Airbyte-Auth"
             - name: AIRBYTE_API_AUTH_HEADER_VALUE
@@ -746,6 +1406,8 @@ spec:
               value: $(S3_BUCKET)
             - name: STORAGE_BUCKET_WORKLOAD_OUTPUT
               value: $(S3_BUCKET)
+            - name: STORAGE_BUCKET_AUDIT_LOGGING
+              value: $(S3_BUCKET)
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
@@ -770,9 +1432,24 @@ spec:
               value: db-airbyte
             - name: DATABASE_URL
               value: jdbc:postgresql://$(DATABASE_HOST):$(DATABASE_PORT)/db-airbyte
+            - name: CONFIG_DATABASE_REPLICA_URL
+              value: jdbc:postgresql://$(DATABASE_HOST):$(DATABASE_PORT)/db-airbyte
+            - name: CONFIG_DATABASE_REPLICA_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: username
+            - name: CONFIG_DATABASE_REPLICA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-pg-conn-credential
+                  key: password
           ports:
             - name: http
               containerPort: 8001
+              protocol: TCP
+            - name: management
+              containerPort: 8085
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -799,18 +1476,37 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 512Mi
+              memory: 1024Mi
             requests:
               cpu: 20m
-              memory: 51Mi
-
+              memory: 102Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-server-kube-api
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3607
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace
+        - name: ${{ defaults.app_name }}-server-cm
+          configMap:
+            name: ${{ defaults.app_name }}-server
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-worker
   annotations:
-    originImageName: airbyte/worker:0.63.11
+    originImageName: airbyte/worker:2.1.0
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -826,19 +1522,84 @@ spec:
     metadata:
       labels:
         app: ${{ defaults.app_name }}-worker
+      annotations:
+        sealos.io/service-account-token-reason: "Airbyte worker launches Kubernetes workloads."
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
+      initContainers:
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
+                sleep 2
+              done
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
       containers:
         - name: ${{ defaults.app_name }}-worker
-          image: airbyte/worker:0.63.11
+          image: airbyte/worker:2.1.0
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: AIRBYTE_VERSION
               valueFrom:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: AIRBYTE_VERSION
+            - name: AIRBYTE_CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AIRBYTE_CLUSTER_TYPE
+            - name: CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: CLUSTER_TYPE
+            - name: AB_JWT_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
+            - name: MAX_CHECK_WORKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: MAX_CHECK_WORKERS
+            - name: MAX_SYNC_WORKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: MAX_SYNC_WORKERS
             - name: CONFIG_ROOT
               valueFrom:
                 configMapKeyRef:
@@ -908,6 +1669,10 @@ spec:
                   key: TEMPORAL_WORKER_PORTS
             - name: LOG_LEVEL
               value: "INFO"
+            - name: AIRBYTE_INTERNAL_API_AUTH_TYPE
+              value: "INTERNAL_CLIENT_TOKEN"
+            - name: AIRBYTE_INTERNAL_API_AUTH_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
             - name: JOB_KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1057,6 +1822,8 @@ spec:
               value: $(S3_BUCKET)
             - name: STORAGE_BUCKET_WORKLOAD_OUTPUT
               value: $(S3_BUCKET)
+            - name: STORAGE_BUCKET_AUDIT_LOGGING
+              value: $(S3_BUCKET)
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
@@ -1123,7 +1890,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-cron
   annotations:
-    originImageName: airbyte/cron:0.63.11
+    originImageName: airbyte/cron:2.1.0
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -1142,16 +1909,78 @@ spec:
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
       automountServiceAccountToken: false
+      initContainers:
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
+                sleep 2
+              done
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-cron-kube-api
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
       containers:
         - name: ${{ defaults.app_name }}-cron
-          image: airbyte/cron:0.63.11
+          image: airbyte/cron:2.1.0
           imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - exec /bin/bash /opt/airbyte/cron-entrypoint.sh
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: AIRBYTE_VERSION
               valueFrom:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: AIRBYTE_VERSION
+            - name: AIRBYTE_CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: AIRBYTE_CLUSTER_TYPE
+            - name: CLUSTER_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: CLUSTER_TYPE
+            - name: AB_JWT_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
             - name: CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION
               valueFrom:
                 configMapKeyRef:
@@ -1197,6 +2026,15 @@ spec:
                 configMapKeyRef:
                   name: ${{ defaults.app_name }}
                   key: TRACKING_STRATEGY
+            - name: INTERNAL_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: ${{ defaults.app_name }}
+                  key: INTERNAL_API_HOST
+            - name: AIRBYTE_INTERNAL_API_AUTH_TYPE
+              value: "INTERNAL_CLIENT_TOKEN"
+            - name: AIRBYTE_INTERNAL_API_AUTH_SIGNATURE_SECRET
+              value: ${{ defaults.jwt_signature_secret }}
             - name: WORKFLOW_FAILURE_RESTART_DELAY_SECONDS
               valueFrom:
                 configMapKeyRef:
@@ -1246,10 +2084,37 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 512Mi
+              memory: 1024Mi
             requests:
               cpu: 20m
-              memory: 51Mi
+              memory: 102Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-cron-cm
+              mountPath: /opt/airbyte/cron-entrypoint.sh
+              subPath: vn-optvn-airbytevn-cronvn-entrypointvn-sh
+      volumes:
+        - name: ${{ defaults.app_name }}-cron-kube-api
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3607
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace
+        - name: ${{ defaults.app_name }}-cron-cm
+          configMap:
+            name: ${{ defaults.app_name }}-cron
+            items:
+              - key: vn-optvn-airbytevn-cronvn-entrypointvn-sh
+                path: vn-optvn-airbytevn-cronvn-entrypointvn-sh
 
 ---
 apiVersion: apps/v1
@@ -1257,7 +2122,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-temporal
   annotations:
-    originImageName: temporalio/auto-setup:1.23.0
+    originImageName: temporalio/auto-setup:1.29.7
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -1276,17 +2141,52 @@ spec:
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
       automountServiceAccountToken: false
+      initContainers:
+        - name: wait-pg-conn-secret
+          image: bitnamilegacy/kubectl:1.33.4
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              until kubectl get secret "${APP_NAME}-pg-conn-credential" >/dev/null 2>&1; do
+                sleep 2
+              done
+          env:
+            - name: APP_NAME
+              value: ${{ defaults.app_name }}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 12Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-temporal-kube-api
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
       containers:
         - name: ${{ defaults.app_name }}-temporal
-          image: temporalio/auto-setup:1.23.0
+          image: temporalio/auto-setup:1.29.7
           imagePullPolicy: IfNotPresent
           env:
             - name: AUTO_SETUP
               value: "true"
             - name: DB
-              value: "postgresql"
+              value: "postgres12"
             - name: DYNAMIC_CONFIG_FILE_PATH
-              value: "config/dynamicconfig/development.yaml"
+              value: "/etc/temporal/config/dynamicconfig/development.yaml"
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
@@ -1333,8 +2233,9 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 30
           volumeMounts:
-            - name: dynamic-config
-              mountPath: /etc/temporal/config/dynamicconfig
+            - name: ${{ defaults.app_name }}-temporal-cm
+              mountPath: /etc/temporal/config/dynamicconfig/development.yaml
+              subPath: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developmentvn-yaml
           resources:
             limits:
               cpu: 200m
@@ -1343,127 +2244,28 @@ spec:
               cpu: 20m
               memory: 25Mi
       volumes:
-        - name: dynamic-config
+        - name: ${{ defaults.app_name }}-temporal-kube-api
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3607
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace
+        - name: ${{ defaults.app_name }}-temporal-cm
           configMap:
             name: ${{ defaults.app_name }}-temporal
             items:
-              - key: development.yaml
-                path: development.yaml
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ${{ defaults.app_name }}-webapp
-  annotations:
-    originImageName: airbyte/webapp:0.63.11
-    deploy.cloud.sealos.io/minReplicas: "1"
-    deploy.cloud.sealos.io/maxReplicas: "1"
-  labels:
-    app: ${{ defaults.app_name }}-webapp
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-webapp
-spec:
-  revisionHistoryLimit: 1
-  replicas: 1
-  selector:
-    matchLabels:
-      app: ${{ defaults.app_name }}-webapp
-  template:
-    metadata:
-      labels:
-        app: ${{ defaults.app_name }}-webapp
-    spec:
-      serviceAccountName: ${{ defaults.app_name }}-admin
-      automountServiceAccountToken: false
-      containers:
-        - name: ${{ defaults.app_name }}-webapp
-          image: airbyte/webapp:0.63.11
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: TRACKING_STRATEGY
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: TRACKING_STRATEGY
-            - name: AIRBYTE_SERVER_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: AIRBYTE_SERVER_HOST
-            - name: KEYCLOAK_INTERNAL_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: KEYCLOAK_INTERNAL_HOST
-            - name: CONNECTOR_BUILDER_API_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: CONNECTOR_BUILDER_API_HOST
-            - name: AIRBYTE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: AIRBYTE_VERSION
-            - name: API_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: API_URL
-            - name: CONNECTOR_BUILDER_API_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: ${{ defaults.app_name }}
-                  key: CONNECTOR_BUILDER_API_URL
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /index.html
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-          startupProbe:
-            httpGet:
-              path: /index.html
-              port: http
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 1
-            failureThreshold: 30
-          resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 10m
-              memory: 12Mi
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${{ defaults.app_name }}-connector-builder-server
-  labels:
-    app: ${{ defaults.app_name }}-connector-builder-server
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-connector-builder-server
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: http
-      protocol: TCP
-  selector:
-    app: ${{ defaults.app_name }}-connector-builder-server
+              - key: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developmentvn-yaml
+                path: vn-etcvn-temporalvn-configvn-dynamicconfigvn-developmentvn-yaml
 
 ---
 apiVersion: v1
@@ -1500,29 +2302,12 @@ spec:
     app: ${{ defaults.app_name }}-temporal
 
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${{ defaults.app_name }}-webapp
-  labels:
-    app: ${{ defaults.app_name }}-webapp
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-webapp
-spec:
-  ports:
-    - name: http
-      port: 80
-      targetPort: http
-      protocol: TCP
-  selector:
-    app: ${{ defaults.app_name }}-webapp
-
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${{ defaults.app_name }}-webapp
+  name: ${{ defaults.app_name }}-server
   labels:
-    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-webapp
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-server
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -1550,9 +2335,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: ${{ defaults.app_name }}-webapp
+                name: ${{ defaults.app_name }}-server
                 port:
-                  number: 80
+                  number: 8001
   tls:
     - hosts:
         - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
@@ -1566,3 +2351,7 @@ metadata:
 spec:
   data:
     url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+  displayType: normal
+  icon: "https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/airbyte/logo.svg"
+  name: ${{ defaults.app_name }}
+  type: link

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -285,13 +285,12 @@ data:
   IDENTITY_PROVIDER_TYPE: "simple"
   AIRBYTE_URL: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}"
   AIRBYTE_SERVER_HOST: "${{ defaults.app_name }}-server:8001"
-  API_URL: "/api/v1/"
   CONFIG_API_HOST: "http://${{ defaults.app_name }}-server:8001"
   CONFIG_ROOT: "/configs"
   CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.35.15.001"
   INTERNAL_API_HOST: "http://${{ defaults.app_name }}-server:8001"
   WORKLOAD_API_HOST: "http://${{ defaults.app_name }}-server:8001"
-  AIRBYTE_API_HOST: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/api/public"
+  AIRBYTE_API_HOST: "https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/api/public/v1"
   JOB_MAIN_CONTAINER_CPU_LIMIT: ""
   JOB_MAIN_CONTAINER_CPU_REQUEST: ""
   JOB_MAIN_CONTAINER_MEMORY_LIMIT: ""
@@ -974,10 +973,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: 2048Mi
+              memory: 2G
             requests:
               cpu: 100m
-              memory: 204Mi
+              memory: 200Mi
 
 ---
 apiVersion: batch/v1
@@ -1226,6 +1225,12 @@ spec:
               value: ${{ defaults.workload_api_bearer_token }}
             - name: AB_JWT_SIGNATURE_SECRET
               value: ${{ defaults.jwt_signature_secret }}
+            - name: MICRONAUT_SECURITY_TOKEN_JWT_GENERATOR_REFRESH_TOKEN_SECRET
+              value: ${{ defaults.jwt_refresh_secret }}
+            - name: MICRONAUT_SECURITY_TOKEN_GENERATOR_ACCESS_TOKEN_EXPIRATION
+              value: "86400"
+            - name: MICRONAUT_SECURITY_TOKEN_COOKIE_COOKIE_MAX_AGE
+              value: "PT24H"
             - name: IDENTITY_PROVIDER_TYPE
               valueFrom:
                 configMapKeyRef:
@@ -1476,10 +1481,10 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 1024Mi
+              memory: 1G
             requests:
               cpu: 20m
-              memory: 102Mi
+              memory: 100Mi
       volumes:
         - name: ${{ defaults.app_name }}-server-kube-api
           projected:
@@ -1526,7 +1531,7 @@ spec:
         sealos.io/service-account-token-reason: "Airbyte worker launches Kubernetes workloads."
     spec:
       serviceAccountName: ${{ defaults.app_name }}-admin
-      automountServiceAccountToken: true
+      automountServiceAccountToken: false
       initContainers:
         - name: wait-pg-conn-secret
           image: bitnamilegacy/kubectl:1.33.4
@@ -1558,6 +1563,10 @@ spec:
             requests:
               cpu: 10m
               memory: 12Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-worker-kube-api
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
       containers:
         - name: ${{ defaults.app_name }}-worker
           image: airbyte/worker:2.1.0
@@ -1883,6 +1892,27 @@ spec:
             requests:
               cpu: 20m
               memory: 51Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-worker-kube-api
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+      volumes:
+        - name: ${{ defaults.app_name }}-worker-kube-api
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 3607
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        fieldPath: metadata.namespace
 
 ---
 apiVersion: apps/v1
@@ -2084,10 +2114,10 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 1024Mi
+              memory: 1G
             requests:
               cpu: 20m
-              memory: 102Mi
+              memory: 100Mi
           volumeMounts:
             - name: ${{ defaults.app_name }}-cron-cm
               mountPath: /opt/airbyte/cron-entrypoint.sh

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -552,6 +552,27 @@ data:
         initial_setup_complete = true,
         display_setup_wizard = false
     WHERE tombstone = false;
+
+    INSERT INTO permission (id, user_id, workspace_id, created_at, updated_at, permission_type)
+    SELECT gen_random_uuid(),
+           '00000000-0000-0000-0000-000000000000'::uuid,
+           workspace.id,
+           NOW(),
+           NOW(),
+           'workspace_admin'::permission_type
+    FROM workspace
+    WHERE workspace.tombstone = false
+      AND NOT EXISTS (
+        SELECT 1
+        FROM permission
+        WHERE permission.user_id = '00000000-0000-0000-0000-000000000000'::uuid
+          AND permission.workspace_id = workspace.id
+          AND permission.permission_type IN (
+            'workspace_admin'::permission_type,
+            'workspace_editor'::permission_type,
+            'workspace_reader'::permission_type
+          )
+      );
     SQL
 
 ---

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -704,6 +704,22 @@ data:
             'workspace_reader'::permission_type
           )
       )
+      AND EXISTS (
+        SELECT 1
+        FROM actor_definition
+        WHERE tombstone = false
+          AND actor_type = 'source'::actor_type
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM actor_definition
+        WHERE tombstone = false
+          AND actor_type = 'destination'::actor_type
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM actor_definition_version
+      )
     )::int;
     SQL
       )"

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -496,6 +496,7 @@ data:
     cat >/tmp/airbyte-auth-tables-ready.sql <<'SQL'
     SELECT (
       to_regclass('public.organization') IS NOT NULL
+      AND to_regclass('public.permission') IS NOT NULL
       AND to_regclass('public.workspace') IS NOT NULL
       AND to_regclass('public."user"') IS NOT NULL
     )::int;
@@ -690,6 +691,18 @@ data:
           AND email = :'admin_email'
           AND initial_setup_complete = true
           AND display_setup_wizard = false
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM permission
+        JOIN workspace ON permission.workspace_id = workspace.id
+        WHERE permission.user_id = '00000000-0000-0000-0000-000000000000'::uuid
+          AND workspace.tombstone = false
+          AND permission.permission_type IN (
+            'workspace_admin'::permission_type,
+            'workspace_editor'::permission_type,
+            'workspace_reader'::permission_type
+          )
       )
     )::int;
     SQL

--- a/template/airbyte/index.yaml
+++ b/template/airbyte/index.yaml
@@ -731,6 +731,35 @@ data:
     cat /tmp/airbyte-auth-state-check.err >&2 2>/dev/null || true
     echo "Airbyte auth state was not ready in time" >&2
     exit 1
+  vn-scriptsvn-patchvn-webappvn-sh: |
+    set -eu
+
+    jar_path="/app/airbyte-app/lib/io.airbyte-airbyte-server-2.1.0.jar"
+    work_dir="$(mktemp -d)"
+    cleanup() {
+      rm -rf "${work_dir}"
+    }
+    trap cleanup EXIT
+
+    cd "${work_dir}"
+    jar xf "${jar_path}" webapp/index.html
+    python <<'PY'
+    path = "webapp/index.html"
+    marker = "__AIRBYTE_FIREFOX_RESIZE_PATCH__"
+    with open(path, "r") as f:
+        html = f.read()
+
+    if marker not in html:
+        patch = """<script>(function(){if(window.__AIRBYTE_FIREFOX_RESIZE_PATCH__)return;if(!/Firefox\\/\\d+/.test(navigator.userAgent)||!window.ResizeObserver)return;window.__AIRBYTE_FIREFOX_RESIZE_PATCH__=true;var NativeResizeObserver=window.ResizeObserver;window.ResizeObserver=function(callback){var frame=0,lastEntries;return new NativeResizeObserver(function(entries,observer){lastEntries=entries;if(frame)return;frame=requestAnimationFrame(function(){frame=0;callback(lastEntries,observer);});});};window.ResizeObserver.prototype=NativeResizeObserver.prototype;})();</script>"""
+        if "</head>" not in html:
+            raise SystemExit("webapp/index.html is missing </head>")
+        html = html.replace("</head>", patch + "</head>", 1)
+        with open(path, "w") as f:
+            f.write(html)
+    PY
+    jar uf "${jar_path}" webapp/index.html
+
+    exec /entrypoint.sh /app/airbyte-app/bin/airbyte-server
 
 ---
 apiVersion: batch/v1
@@ -1202,6 +1231,9 @@ spec:
         - name: ${{ defaults.app_name }}-server
           image: airbyte/server:2.1.0
           imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - /scripts/patch-webapp.sh
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -1212,6 +1244,11 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-server-cm
+              mountPath: /scripts/patch-webapp.sh
+              subPath: vn-scriptsvn-patchvn-webappvn-sh
+              readOnly: true
           env:
             - name: AIRBYTE_API_HOST
               valueFrom:

--- a/template/apitable/index.yaml
+++ b/template/apitable/index.yaml
@@ -32,52 +32,13 @@ spec:
       type: string
       value: ${{ random(32) }}
   inputs:
-    apitable_s3_provider:
-      description: S3-compatible storage backend for APITable attachments, images, and uploads.
-      type: choice
-      default: sealos-objectstorage
-      required: true
-      options:
-        - sealos-objectstorage
-        - external-s3
-    external_s3_endpoint:
-      description: External S3-compatible API endpoint, for example https://s3.amazonaws.com or https://s3.example.com.
-      type: string
-      default: ''
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
-    external_s3_public_endpoint:
-      description: Public S3-compatible endpoint used in generated asset URLs.
-      type: string
-      default: ''
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
-    external_s3_access_key:
-      description: Access key for the external S3-compatible bucket.
-      type: string
-      default: ''
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
-    external_s3_secret_key:
-      description: Secret key for the external S3-compatible bucket.
-      type: string
-      default: ''
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
-    external_s3_bucket:
-      description: Existing external S3-compatible bucket name.
-      type: string
-      default: ''
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
-    external_s3_region:
-      description: Region for the external S3-compatible bucket.
-      type: string
-      default: us-east-1
-      required: true
-      if: inputs.apitable_s3_provider === 'external-s3'
+    use_sealos_objectstorage:
+      description: Use the Sealos ObjectStorage bucket for APITable attachments, images, and uploads.
+      type: boolean
+      default: 'true'
+      required: false
 ---
-${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
+${{ if(inputs.use_sealos_objectstorage === 'true') }}
 apiVersion: objectstorage.sealos.io/v1
 kind: ObjectStorageBucket
 metadata:
@@ -136,7 +97,8 @@ metadata:
   name: ${{ defaults.app_name }}-mysql
   labels:
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
-    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30
+    clusterversion.kubeblocks.io/name: ac-mysql-8.0.30-1
+    kb.io/database: ac-mysql-8.0.30-1
     sealos-db-provider-cr: ${{ defaults.app_name }}-mysql
 spec:
   affinity:
@@ -146,7 +108,7 @@ spec:
     topologyKeys:
       - kubernetes.io/hostname
   clusterDefinitionRef: apecloud-mysql
-  clusterVersionRef: ac-mysql-8.0.30
+  clusterVersionRef: ac-mysql-8.0.30-1
   componentSpecs:
     - componentDefRef: mysql
       monitor: true
@@ -336,11 +298,111 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: ${{ defaults.app_name }}-init-appdata
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-init-appdata
+    app: ${{ defaults.app_name }}-init-appdata
+data:
+  vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh: |
+    set -eu
+    export MYSQL_PWD="${MYSQL_PASSWORD}"
+    mysql_base="mysql --protocol=TCP -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USER} ${MYSQL_DATABASE} --batch --skip-column-names --connect-timeout=5"
+    for i in $(seq 1 180); do
+      ready_tables="$(${mysql_base} -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('apitable_db_changelog','apitable_datasheet','apitable_node','apitable_space','apitable_user');" 2>/dev/null || true)"
+      ready_marker="$(${mysql_base} -e "SELECT COUNT(*) FROM apitable_db_changelog WHERE ID = 'V1.13-20250116-001';" 2>/dev/null || true)"
+      if [ "${ready_tables}" = "5" ] && [ "${ready_marker}" = "1" ]; then
+        exit 0
+      fi
+      echo "Waiting for APITable database migrations (${i}/180)"
+      sleep 2
+    done
+    echo "APITable database migrations did not become ready" >&2
+    exit 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-backend-server
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-backend-server
+    app: ${{ defaults.app_name }}-backend-server
+data:
+  vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh: |
+    set -eu
+    export MYSQL_PWD="${MYSQL_PASSWORD}"
+    mysql_base="mysql --protocol=TCP -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USER} ${MYSQL_DATABASE} --batch --skip-column-names --connect-timeout=5"
+    for i in $(seq 1 180); do
+      ready_tables="$(${mysql_base} -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('apitable_db_changelog','apitable_datasheet','apitable_node','apitable_space','apitable_user');" 2>/dev/null || true)"
+      ready_marker="$(${mysql_base} -e "SELECT COUNT(*) FROM apitable_db_changelog WHERE ID = 'V1.13-20250116-001';" 2>/dev/null || true)"
+      if [ "${ready_tables}" = "5" ] && [ "${ready_marker}" = "1" ]; then
+        exit 0
+      fi
+      echo "Waiting for APITable database migrations (${i}/180)"
+      sleep 2
+    done
+    echo "APITable database migrations did not become ready" >&2
+    exit 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-room-server
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-room-server
+    app: ${{ defaults.app_name }}-room-server
+data:
+  vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh: |
+    set -eu
+    export MYSQL_PWD="${MYSQL_PASSWORD}"
+    mysql_base="mysql --protocol=TCP -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USER} ${MYSQL_DATABASE} --batch --skip-column-names --connect-timeout=5"
+    for i in $(seq 1 180); do
+      ready_tables="$(${mysql_base} -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('apitable_db_changelog','apitable_datasheet','apitable_node','apitable_space','apitable_user');" 2>/dev/null || true)"
+      ready_marker="$(${mysql_base} -e "SELECT COUNT(*) FROM apitable_db_changelog WHERE ID = 'V1.13-20250116-001';" 2>/dev/null || true)"
+      if [ "${ready_tables}" = "5" ] && [ "${ready_marker}" = "1" ]; then
+        exit 0
+      fi
+      echo "Waiting for APITable database migrations (${i}/180)"
+      sleep 2
+    done
+    echo "APITable database migrations did not become ready" >&2
+    exit 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${{ defaults.app_name }}-databus-server
+  labels:
+    cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-databus-server
+    app: ${{ defaults.app_name }}-databus-server
+data:
+  vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh: |
+    set -eu
+    export MYSQL_PWD="${MYSQL_PASSWORD}"
+    mysql_base="mysql --protocol=TCP -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USER} ${MYSQL_DATABASE} --batch --skip-column-names --connect-timeout=5"
+    for i in $(seq 1 180); do
+      ready_tables="$(${mysql_base} -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ('apitable_db_changelog','apitable_datasheet','apitable_node','apitable_space','apitable_user');" 2>/dev/null || true)"
+      ready_marker="$(${mysql_base} -e "SELECT COUNT(*) FROM apitable_db_changelog WHERE ID = 'V1.13-20250116-001';" 2>/dev/null || true)"
+      if [ "${ready_tables}" = "5" ] && [ "${ready_marker}" = "1" ]; then
+        exit 0
+      fi
+      echo "Waiting for APITable database migrations (${i}/180)"
+      sleep 2
+    done
+    echo "APITable database migrations did not become ready" >&2
+    exit 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: ${{ defaults.app_name }}-gateway
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-gateway
     app: ${{ defaults.app_name }}-gateway
 data:
+  vn-etcvn-nginxvn-templatesvn-apitablevn-entrypointvn-sh: |
+    set -eu
+    envsubst '$OBJECT_STORAGE_EXTERNAL_ENDPOINT' < /etc/nginx/templates/apitable.conf.template > /etc/nginx/conf.d/default.conf
+    exec nginx -g 'daemon off;'
   vn-etcvn-nginxvn-templatesvn-apitablevn-confvn-template: |
     log_format json_combined escape=json '{"@timestamp":"$time_iso8601","@source":"$server_addr","@nginx_fields":{"remote_addr":"$remote_addr","body_bytes_sent":"$body_bytes_sent","request_time":"$request_time","status":"$status","host":"$host","uri":"$uri","server":"$server_name","request_uri":"$request_uri","request_method":"$request_method","http_referrer":"$http_referer","http_x_forwarded_for":"$http_x_forwarded_for","http_user_agent":"$http_user_agent","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","upstream_addr":"$upstream_addr"}}';
     access_log /dev/stdout json_combined;
@@ -576,7 +638,7 @@ kind: Job
 metadata:
   name: ${{ defaults.app_name }}-mysql-init
   annotations:
-    originImageName: mysql:8.0.32
+    originImageName: mysql:9.7.1
   labels:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}-mysql-init
     app: ${{ defaults.app_name }}-mysql-init
@@ -589,11 +651,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-mysql-init
-          image: mysql:8.0.32
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -634,8 +694,8 @@ spec:
                 -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
           resources:
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 20m
+              memory: 25Mi
             limits:
               cpu: 200m
               memory: 256Mi
@@ -646,7 +706,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}-rabbitmq
   annotations:
-    originImageName: rabbitmq:3.11.9-management
+    originImageName: rabbitmq:4.3.2-management
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.resource-override-source: APITable official docs recommend 4 CPUs and 8GB RAM for the Docker deployment host; RabbitMQ requires 512Mi to cold start consistently with the APITable stack.
@@ -666,12 +726,10 @@ spec:
         app: ${{ defaults.app_name }}-rabbitmq
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: ${{ defaults.app_name }}-rabbitmq
-          image: rabbitmq:3.11.9-management
+          image: rabbitmq:4.3.2-management
           imagePullPolicy: IfNotPresent
           env:
             - name: RABBITMQ_DEFAULT_USER
@@ -716,8 +774,8 @@ spec:
             failureThreshold: 60
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 50m
+              memory: 51Mi
             limits:
               cpu: 500m
               memory: 512Mi
@@ -772,11 +830,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       initContainers:
         - name: ${{ defaults.app_name }}-wait-mysql
-          image: mysql:8.0.32
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -809,8 +865,8 @@ spec:
               done
           resources:
             requests:
-              cpu: 20m
-              memory: 32Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
@@ -850,11 +906,11 @@ spec:
               value: update
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 50m
+              memory: 102Mi
             limits:
               cpu: 500m
-              memory: 768Mi
+              memory: 1024Mi
   ttlSecondsAfterFinished: 300
 ---
 apiVersion: batch/v1
@@ -876,11 +932,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       initContainers:
-        - name: ${{ defaults.app_name }}-wait-mysql
-          image: mysql:8.0.32
+        - name: ${{ defaults.app_name }}-wait-db-ready
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -903,21 +957,22 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: password
+            - name: MYSQL_DATABASE
+              value: apitable
           command:
             - /bin/sh
-            - -c
-            - |
-              set -eu
-              until mysqladmin ping -h"${MYSQL_HOST}" -P"${MYSQL_PORT}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --silent; do
-                sleep 2
-              done
+            - /opt/apitable/wait-db-ready.sh
           resources:
             requests:
-              cpu: 20m
-              memory: 32Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-init-appdata-cm
+              mountPath: /opt/apitable/wait-db-ready.sh
+              subPath: vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh
       containers:
         - name: ${{ defaults.app_name }}-init-appdata
           image: apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b
@@ -950,11 +1005,15 @@ spec:
               value: apitable
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 50m
+              memory: 102Mi
             limits:
               cpu: 500m
-              memory: 768Mi
+              memory: 1024Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-init-appdata-cm
+          configMap:
+            name: ${{ defaults.app_name }}-init-appdata
   ttlSecondsAfterFinished: 300
 ---
 apiVersion: apps/v1
@@ -981,11 +1040,9 @@ spec:
         app: ${{ defaults.app_name }}-backend-server
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       initContainers:
-        - name: ${{ defaults.app_name }}-wait-deps
-          image: busybox:1.36.1
+        - name: ${{ defaults.app_name }}-wait-db-ready
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -993,21 +1050,58 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: host
+            - name: MYSQL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MYSQL_DATABASE
+              value: apitable
+          command:
+            - /bin/sh
+            - /opt/apitable/wait-db-ready.sh
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-backend-server-cm
+              mountPath: /opt/apitable/wait-db-ready.sh
+              subPath: vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh
+        - name: ${{ defaults.app_name }}-wait-deps
+          image: busybox:1.38.0
+          imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
             - |
               set -eu
-              until nc -z "${MYSQL_HOST}" 3306; do sleep 2; done
               until nc -z ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local 6379; do sleep 2; done
               until nc -z ${{ defaults.app_name }}-rabbitmq.${{ SEALOS_NAMESPACE }}.svc.cluster.local 5672; do sleep 2; done
           resources:
             requests:
               cpu: 10m
-              memory: 16Mi
+              memory: 12Mi
             limits:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-backend-server-cm
+          configMap:
+            name: ${{ defaults.app_name }}-backend-server
       containers:
         - name: ${{ defaults.app_name }}-backend-server
           image: apitable/backend-server:v1.13.0-beta.1_2016
@@ -1065,27 +1159,28 @@ spec:
               value: ${{ defaults.rabbitmq_password }}
             - name: RABBITMQ_VHOST
               value: /
-${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
-            - name: AWS_ACCESS_KEY
+${{ if(inputs.use_sealos_objectstorage === 'true') }}
+            - name: S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key
                   key: accessKey
-            - name: AWS_ACCESS_SECRET
+            - name: S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key
                   key: secretKey
+            - name: AWS_ACCESS_KEY
+              value: $(S3_ACCESS_KEY_ID)
+            - name: AWS_ACCESS_SECRET
+              value: $(S3_SECRET_ACCESS_KEY)
             - name: ASSETS_BUCKET
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
                   key: bucket
             - name: OSS_BUCKET_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: object-storage-key-${{ SEALOS_SERVICE_ACCOUNT }}-${{ defaults.app_name }}
-                  key: bucket
+              value: $(ASSETS_BUCKET)
             - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -1097,22 +1192,6 @@ ${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
               value: https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
             - name: AWS_REGION
               value: us-east-1
-${{ endif() }}
-${{ if(inputs.apitable_s3_provider === 'external-s3') }}
-            - name: AWS_ACCESS_KEY
-              value: ${{ inputs.external_s3_access_key }}
-            - name: AWS_ACCESS_SECRET
-              value: ${{ inputs.external_s3_secret_key }}
-            - name: ASSETS_BUCKET
-              value: ${{ inputs.external_s3_bucket }}
-            - name: OSS_BUCKET_NAME
-              value: ${{ inputs.external_s3_bucket }}
-            - name: AWS_ENDPOINT
-              value: ${{ inputs.external_s3_endpoint }}
-            - name: ASSETS_URL
-              value: ${{ inputs.external_s3_public_endpoint }}
-            - name: AWS_REGION
-              value: ${{ inputs.external_s3_region }}
 ${{ endif() }}
           ports:
             - containerPort: 8081
@@ -1142,10 +1221,10 @@ ${{ endif() }}
             failureThreshold: 6
           resources:
             requests:
-              cpu: 200m
-              memory: 512Mi
+              cpu: 100m
+              memory: 102Mi
             limits:
-              cpu: 1000m
+              cpu: 1
               memory: 1024Mi
 ---
 apiVersion: v1
@@ -1186,11 +1265,9 @@ spec:
         app: ${{ defaults.app_name }}-room-server
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       initContainers:
-        - name: ${{ defaults.app_name }}-wait-deps
-          image: busybox:1.36.1
+        - name: ${{ defaults.app_name }}-wait-db-ready
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -1198,21 +1275,58 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: host
+            - name: MYSQL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MYSQL_DATABASE
+              value: apitable
+          command:
+            - /bin/sh
+            - /opt/apitable/wait-db-ready.sh
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-room-server-cm
+              mountPath: /opt/apitable/wait-db-ready.sh
+              subPath: vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh
+        - name: ${{ defaults.app_name }}-wait-deps
+          image: busybox:1.38.0
+          imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
             - |
               set -eu
-              until nc -z "${MYSQL_HOST}" 3306; do sleep 2; done
               until nc -z ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local 6379; do sleep 2; done
               until nc -z ${{ defaults.app_name }}-rabbitmq.${{ SEALOS_NAMESPACE }}.svc.cluster.local 5672; do sleep 2; done
           resources:
             requests:
               cpu: 10m
-              memory: 16Mi
+              memory: 12Mi
             limits:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-room-server-cm
+          configMap:
+            name: ${{ defaults.app_name }}-room-server
       containers:
         - name: ${{ defaults.app_name }}-room-server
           image: apitable/room-server:v1.13.0-beta.1_2016
@@ -1278,7 +1392,7 @@ spec:
               value: ${{ defaults.rabbitmq_password }}
             - name: RABBITMQ_VHOST
               value: /
-${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
+${{ if(inputs.use_sealos_objectstorage === 'true') }}
             - name: OSS_BUCKET
               valueFrom:
                 secretKeyRef:
@@ -1291,12 +1405,6 @@ ${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
                   key: external
             - name: OSS_HOST
               value: https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
-${{ endif() }}
-${{ if(inputs.apitable_s3_provider === 'external-s3') }}
-            - name: OSS_BUCKET
-              value: ${{ inputs.external_s3_bucket }}
-            - name: OSS_HOST
-              value: ${{ inputs.external_s3_public_endpoint }}
 ${{ endif() }}
           ports:
             - containerPort: 3333
@@ -1338,10 +1446,10 @@ ${{ endif() }}
             failureThreshold: 6
           resources:
             requests:
-              cpu: 200m
-              memory: 512Mi
+              cpu: 100m
+              memory: 102Mi
             limits:
-              cpu: 1000m
+              cpu: 1
               memory: 1024Mi
 ---
 apiVersion: v1
@@ -1393,8 +1501,6 @@ spec:
         app: ${{ defaults.app_name }}-web-server
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-web-server
           image: apitable/web-server:v1.13.0-beta.1_2016
@@ -1473,11 +1579,9 @@ spec:
         app: ${{ defaults.app_name }}-databus-server
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       initContainers:
-        - name: ${{ defaults.app_name }}-wait-mysql
-          image: busybox:1.36.1
+        - name: ${{ defaults.app_name }}-wait-db-ready
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -1485,12 +1589,46 @@ spec:
                 secretKeyRef:
                   name: ${{ defaults.app_name }}-mysql-conn-credential
                   key: host
+            - name: MYSQL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: port
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${{ defaults.app_name }}-mysql-conn-credential
+                  key: password
+            - name: MYSQL_DATABASE
+              value: apitable
+          command:
+            - /bin/sh
+            - /opt/apitable/wait-db-ready.sh
+          resources:
+            requests:
+              cpu: 10m
+              memory: 12Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: ${{ defaults.app_name }}-databus-server-cm
+              mountPath: /opt/apitable/wait-db-ready.sh
+              subPath: vn-optvn-apitablevn-waitvn-dbvn-readyvn-sh
+        - name: ${{ defaults.app_name }}-wait-deps
+          image: busybox:1.38.0
+          imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
             - |
               set -eu
-              until nc -z "${MYSQL_HOST}" 3306; do sleep 2; done
+              until nc -z ${{ defaults.app_name }}-redis-redis-redis.${{ SEALOS_NAMESPACE }}.svc.cluster.local 6379; do sleep 2; done
           resources:
             requests:
               cpu: 20m
@@ -1498,6 +1636,10 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
+      volumes:
+        - name: ${{ defaults.app_name }}-databus-server-cm
+          configMap:
+            name: ${{ defaults.app_name }}-databus-server
       containers:
         - name: ${{ defaults.app_name }}-databus-server
           image: apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600
@@ -1602,14 +1744,12 @@ spec:
         app: ${{ defaults.app_name }}-imageproxy-server
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-imageproxy-server
           image: apitable/imageproxy-server:v0.13.4-alpha_build13
           imagePullPolicy: IfNotPresent
           env:
-${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
+${{ if(inputs.use_sealos_objectstorage === 'true') }}
             - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -1617,10 +1757,6 @@ ${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
                   key: external
             - name: BASEURL
               value: https://$(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
-${{ endif() }}
-${{ if(inputs.apitable_s3_provider === 'external-s3') }}
-            - name: BASEURL
-              value: ${{ inputs.external_s3_public_endpoint }}
 ${{ endif() }}
           ports:
             - containerPort: 8080
@@ -1644,8 +1780,8 @@ ${{ endif() }}
             failureThreshold: 6
           resources:
             requests:
-              cpu: 20m
-              memory: 32Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
@@ -1669,7 +1805,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-gateway
   annotations:
-    originImageName: nginx:1.27.5-alpine
+    originImageName: nginx:1.31.2-alpine
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -1687,30 +1823,24 @@ spec:
         app: ${{ defaults.app_name }}-gateway
     spec:
       automountServiceAccountToken: false
-      imagePullSecrets:
-        - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}-gateway
-          image: nginx:1.27.5-alpine
+          image: nginx:1.31.2-alpine
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
-            - -c
-            - |
-              set -eu
-              envsubst '$OBJECT_STORAGE_EXTERNAL_ENDPOINT' < /etc/nginx/templates/apitable.conf.template > /etc/nginx/conf.d/default.conf
-              nginx -g 'daemon off;'
+            - -ec
+          args:
+            - exec /bin/sh /etc/nginx/templates/apitable-entrypoint.sh
           env:
-${{ if(inputs.apitable_s3_provider === 'sealos-objectstorage') }}
-            - name: OBJECT_STORAGE_EXTERNAL_ENDPOINT
+${{ if(inputs.use_sealos_objectstorage === 'true') }}
+            - name: BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT
               valueFrom:
                 secretKeyRef:
                   name: object-storage-key
                   key: external
-${{ endif() }}
-${{ if(inputs.apitable_s3_provider === 'external-s3') }}
             - name: OBJECT_STORAGE_EXTERNAL_ENDPOINT
-              value: ${{ inputs.external_s3_public_endpoint }}
+              value: $(BACKEND_STORAGE_MINIO_EXTERNAL_ENDPOINT)
 ${{ endif() }}
           ports:
             - containerPort: 80
@@ -1740,17 +1870,20 @@ ${{ endif() }}
             failureThreshold: 6
           resources:
             requests:
-              cpu: 20m
-              memory: 32Mi
+              cpu: 10m
+              memory: 12Mi
             limits:
               cpu: 100m
               memory: 128Mi
           volumeMounts:
-            - name: vn-etcvn-nginxvn-templatesvn-apitablevn-confvn-template
+            - name: ${{ defaults.app_name }}-gateway-cm
               mountPath: /etc/nginx/templates/apitable.conf.template
               subPath: vn-etcvn-nginxvn-templatesvn-apitablevn-confvn-template
+            - name: ${{ defaults.app_name }}-gateway-cm
+              mountPath: /etc/nginx/templates/apitable-entrypoint.sh
+              subPath: vn-etcvn-nginxvn-templatesvn-apitablevn-entrypointvn-sh
       volumes:
-        - name: vn-etcvn-nginxvn-templatesvn-apitablevn-confvn-template
+        - name: ${{ defaults.app_name }}-gateway-cm
           configMap:
             name: ${{ defaults.app_name }}-gateway
 ---


### PR DESCRIPTION
## Summary

Refresh only these Sealos templates:

- AFFiNE
- Airbyte
- APITable

This branch is rebuilt from the latest `upstream/kb-0.9` and intentionally excludes the other template updates from the previous broad refresh branch.

## Changes

- Update `template/affine/index.yaml` to the validated AFFiNE refresh, including the PostgreSQL database readiness gate and `0.26.7` image update.
- Update `template/airbyte/index.yaml` to the validated Airbyte runtime refresh.
- Update `template/apitable/index.yaml` to the validated APITable refresh, with Sealos object storage toggle preserved and resource values aligned with the current Sealos ladder.

## Scope Guard

`git diff upstream/kb-0.9...HEAD --name-status` contains only:

- `template/affine/index.yaml`
- `template/airbyte/index.yaml`
- `template/apitable/index.yaml`

## Verification

- [x] `DOCKER_TO_SEALOS_ARTIFACTS=<affine,airbyte,apitable> /opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/quality_gate.py`
- [x] `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/check_consistency.py --skill SKILL.md --references references --rules-file references/rules-registry.yaml --artifacts <affine,airbyte,apitable>`
- [x] `git diff --check`

