### PR TITLE
chore: refresh Sealos template image versions

### DIFF
--- a/.sealos/update-reports/blocked-template-list.md
+++ b/.sealos/update-reports/blocked-template-list.md
@@ -1,0 +1,134 @@
+# Blocked Template List
+
+Source: `.sealos/update-reports/template-update-status.json`
+
+Blocked templates: 121
+Blocked candidates: 228
+
+These templates were excluded from the submitted image refresh diff because
+per-artifact docker-to-sealos validation reported existing template rule
+failures beyond the scoped image version update.
+
+| Template | Blocked candidates |
+| --- | ---: |
+| `Reactive-Resume` | 2 |
+| `Readeck` | 1 |
+| `anything-llm` | 1 |
+| `appflowy` | 4 |
+| `authentik` | 1 |
+| `billionmail` | 4 |
+| `budibase` | 4 |
+| `bunkerweb` | 4 |
+| `bytebase` | 1 |
+| `casdoor` | 2 |
+| `changedetection` | 1 |
+| `chatgpt-next-web` | 1 |
+| `chatgpt-on-wechat` | 1 |
+| `chatnio` | 1 |
+| `chatwoot` | 1 |
+| `code-server` | 1 |
+| `coze-studio` | 6 |
+| `crawl4ai` | 1 |
+| `crmeb` | 1 |
+| `cronicle` | 1 |
+| `dataease` | 2 |
+| `dbgate` | 1 |
+| `deeplx` | 1 |
+| `dify` | 4 |
+| `directus` | 3 |
+| `docuseal` | 1 |
+| `drawdb` | 1 |
+| `edgequake` | 2 |
+| `elasticsearch` | 1 |
+| `emqx` | 1 |
+| `erpnext` | 4 |
+| `ever-gauzy` | 1 |
+| `fastgpt` | 5 |
+| `fastgpt-milvus` | 5 |
+| `fastgpt-pro` | 6 |
+| `featbit-standard` | 4 |
+| `firecrawl` | 3 |
+| `flarum` | 1 |
+| `flowise` | 1 |
+| `formbricks` | 1 |
+| `frp` | 1 |
+| `gitea` | 1 |
+| `glitchtip` | 1 |
+| `grafana-otel` | 3 |
+| `halo` | 1 |
+| `harbor` | 6 |
+| `hasura` | 2 |
+| `headscale` | 1 |
+| `illa-builder` | 1 |
+| `immich` | 1 |
+| `insforge` | 3 |
+| `kanboard` | 1 |
+| `kaneo` | 2 |
+| `keycloak` | 1 |
+| `keystone` | 1 |
+| `kuvasz` | 1 |
+| `laf` | 1 |
+| `langfuse` | 4 |
+| `librechat` | 1 |
+| `liebianbao` | 2 |
+| `llmgateway` | 6 |
+| `lobe-chat-db` | 1 |
+| `mastodon` | 2 |
+| `metabase` | 1 |
+| `mlflow` | 1 |
+| `n8n` | 2 |
+| `nacos` | 1 |
+| `nexus` | 2 |
+| `nocodb` | 1 |
+| `nofx` | 1 |
+| `odysseus` | 2 |
+| `open-webui` | 1 |
+| `openclaw` | 1 |
+| `openlist` | 1 |
+| `outline` | 1 |
+| `overleaf` | 1 |
+| `pageplug` | 1 |
+| `pangolin` | 1 |
+| `pdf2zh` | 1 |
+| `penpot` | 3 |
+| `perplexica` | 1 |
+| `phpmyadmin` | 1 |
+| `planka` | 1 |
+| `pocket-id` | 1 |
+| `pocketbase` | 1 |
+| `posthog` | 2 |
+| `postiz` | 4 |
+| `presenton` | 1 |
+| `privatebin` | 1 |
+| `quay` | 2 |
+| `refly` | 1 |
+| `registry` | 2 |
+| `rocketchat` | 1 |
+| `rocketchat-micro` | 7 |
+| `rsshub` | 1 |
+| `rybbit` | 1 |
+| `s-pdf` | 1 |
+| `signoz` | 4 |
+| `skardi` | 1 |
+| `strapi` | 1 |
+| `sub2api` | 1 |
+| `supabase` | 11 |
+| `surveyking` | 2 |
+| `tailchat` | 1 |
+| `tianji` | 1 |
+| `tolgee` | 1 |
+| `tooljet` | 2 |
+| `tradingagents` | 1 |
+| `tududi` | 1 |
+| `twenty` | 1 |
+| `typo3` | 1 |
+| `umami` | 1 |
+| `uptime-kuma` | 1 |
+| `webos` | 1 |
+| `wewe-rss` | 1 |
+| `woocommerce` | 2 |
+| `wordpress` | 1 |
+| `wrenai` | 5 |
+| `yourls` | 2 |
+| `zitadel` | 1 |
+| `zot` | 2 |

--- a/.sealos/update-reports/docker-to-sealos-artifact-validation.json
+++ b/.sealos/update-reports/docker-to-sealos-artifact-validation.json
@@ -1,0 +1,1634 @@
+[
+  {
+    "artifact": "template/Reactive-Resume/index.yaml",
+    "ok": false,
+    "issue_count": 46,
+    "sample_issues": [
+      "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:34: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:165: metadata.annotations.originImageName must match a container image in the workload",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:182: managed app workloads must explicitly set automountServiceAccountToken: false",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:212: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:217: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:231: container ${{ defaults.app_name }}-minio limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+    ]
+  },
+  {
+    "artifact": "template/Readeck/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:75: container imagePullPolicy must be IfNotPresent",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:100: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/anything-llm/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml:156: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/appflowy/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+    ]
+  },
+  {
+    "artifact": "template/appwrite/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/authentik/index.yaml",
+    "ok": false,
+    "issue_count": 12,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:119: container pg-init must define resources limits/requests from the Sealos ladder",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:187: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:302: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:417: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/billionmail/index.yaml",
+    "ok": false,
+    "issue_count": 16,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/budibase/index.yaml",
+    "ok": false,
+    "issue_count": 23,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+    ]
+  },
+  {
+    "artifact": "template/bunkerweb/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+    ]
+  },
+  {
+    "artifact": "template/bytebase/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:75: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:124: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:127: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/casdoor/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:48: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:513: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/changedetection/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:56: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:111: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/chatgpt-next-web/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:79: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:141: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:142: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:158: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:176: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/chatgpt-on-wechat/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:68: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:169: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:172: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/chatnio/index.yaml",
+    "ok": false,
+    "issue_count": 20,
+    "sample_issues": [
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:79: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:98: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:149: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:152: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/chatwoot/index.yaml",
+    "ok": false,
+    "issue_count": 17,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:130: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:172: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:190: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:200: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:203: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:348: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:349: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:351: database component redis-sentinel resources.requests.cpu must be 50m"
+    ]
+  },
+  {
+    "artifact": "template/cobalt/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/code-server/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:35: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:120: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+      "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:178: App resource spec.type must be 'link'"
+    ]
+  },
+  {
+    "artifact": "template/coze-studio/index.yaml",
+    "ok": false,
+    "issue_count": 15,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/crawl4ai/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:96: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:97: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/crmeb/index.yaml",
+    "ok": false,
+    "issue_count": 13,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:226: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:227: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:229: database component redis-sentinel resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:230: database component redis-sentinel resources.requests.memory must be 51Mi",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:279: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:281: ConfigMap metadata.labels.app is required and must match metadata.name"
+    ]
+  },
+  {
+    "artifact": "template/cronicle/index.yaml",
+    "ok": false,
+    "issue_count": 5,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:25: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:121: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:141: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/dataease/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:30: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:34: container init-config must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:120: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:210: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:213: Service spec.ports entries must define a non-empty name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:348: container mysql-init must define resources limits/requests from the Sealos ladder",
+      "- [R001/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: forbidden ':latest' image tag",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: container must explicitly set imagePullPolicy: IfNotPresent"
+    ]
+  },
+  {
+    "artifact": "template/dbgate/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:134: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:137: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+      "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:173: App resource spec.type must be 'link'"
+    ]
+  },
+  {
+    "artifact": "template/deeplx/index.yaml",
+    "ok": false,
+    "issue_count": 7,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:57: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:75: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:88: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:91: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:111: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/derper/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/dify/index.yaml",
+    "ok": false,
+    "issue_count": 48,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/directus/index.yaml",
+    "ok": false,
+    "issue_count": 12,
+    "sample_issues": [
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+    ]
+  },
+  {
+    "artifact": "template/docuseal/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml:203: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/dolibarr/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/drawdb/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml:72: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/edgequake/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:294: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:392: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/elasticsearch/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:57: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/emqx/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml:81: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/erpnext/index.yaml",
+    "ok": false,
+    "issue_count": 17,
+    "sample_issues": [
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/ever-gauzy/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:137: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:200: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:437: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:529: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/evolution-api/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/fastgpt-milvus/index.yaml",
+    "ok": false,
+    "issue_count": 35,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/fastgpt-pro/index.yaml",
+    "ok": false,
+    "issue_count": 34,
+    "sample_issues": [
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+    ]
+  },
+  {
+    "artifact": "template/fastgpt/index.yaml",
+    "ok": false,
+    "issue_count": 32,
+    "sample_issues": [
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+    ]
+  },
+  {
+    "artifact": "template/featbit-standard/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/firecrawl/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/flarum/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml:150: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/flowise/index.yaml",
+    "ok": false,
+    "issue_count": 5,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:147: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:157: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:400: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:403: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/formbricks/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:358: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:507: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:511: container ${{ defaults.app_name }} requests.memory must be 25Mi when limits.memory is 256Mi"
+    ]
+  },
+  {
+    "artifact": "template/frp/index.yaml",
+    "ok": false,
+    "issue_count": 16,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:17: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:53: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:55: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:79: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+      "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:104: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:156: Service metadata.name must match spec.selector.app",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:157: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/ghost/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/gitea/index.yaml",
+    "ok": false,
+    "issue_count": 12,
+    "sample_issues": [
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:67: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:71: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:140: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/glitchtip/index.yaml",
+    "ok": false,
+    "issue_count": 21,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:52: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:363: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:366: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/grafana-otel/index.yaml",
+    "ok": false,
+    "issue_count": 12,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/grafana/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/halo/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:87: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:88: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:129: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:132: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:151: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/harbor/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/hasura/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:276: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:291: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/headscale/index.yaml",
+    "ok": false,
+    "issue_count": 9,
+    "sample_issues": [
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:221: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:223: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1156: Ingress backend service.name must match Ingress metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1158: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1240: Ingress backend service.name must match Ingress metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1242: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1257: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1282: Ingress backend service.name must match Ingress metadata.name"
+    ]
+  },
+  {
+    "artifact": "template/illa-builder/index.yaml",
+    "ok": false,
+    "issue_count": 9,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:100: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/immich/index.yaml",
+    "ok": false,
+    "issue_count": 5,
+    "sample_issues": [
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:223: database component postgresql resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:224: database component postgresql resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:226: database component postgresql resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:227: database component postgresql resources.requests.memory must be 51Mi",
+      "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:238: PVC storage request must be <= 1Gi"
+    ]
+  },
+  {
+    "artifact": "template/insforge/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/jellyfin/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/kanboard/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml:200: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/kaneo/index.yaml",
+    "ok": false,
+    "issue_count": 15,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:162: Service spec.ports entries must define a non-empty name",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:182: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R037/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:199: PostgreSQL secret reference '${{ defaults.app_name}}-pg-conn-credential' must match the Cluster metadata.name-derived secret (${{ defaults.app_name }}-pg-conn-credential)"
+    ]
+  },
+  {
+    "artifact": "template/keycloak/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:139: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:152: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:159: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:222: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:224: database env 'KC_DB_URL_HOST' must use secret key 'endpoint' from an approved database secret",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:294: Service metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name/spec.selector.app",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:296: Service metadata.name must match spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/keystone/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml:138: container pg-init must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/kuvasz/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:132: container pg-init must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:329: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi"
+    ]
+  },
+  {
+    "artifact": "template/laf/index.yaml",
+    "ok": false,
+    "issue_count": 58,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:5: Template spec.categories must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:50: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:139: database component mongodb resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:140: database component mongodb resources.requests.memory must be 51Mi",
+      "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:149: PVC storage request must be <= 1Gi",
+      "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:188: managed app workloads must define metadata.annotations.originImageName",
+      "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:193: managed app workloads must explicitly set revisionHistoryLimit: 1",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:203: automountServiceAccountToken must be false for managed app workloads"
+    ]
+  },
+  {
+    "artifact": "template/langflow/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/langfuse/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+    ]
+  },
+  {
+    "artifact": "template/librechat/index.yaml",
+    "ok": false,
+    "issue_count": 15,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:32: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:50: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:66: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:249: Service spec.ports entries must define a non-empty name",
+      "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:260: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+      "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:283: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest"
+    ]
+  },
+  {
+    "artifact": "template/liebianbao/index.yaml",
+    "ok": false,
+    "issue_count": 36,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:5: Template spec.categories must be defined and non-empty",
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:8: Template spec.gitRepo must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:47: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:72: container initializer must define resources limits/requests from the Sealos ladder",
+      "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:77: metadata.annotations.originImageName must match a container image in the workload",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:131: container imagePullPolicy must be IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:221: container ${{ defaults.app_name }} requests.cpu must be 100m when limits.cpu is 1"
+    ]
+  },
+  {
+    "artifact": "template/listmonk/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/litellm/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/llmgateway/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+    ]
+  },
+  {
+    "artifact": "template/lobe-chat-db/index.yaml",
+    "ok": false,
+    "issue_count": 7,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:162: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:278: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:312: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:326: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:329: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:348: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/logto/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/loki/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/mastodon/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:561: container mastodon-setup limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:562: container mastodon-setup limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:590: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:742: container ${{ defaults.app_name }}-web limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:743: container ${{ defaults.app_name }}-web limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:768: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:926: container ${{ defaults.app_name }}-sidekiq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:927: container ${{ defaults.app_name }}-sidekiq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/matomo/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/mautic/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/meilisearch/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/metabase/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml:251: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/minecraft/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/mlflow/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml:214: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/n8n/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:540: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:601: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:729: public-image managed app workloads must omit template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/nacos/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:494: container ${{ defaults.app_name }}-console limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:631: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/netbird/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/nexus/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml:94: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/nocodb/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml:192: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/node-red/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/nofx/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:201: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:439: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/odysseus/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:286: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:363: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/open-webui/index.yaml",
+    "ok": false,
+    "issue_count": 20,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container copy-data must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container init-data must define resources limits/requests from the Sealos ladder",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:89: container must explicitly set imagePullPolicy: IfNotPresent"
+    ]
+  },
+  {
+    "artifact": "template/openclaw/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:57: container init-openclaw-data must define resources limits/requests from the Sealos ladder",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:221: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:222: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/openlist/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:120: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:123: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/openobserve/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/outline/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml:371: container pgsql-init must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/overleaf/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:330: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:331: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:450: App resource spec.type must be 'link'"
+    ]
+  },
+  {
+    "artifact": "template/pageplug/index.yaml",
+    "ok": false,
+    "issue_count": 8,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:100: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:119: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/pangolin/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:44: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:127: container ${{ defaults.app_name }}-pangolin limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:181: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/paperclip/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/pdf2zh/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:70: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:81: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:84: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/penpot/index.yaml",
+    "ok": false,
+    "issue_count": 27,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+    ]
+  },
+  {
+    "artifact": "template/perplexica/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:48: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:165: container ${{ defaults.app_name }}-searxng limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:207: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:210: Service spec.ports entries must define a non-empty name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:216: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:218: ConfigMap metadata.labels.app is required and must match metadata.name"
+    ]
+  },
+  {
+    "artifact": "template/phpmyadmin/index.yaml",
+    "ok": false,
+    "issue_count": 7,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:85: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:116: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:119: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/planka/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml:211: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/pocket-id/index.yaml",
+    "ok": false,
+    "issue_count": 12,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:52: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:99: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:102: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/pocketbase/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:147: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:151: Service spec.ports entries must define a non-empty name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:201: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:204: Ingress backend service.name must match Ingress metadata.name"
+    ]
+  },
+  {
+    "artifact": "template/posthog/index.yaml",
+    "ok": false,
+    "issue_count": 32,
+    "sample_issues": [
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:322: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:323: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:463: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:538: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:539: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:612: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:625: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:627: container ${{ defaults.app_name }} requests.cpu must be 50m when limits.cpu is 500m"
+    ]
+  },
+  {
+    "artifact": "template/postiz/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/presenton/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:96: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/prestashop/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/privatebin/index.yaml",
+    "ok": false,
+    "issue_count": 13,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:31: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:33: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:244: container take-data-dir-ownership must define resources limits/requests from the Sealos ladder",
+      "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:249: metadata.annotations.originImageName must match a container image in the workload",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:263: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:286: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+    ]
+  },
+  {
+    "artifact": "template/pterodactyl/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/quay/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:141: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:396: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:532: container ${{ defaults.app_name }}-init-admin must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/refly/index.yaml",
+    "ok": false,
+    "issue_count": 25,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:155: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:165: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:172: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:283: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:284: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:286: database component redis-sentinel resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:287: database component redis-sentinel resources.requests.memory must be 51Mi",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:367: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/registry/index.yaml",
+    "ok": false,
+    "issue_count": 17,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.categories must be defined and non-empty",
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:49: managed app workloads must explicitly set automountServiceAccountToken: false",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:153: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:156: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/rocketchat-micro/index.yaml",
+    "ok": false,
+    "issue_count": 18,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/rocketchat/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:196: managed app workloads must explicitly set automountServiceAccountToken: false",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:260: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:261: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:283: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/rsshub/index.yaml",
+    "ok": false,
+    "issue_count": 15,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:73: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:85: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:119: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:122: Service spec.ports entries must define a non-empty name",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:150: managed app workloads must explicitly set automountServiceAccountToken: false",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:176: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/rybbit/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:124: container pg-init must define resources limits/requests from the Sealos ladder",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:254: public-image managed app workloads must omit template.spec.imagePullSecrets",
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:258: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+      "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:370: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-clickhouse must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-postgres must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/s-pdf/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:82: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:428: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:431: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/signoz/index.yaml",
+    "ok": false,
+    "issue_count": 51,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+    ]
+  },
+  {
+    "artifact": "template/skardi/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml:135: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/stalwart/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/strapi/index.yaml",
+    "ok": false,
+    "issue_count": 17,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:153: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:164: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:171: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:183: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:185: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:702: container strapi-build limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:703: container strapi-build limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:784: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+    ]
+  },
+  {
+    "artifact": "template/sub2api/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml:205: container pgsql-init must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/supabase/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/surveyking/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:212: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:219: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:220: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:247: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:250: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/tailchat/index.yaml",
+    "ok": false,
+    "issue_count": 21,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:5: Template spec.categories must be defined and non-empty",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:87: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:96: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:108: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:110: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:123: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/tianji/index.yaml",
+    "ok": false,
+    "issue_count": 13,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.categories must be defined and non-empty",
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:67: managed app workloads must explicitly set automountServiceAccountToken: false",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:81: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:91: container ${{ defaults.app_name }} requests.cpu must be 20m when limits.cpu is 200m",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:92: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/tolgee/index.yaml",
+    "ok": false,
+    "issue_count": 10,
+    "sample_issues": [
+      "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:185: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:195: container must explicitly set imagePullPolicy: IfNotPresent",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:273: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:285: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:290: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:316: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+    ]
+  },
+  {
+    "artifact": "template/tooljet/index.yaml",
+    "ok": false,
+    "issue_count": 6,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:243: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:291: container wait-for-postgres must define resources limits/requests from the Sealos ladder",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:443: container tooljet-migrate limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:445: container tooljet-migrate requests.cpu must be 100m when limits.cpu is 1",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:756: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:829: App resource spec.type must be 'link'"
+    ]
+  },
+  {
+    "artifact": "template/tradingagents/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container install-runtime limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+    ]
+  },
+  {
+    "artifact": "template/trendradar/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/tududi/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml:239: App resource spec.type must be 'link'"
+    ]
+  },
+  {
+    "artifact": "template/twenty/index.yaml",
+    "ok": false,
+    "issue_count": 23,
+    "sample_issues": [
+      "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:141: PVC storage request must be <= 1Gi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:145: container pgsql-init must define resources limits/requests from the Sealos ladder",
+      "- [R027/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:180: pg-init Job for non-default PostgreSQL databases must include readiness wait (for example pg_isready) and idempotent create logic (exists check before create)",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:282: database component redis-sentinel resources.limits.cpu must be 500m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:283: database component redis-sentinel resources.limits.memory must be 512Mi",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:285: database component redis-sentinel resources.requests.cpu must be 50m",
+      "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:286: database component redis-sentinel resources.requests.memory must be 51Mi",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:311: container fix-permissions must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/typebot/index.yaml",
+    "ok": true,
+    "issue_count": 0,
+    "sample_issues": []
+  },
+  {
+    "artifact": "template/typo3/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml:143: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/umami/index.yaml",
+    "ok": false,
+    "issue_count": 9,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:90: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:103: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:104: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:120: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/uptime-kuma/index.yaml",
+    "ok": false,
+    "issue_count": 9,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:100: Service spec.ports entries must define a non-empty name",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+      "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+    ]
+  },
+  {
+    "artifact": "template/webos/index.yaml",
+    "ok": false,
+    "issue_count": 3,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:114: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:117: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/wewe-rss/index.yaml",
+    "ok": false,
+    "issue_count": 18,
+    "sample_issues": [
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:33: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:124: container mysql-init must define resources limits/requests from the Sealos ladder",
+      "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:180: managed app workloads must explicitly set revisionHistoryLimit: 1",
+      "- [R028/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:192: container name 'app' must exactly match metadata.name '${{ defaults.app_name }}' for managed app workloads",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:205: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:215: container app requests.cpu must be 50m when limits.cpu is 500m",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:216: container app requests.memory must be 51Mi when limits.memory is 512Mi",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:227: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/woocommerce/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml:141: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+    ]
+  },
+  {
+    "artifact": "template/wordpress/index.yaml",
+    "ok": false,
+    "issue_count": 11,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:72: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:74: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:88: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:89: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:118: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:121: Service spec.ports entries must define a non-empty name"
+    ]
+  },
+  {
+    "artifact": "template/wrenai/index.yaml",
+    "ok": false,
+    "issue_count": 51,
+    "sample_issues": [
+      "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+      "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+      "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+      "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+      "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+      "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+      "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+    ]
+  },
+  {
+    "artifact": "template/yourls/index.yaml",
+    "ok": false,
+    "issue_count": 4,
+    "sample_issues": [
+      "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:130: container mysql-init must define resources limits/requests from the Sealos ladder",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:302: Ingress backend service.name must match Ingress metadata.name",
+      "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:304: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name"
+    ]
+  },
+  {
+    "artifact": "template/zitadel/index.yaml",
+    "ok": false,
+    "issue_count": 2,
+    "sample_issues": [
+      "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:147: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+      "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:253: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+    ]
+  },
+  {
+    "artifact": "template/zot/index.yaml",
+    "ok": false,
+    "issue_count": 1,
+    "sample_issues": [
+      "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+    ]
+  }
+]

--- a/.sealos/update-reports/template-update-queue.json
+++ b/.sealos/update-reports/template-update-queue.json
@@ -1,0 +1,14353 @@
+{
+  "generated_at": "2026-07-08T11:01:47.668228+00:00",
+  "repo": "/Users/longnv/bin/repo/templates-version-refresh-20260708",
+  "source_report": "template-version-updates.json",
+  "template_count": 147,
+  "candidate_count": 273,
+  "templates": [
+    {
+      "template": "Reactive-Resume",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "Reactive-Resume",
+          "image": "amruthpillai/reactive-resume:v4.1.2",
+          "repository": "amruthpillai/reactive-resume",
+          "current_tag": "v4.1.2",
+          "candidate_tag": "v5.2.2",
+          "candidate_image": "amruthpillai/reactive-resume:v5.2.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "Reactive-Resume",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+              "line": 351,
+              "key": "image",
+              "image": "amruthpillai/reactive-resume:v4.1.2",
+              "repository": "amruthpillai/reactive-resume",
+              "tag": "v4.1.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:34: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:165: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:182: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:212: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:217: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:231: container ${{ defaults.app_name }}-minio limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        },
+        {
+          "template": "Reactive-Resume",
+          "image": "ghcr.io/browserless/chromium:v2.11.0",
+          "repository": "ghcr.io/browserless/chromium",
+          "current_tag": "v2.11.0",
+          "candidate_tag": "v2.54.2",
+          "candidate_image": "ghcr.io/browserless/chromium:v2.54.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "Reactive-Resume",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+              "line": 290,
+              "key": "image",
+              "image": "ghcr.io/browserless/chromium:v2.11.0",
+              "repository": "ghcr.io/browserless/chromium",
+              "tag": "v2.11.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:34: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:165: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:182: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:212: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:217: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:231: container ${{ defaults.app_name }}-minio limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "Readeck",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "Readeck",
+          "image": "codeberg.org/readeck/readeck:0.16.0",
+          "repository": "codeberg.org/readeck/readeck",
+          "current_tag": "0.16.0",
+          "candidate_tag": "0.22.3",
+          "candidate_image": "codeberg.org/readeck/readeck:0.22.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "Readeck",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml",
+              "line": 36,
+              "key": "originImageName",
+              "image": "codeberg.org/readeck/readeck:0.16.0",
+              "repository": "codeberg.org/readeck/readeck",
+              "tag": "0.16.0",
+              "digest": null
+            },
+            {
+              "template": "Readeck",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml",
+              "line": 64,
+              "key": "image",
+              "image": "codeberg.org/readeck/readeck:0.16.0",
+              "repository": "codeberg.org/readeck/readeck",
+              "tag": "0.16.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:75: container imagePullPolicy must be IfNotPresent",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "anything-llm",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "anything-llm",
+          "image": "mintplexlabs/anythingllm:1.14.0",
+          "repository": "mintplexlabs/anythingllm",
+          "current_tag": "1.14.0",
+          "candidate_tag": "1.15.0",
+          "candidate_image": "mintplexlabs/anythingllm:1.15.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "anything-llm",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml",
+              "line": 75,
+              "key": "originImageName",
+              "image": "mintplexlabs/anythingllm:1.14.0",
+              "repository": "mintplexlabs/anythingllm",
+              "tag": "1.14.0",
+              "digest": null
+            },
+            {
+              "template": "anything-llm",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml",
+              "line": 100,
+              "key": "image",
+              "image": "mintplexlabs/anythingllm:1.14.0",
+              "repository": "mintplexlabs/anythingllm",
+              "tag": "1.14.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml:156: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "appflowy",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "appflowy",
+          "image": "appflowyinc/appflowy_cloud:0.15.22",
+          "repository": "appflowyinc/appflowy_cloud",
+          "current_tag": "0.15.22",
+          "candidate_tag": "0.16.5",
+          "candidate_image": "appflowyinc/appflowy_cloud:0.16.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 491,
+              "key": "originImageName",
+              "image": "appflowyinc/appflowy_cloud:0.15.22",
+              "repository": "appflowyinc/appflowy_cloud",
+              "tag": "0.15.22",
+              "digest": null
+            },
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 511,
+              "key": "image",
+              "image": "appflowyinc/appflowy_cloud:0.15.22",
+              "repository": "appflowyinc/appflowy_cloud",
+              "tag": "0.15.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "image": "appflowyinc/appflowy_web:0.14.9",
+          "repository": "appflowyinc/appflowy_web",
+          "current_tag": "0.14.9",
+          "candidate_tag": "0.15.5",
+          "candidate_image": "appflowyinc/appflowy_web:0.15.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 820,
+              "key": "originImageName",
+              "image": "appflowyinc/appflowy_web:0.14.9",
+              "repository": "appflowyinc/appflowy_web",
+              "tag": "0.14.9",
+              "digest": null
+            },
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 840,
+              "key": "image",
+              "image": "appflowyinc/appflowy_web:0.14.9",
+              "repository": "appflowyinc/appflowy_web",
+              "tag": "0.14.9",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "image": "appflowyinc/appflowy_worker:0.15.22",
+          "repository": "appflowyinc/appflowy_worker",
+          "current_tag": "0.15.22",
+          "candidate_tag": "0.16.5",
+          "candidate_image": "appflowyinc/appflowy_worker:0.16.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 692,
+              "key": "originImageName",
+              "image": "appflowyinc/appflowy_worker:0.15.22",
+              "repository": "appflowyinc/appflowy_worker",
+              "tag": "0.15.22",
+              "digest": null
+            },
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 712,
+              "key": "image",
+              "image": "appflowyinc/appflowy_worker:0.15.22",
+              "repository": "appflowyinc/appflowy_worker",
+              "tag": "0.15.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "image": "appflowyinc/gotrue:0.15.22",
+          "repository": "appflowyinc/gotrue",
+          "current_tag": "0.15.22",
+          "candidate_tag": "0.16.5",
+          "candidate_image": "appflowyinc/gotrue:0.16.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 356,
+              "key": "originImageName",
+              "image": "appflowyinc/gotrue:0.15.22",
+              "repository": "appflowyinc/gotrue",
+              "tag": "0.15.22",
+              "digest": null
+            },
+            {
+              "template": "appflowy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+              "line": 376,
+              "key": "image",
+              "image": "appflowyinc/gotrue:0.15.22",
+              "repository": "appflowyinc/gotrue",
+              "tag": "0.15.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "appwrite",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "appwrite",
+          "image": "appwrite/appwrite:1.9.0",
+          "repository": "appwrite/appwrite",
+          "current_tag": "1.9.0",
+          "candidate_tag": "1.9.5",
+          "candidate_image": "appwrite/appwrite:1.9.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 285,
+              "key": "originImageName",
+              "image": "appwrite/appwrite:1.9.0",
+              "repository": "appwrite/appwrite",
+              "tag": "1.9.0",
+              "digest": null
+            },
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 356,
+              "key": "image",
+              "image": "appwrite/appwrite:1.9.0",
+              "repository": "appwrite/appwrite",
+              "tag": "1.9.0",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "appwrite",
+          "image": "appwrite/console:7.8.26",
+          "repository": "appwrite/console",
+          "current_tag": "7.8.26",
+          "candidate_tag": "8.7.19",
+          "candidate_image": "appwrite/console:8.7.19",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 556,
+              "key": "originImageName",
+              "image": "appwrite/console:7.8.26",
+              "repository": "appwrite/console",
+              "tag": "7.8.26",
+              "digest": null
+            },
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 577,
+              "key": "image",
+              "image": "appwrite/console:7.8.26",
+              "repository": "appwrite/console",
+              "tag": "7.8.26",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "appwrite",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 311,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "appwrite",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+              "line": 333,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "authentik",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "authentik",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "current_tag": "2025.12.3",
+          "candidate_tag": "2026.5.4",
+          "candidate_image": "ghcr.io/goauthentik/server:2026.5.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "authentik",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+              "line": 175,
+              "key": "originImageName",
+              "image": "ghcr.io/goauthentik/server:2025.12.3",
+              "repository": "ghcr.io/goauthentik/server",
+              "tag": "2025.12.3",
+              "digest": null
+            },
+            {
+              "template": "authentik",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+              "line": 195,
+              "key": "image",
+              "image": "ghcr.io/goauthentik/server:2025.12.3",
+              "repository": "ghcr.io/goauthentik/server",
+              "tag": "2025.12.3",
+              "digest": null
+            },
+            {
+              "template": "authentik",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+              "line": 290,
+              "key": "originImageName",
+              "image": "ghcr.io/goauthentik/server:2025.12.3",
+              "repository": "ghcr.io/goauthentik/server",
+              "tag": "2025.12.3",
+              "digest": null
+            },
+            {
+              "template": "authentik",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+              "line": 310,
+              "key": "image",
+              "image": "ghcr.io/goauthentik/server:2025.12.3",
+              "repository": "ghcr.io/goauthentik/server",
+              "tag": "2025.12.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:119: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:187: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:302: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:417: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "billionmail",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "billionmail",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "current_tag": "3.5.4",
+          "candidate_tag": "3.5.7",
+          "candidate_image": "alpine/openssl:3.5.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "billionmail",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+              "line": 6468,
+              "key": "image",
+              "image": "alpine/openssl:3.5.4",
+              "repository": "alpine/openssl",
+              "tag": "3.5.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "repository": "billionmail/core",
+          "current_tag": "4.9.3",
+          "candidate_tag": "4.9.5",
+          "candidate_image": "billionmail/core:4.9.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "billionmail",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+              "line": 6434,
+              "key": "originImageName",
+              "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+              "repository": "billionmail/core",
+              "tag": "4.9.3",
+              "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+            },
+            {
+              "template": "billionmail",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+              "line": 7033,
+              "key": "image",
+              "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+              "repository": "billionmail/core",
+              "tag": "4.9.3",
+              "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "image": "python:3.12.12-alpine",
+          "repository": "python",
+          "current_tag": "3.12.12-alpine",
+          "candidate_tag": "3.14.6-alpine",
+          "candidate_image": "python:3.14.6-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "billionmail",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+              "line": 6672,
+              "key": "image",
+              "image": "python:3.12.12-alpine",
+              "repository": "python",
+              "tag": "3.12.12-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+          "repository": "roundcube/roundcubemail",
+          "current_tag": "1.6.11-fpm-alpine",
+          "candidate_tag": "1.7.2-fpm-alpine",
+          "candidate_image": "roundcube/roundcubemail:1.7.2-fpm-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "billionmail",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+              "line": 6974,
+              "key": "image",
+              "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+              "repository": "roundcube/roundcubemail",
+              "tag": "1.6.11-fpm-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "budibase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "budibase",
+          "image": "budibase/apps:3.15.0",
+          "repository": "budibase/apps",
+          "current_tag": "3.15.0",
+          "candidate_tag": "3.39.27",
+          "candidate_image": "budibase/apps:3.39.27",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 429,
+              "key": "originImageName",
+              "image": "budibase/apps:3.15.0",
+              "repository": "budibase/apps",
+              "tag": "3.15.0",
+              "digest": null
+            },
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 449,
+              "key": "image",
+              "image": "budibase/apps:3.15.0",
+              "repository": "budibase/apps",
+              "tag": "3.15.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "image": "budibase/proxy:3.15.0",
+          "repository": "budibase/proxy",
+          "current_tag": "3.15.0",
+          "candidate_tag": "3.39.27",
+          "candidate_image": "budibase/proxy:3.39.27",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 821,
+              "key": "originImageName",
+              "image": "budibase/proxy:3.15.0",
+              "repository": "budibase/proxy",
+              "tag": "3.15.0",
+              "digest": null
+            },
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 841,
+              "key": "image",
+              "image": "budibase/proxy:3.15.0",
+              "repository": "budibase/proxy",
+              "tag": "3.15.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "image": "budibase/worker:3.15.0",
+          "repository": "budibase/worker",
+          "current_tag": "3.15.0",
+          "candidate_tag": "3.39.27",
+          "candidate_image": "budibase/worker:3.39.27",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 625,
+              "key": "originImageName",
+              "image": "budibase/worker:3.15.0",
+              "repository": "budibase/worker",
+              "tag": "3.15.0",
+              "digest": null
+            },
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 645,
+              "key": "image",
+              "image": "budibase/worker:3.15.0",
+              "repository": "budibase/worker",
+              "tag": "3.15.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "current_tag": "1.37.0",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "budibase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+              "line": 276,
+              "key": "image",
+              "image": "busybox:1.37.0",
+              "repository": "busybox",
+              "tag": "1.37.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "bunkerweb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "bunkerweb",
+          "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+          "current_tag": "1.6.11",
+          "candidate_tag": "1.6.12",
+          "candidate_image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.12",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 607,
+              "key": "originImageName",
+              "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+              "tag": "1.6.11",
+              "digest": null
+            },
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 680,
+              "key": "image",
+              "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+              "tag": "1.6.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-ui",
+          "current_tag": "1.6.11",
+          "candidate_tag": "1.6.12",
+          "candidate_image": "docker.io/bunkerity/bunkerweb-ui:1.6.12",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 855,
+              "key": "originImageName",
+              "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb-ui",
+              "tag": "1.6.11",
+              "digest": null
+            },
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 937,
+              "key": "image",
+              "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb-ui",
+              "tag": "1.6.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb",
+          "current_tag": "1.6.11",
+          "candidate_tag": "1.6.12",
+          "candidate_image": "docker.io/bunkerity/bunkerweb:1.6.12",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 418,
+              "key": "originImageName",
+              "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb",
+              "tag": "1.6.11",
+              "digest": null
+            },
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 511,
+              "key": "image",
+              "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+              "repository": "docker.io/bunkerity/bunkerweb",
+              "tag": "1.6.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "docker.io/library/busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 487,
+              "key": "image",
+              "image": "docker.io/library/busybox:1.36.1",
+              "repository": "docker.io/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 633,
+              "key": "image",
+              "image": "docker.io/library/busybox:1.36.1",
+              "repository": "docker.io/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "bunkerweb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+              "line": 656,
+              "key": "image",
+              "image": "docker.io/library/busybox:1.36.1",
+              "repository": "docker.io/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "bytebase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "bytebase",
+          "image": "bytebase/bytebase:3.6.1",
+          "repository": "bytebase/bytebase",
+          "current_tag": "3.6.1",
+          "candidate_tag": "3.20.0",
+          "candidate_image": "bytebase/bytebase:3.20.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "bytebase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml",
+              "line": 45,
+              "key": "originImageName",
+              "image": "bytebase/bytebase:3.6.1",
+              "repository": "bytebase/bytebase",
+              "tag": "3.6.1",
+              "digest": null
+            },
+            {
+              "template": "bytebase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml",
+              "line": 68,
+              "key": "image",
+              "image": "bytebase/bytebase:3.6.1",
+              "repository": "bytebase/bytebase",
+              "tag": "3.6.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:75: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:124: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:127: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "casdoor",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "casdoor",
+          "image": "casbin/casdoor:v1.702.0",
+          "repository": "casbin/casdoor",
+          "current_tag": "v1.702.0",
+          "candidate_tag": "v2.190.0",
+          "candidate_image": "casbin/casdoor:v2.190.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "casdoor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+              "line": 425,
+              "key": "image",
+              "image": "casbin/casdoor:v1.702.0",
+              "repository": "casbin/casdoor",
+              "tag": "v1.702.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:48: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:513: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "casdoor",
+          "image": "casbin/casdoor:v2.32.0",
+          "repository": "casbin/casdoor",
+          "current_tag": "v2.32.0",
+          "candidate_tag": "v2.190.0",
+          "candidate_image": "casbin/casdoor:v2.190.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "casdoor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+              "line": 334,
+              "key": "originImageName",
+              "image": "casbin/casdoor:v2.32.0",
+              "repository": "casbin/casdoor",
+              "tag": "v2.32.0",
+              "digest": null
+            },
+            {
+              "template": "casdoor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+              "line": 355,
+              "key": "image",
+              "image": "casbin/casdoor:v2.32.0",
+              "repository": "casbin/casdoor",
+              "tag": "v2.32.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:48: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:513: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "changedetection",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "changedetection",
+          "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "repository": "ghcr.io/dgtlmoon/changedetection.io",
+          "current_tag": "0.50.43",
+          "candidate_tag": "0.55.7",
+          "candidate_image": "ghcr.io/dgtlmoon/changedetection.io:0.55.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "changedetection",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml",
+              "line": 43,
+              "key": "originImageName",
+              "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+              "repository": "ghcr.io/dgtlmoon/changedetection.io",
+              "tag": "0.50.43",
+              "digest": null
+            },
+            {
+              "template": "changedetection",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml",
+              "line": 64,
+              "key": "image",
+              "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+              "repository": "ghcr.io/dgtlmoon/changedetection.io",
+              "tag": "0.50.43",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:56: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:111: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "chatgpt-next-web",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatgpt-next-web",
+          "image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "repository": "yidadaa/chatgpt-next-web",
+          "current_tag": "v2.12.4",
+          "candidate_tag": "v2.16.1",
+          "candidate_image": "yidadaa/chatgpt-next-web:v2.16.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "chatgpt-next-web",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml",
+              "line": 89,
+              "key": "originImageName",
+              "image": "yidadaa/chatgpt-next-web:v2.12.4",
+              "repository": "yidadaa/chatgpt-next-web",
+              "tag": "v2.12.4",
+              "digest": null
+            },
+            {
+              "template": "chatgpt-next-web",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml",
+              "line": 114,
+              "key": "image",
+              "image": "yidadaa/chatgpt-next-web:v2.12.4",
+              "repository": "yidadaa/chatgpt-next-web",
+              "tag": "v2.12.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:79: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:141: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:142: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:158: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:176: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "chatgpt-on-wechat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatgpt-on-wechat",
+          "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "repository": "zhayujie/chatgpt-on-wechat",
+          "current_tag": "1.6.8",
+          "candidate_tag": "2.1.3",
+          "candidate_image": "zhayujie/chatgpt-on-wechat:2.1.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "chatgpt-on-wechat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml",
+              "line": 78,
+              "key": "originImageName",
+              "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+              "repository": "zhayujie/chatgpt-on-wechat",
+              "tag": "1.6.8",
+              "digest": null
+            },
+            {
+              "template": "chatgpt-on-wechat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml",
+              "line": 98,
+              "key": "image",
+              "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+              "repository": "zhayujie/chatgpt-on-wechat",
+              "tag": "1.6.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:68: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:169: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:172: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "chatnio",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatnio",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "current_tag": "8.0.30",
+          "candidate_tag": "8.0.44",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "chatnio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml",
+              "line": 290,
+              "key": "image",
+              "image": "joseluisq/mysql-client:8.0.30",
+              "repository": "joseluisq/mysql-client",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:79: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:98: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:149: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:152: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "chatwoot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatwoot",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "current_tag": "v4.7.0",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "chatwoot/chatwoot:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "chatwoot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+              "line": 171,
+              "key": "image",
+              "image": "chatwoot/chatwoot:v4.7.0",
+              "repository": "chatwoot/chatwoot",
+              "tag": "v4.7.0",
+              "digest": null
+            },
+            {
+              "template": "chatwoot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+              "line": 383,
+              "key": "originImageName",
+              "image": "chatwoot/chatwoot:v4.7.0",
+              "repository": "chatwoot/chatwoot",
+              "tag": "v4.7.0",
+              "digest": null
+            },
+            {
+              "template": "chatwoot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+              "line": 404,
+              "key": "image",
+              "image": "chatwoot/chatwoot:v4.7.0",
+              "repository": "chatwoot/chatwoot",
+              "tag": "v4.7.0",
+              "digest": null
+            },
+            {
+              "template": "chatwoot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+              "line": 507,
+              "key": "originImageName",
+              "image": "chatwoot/chatwoot:v4.7.0",
+              "repository": "chatwoot/chatwoot",
+              "tag": "v4.7.0",
+              "digest": null
+            },
+            {
+              "template": "chatwoot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+              "line": 528,
+              "key": "image",
+              "image": "chatwoot/chatwoot:v4.7.0",
+              "repository": "chatwoot/chatwoot",
+              "tag": "v4.7.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:130: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:172: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:190: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:200: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:203: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:348: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:349: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:351: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "cobalt",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "cobalt",
+          "image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "repository": "ghcr.io/imputnet/cobalt",
+          "current_tag": "7.13.3",
+          "candidate_tag": "11.7.1",
+          "candidate_image": "ghcr.io/imputnet/cobalt:11.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "cobalt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cobalt/index.yaml",
+              "line": 62,
+              "key": "originImageName",
+              "image": "ghcr.io/imputnet/cobalt:7.13.3",
+              "repository": "ghcr.io/imputnet/cobalt",
+              "tag": "7.13.3",
+              "digest": null
+            },
+            {
+              "template": "cobalt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cobalt/index.yaml",
+              "line": 83,
+              "key": "image",
+              "image": "ghcr.io/imputnet/cobalt:7.13.3",
+              "repository": "ghcr.io/imputnet/cobalt",
+              "tag": "7.13.3",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/cobalt/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "code-server",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "code-server",
+          "image": "codercom/code-server:4.90.3-39",
+          "repository": "codercom/code-server",
+          "current_tag": "4.90.3-39",
+          "candidate_tag": "4.127.0-39",
+          "candidate_image": "codercom/code-server:4.127.0-39",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "code-server",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml",
+              "line": 45,
+              "key": "originImageName",
+              "image": "codercom/code-server:4.90.3-39",
+              "repository": "codercom/code-server",
+              "tag": "4.90.3-39",
+              "digest": null
+            },
+            {
+              "template": "code-server",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml",
+              "line": 72,
+              "key": "image",
+              "image": "codercom/code-server:4.90.3-39",
+              "repository": "codercom/code-server",
+              "tag": "4.90.3-39",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:35: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:120: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:178: App resource spec.type must be 'link'"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "coze-studio",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "coze-studio",
+          "image": "alpine/curl:8.12.1",
+          "repository": "alpine/curl",
+          "current_tag": "8.12.1",
+          "candidate_tag": "8.21.0",
+          "candidate_image": "alpine/curl:8.21.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 1042,
+              "key": "image",
+              "image": "alpine/curl:8.12.1",
+              "repository": "alpine/curl",
+              "tag": "8.12.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "image": "bitnamilegacy/elasticsearch:8.18.0",
+          "repository": "bitnamilegacy/elasticsearch",
+          "current_tag": "8.18.0",
+          "candidate_tag": "9.1.2",
+          "candidate_image": "bitnamilegacy/elasticsearch:9.1.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 633,
+              "key": "originImageName",
+              "image": "bitnamilegacy/elasticsearch:8.18.0",
+              "repository": "bitnamilegacy/elasticsearch",
+              "tag": "8.18.0",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 666,
+              "key": "image",
+              "image": "bitnamilegacy/elasticsearch:8.18.0",
+              "repository": "bitnamilegacy/elasticsearch",
+              "tag": "8.18.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 540,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 655,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 908,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 982,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 989,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 996,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 1148,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "image": "milvusdb/milvus:v2.5.10",
+          "repository": "milvusdb/milvus",
+          "current_tag": "v2.5.10",
+          "candidate_tag": "v2.6.19",
+          "candidate_image": "milvusdb/milvus:v2.6.19",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 755,
+              "key": "originImageName",
+              "image": "milvusdb/milvus:v2.5.10",
+              "repository": "milvusdb/milvus",
+              "tag": "v2.5.10",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 775,
+              "key": "image",
+              "image": "milvusdb/milvus:v2.5.10",
+              "repository": "milvusdb/milvus",
+              "tag": "v2.5.10",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "image": "mysql:8.0.36",
+          "repository": "mysql",
+          "current_tag": "8.0.36",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 937,
+              "key": "image",
+              "image": "mysql:8.0.36",
+              "repository": "mysql",
+              "tag": "8.0.36",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "current_tag": "v1.2.1",
+          "candidate_tag": "v1.3.0",
+          "candidate_image": "nsqio/nsq:v1.3.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 378,
+              "key": "originImageName",
+              "image": "nsqio/nsq:v1.2.1",
+              "repository": "nsqio/nsq",
+              "tag": "v1.2.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 394,
+              "key": "image",
+              "image": "nsqio/nsq:v1.2.1",
+              "repository": "nsqio/nsq",
+              "tag": "v1.2.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 447,
+              "key": "originImageName",
+              "image": "nsqio/nsq:v1.2.1",
+              "repository": "nsqio/nsq",
+              "tag": "v1.2.1",
+              "digest": null
+            },
+            {
+              "template": "coze-studio",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+              "line": 463,
+              "key": "image",
+              "image": "nsqio/nsq:v1.2.1",
+              "repository": "nsqio/nsq",
+              "tag": "v1.2.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "crawl4ai",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "crawl4ai",
+          "image": "unclecode/crawl4ai:0.8.9",
+          "repository": "unclecode/crawl4ai",
+          "current_tag": "0.8.9",
+          "candidate_tag": "0.9.0",
+          "candidate_image": "unclecode/crawl4ai:0.9.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "crawl4ai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml",
+              "line": 37,
+              "key": "originImageName",
+              "image": "unclecode/crawl4ai:0.8.9",
+              "repository": "unclecode/crawl4ai",
+              "tag": "0.8.9",
+              "digest": null
+            },
+            {
+              "template": "crawl4ai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml",
+              "line": 59,
+              "key": "image",
+              "image": "unclecode/crawl4ai:0.8.9",
+              "repository": "unclecode/crawl4ai",
+              "tag": "0.8.9",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:96: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:97: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "crmeb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "crmeb",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "current_tag": "8.0.30",
+          "candidate_tag": "8.0.44",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "crmeb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+              "line": 129,
+              "key": "image",
+              "image": "joseluisq/mysql-client:8.0.30",
+              "repository": "joseluisq/mysql-client",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:226: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:227: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:229: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:230: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:279: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:281: ConfigMap metadata.labels.app is required and must match metadata.name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "cronicle",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "cronicle",
+          "image": "soulteary/cronicle:0.9.46",
+          "repository": "soulteary/cronicle",
+          "current_tag": "0.9.46",
+          "candidate_tag": "0.9.80",
+          "candidate_image": "soulteary/cronicle:0.9.80",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "cronicle",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml",
+              "line": 34,
+              "key": "originImageName",
+              "image": "soulteary/cronicle:0.9.46",
+              "repository": "soulteary/cronicle",
+              "tag": "0.9.46",
+              "digest": null
+            },
+            {
+              "template": "cronicle",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml",
+              "line": 62,
+              "key": "image",
+              "image": "soulteary/cronicle:0.9.46",
+              "repository": "soulteary/cronicle",
+              "tag": "0.9.46",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:25: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:121: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:141: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "dataease",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dataease",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dataease",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+              "line": 63,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:30: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:34: container init-config must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:120: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:210: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:213: Service spec.ports entries must define a non-empty name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:348: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R001/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: forbidden ':latest' image tag",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "dataease",
+          "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+          "current_tag": "v2.10.12",
+          "candidate_tag": "v2.10.25",
+          "candidate_image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dataease",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+              "line": 39,
+              "key": "originImageName",
+              "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+              "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+              "tag": "v2.10.12",
+              "digest": null
+            },
+            {
+              "template": "dataease",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+              "line": 113,
+              "key": "image",
+              "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+              "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+              "tag": "v2.10.12",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:30: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:34: container init-config must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:120: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:210: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:213: Service spec.ports entries must define a non-empty name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:348: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R001/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: forbidden ':latest' image tag",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "dbgate",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dbgate",
+          "image": "dbgate/dbgate:5.3.1-alpine",
+          "repository": "dbgate/dbgate",
+          "current_tag": "5.3.1-alpine",
+          "candidate_tag": "7.2.1-alpine",
+          "candidate_image": "dbgate/dbgate:7.2.1-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dbgate",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml",
+              "line": 50,
+              "key": "originImageName",
+              "image": "dbgate/dbgate:5.3.1-alpine",
+              "repository": "dbgate/dbgate",
+              "tag": "5.3.1-alpine",
+              "digest": null
+            },
+            {
+              "template": "dbgate",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml",
+              "line": 78,
+              "key": "image",
+              "image": "dbgate/dbgate:5.3.1-alpine",
+              "repository": "dbgate/dbgate",
+              "tag": "5.3.1-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:134: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:137: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:173: App resource spec.type must be 'link'"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "deeplx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "deeplx",
+          "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "repository": "ghcr.io/owo-network/deeplx",
+          "current_tag": "v0.9.5",
+          "candidate_tag": "v1.2.2",
+          "candidate_image": "ghcr.io/owo-network/deeplx:v1.2.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "deeplx",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml",
+              "line": 40,
+              "key": "originImageName",
+              "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+              "repository": "ghcr.io/owo-network/deeplx",
+              "tag": "v0.9.5",
+              "digest": null
+            },
+            {
+              "template": "deeplx",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml",
+              "line": 65,
+              "key": "image",
+              "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+              "repository": "ghcr.io/owo-network/deeplx",
+              "tag": "v0.9.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:57: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:75: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:88: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:91: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:111: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "derper",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "derper",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "current_tag": "1.28.9",
+          "candidate_tag": "1.33.4",
+          "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "derper",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+              "line": 196,
+              "key": "image",
+              "image": "bitnamilegacy/kubectl:1.28.9",
+              "repository": "bitnamilegacy/kubectl",
+              "tag": "1.28.9",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/derper/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "derper",
+          "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "repository": "ghcr.io/yangchuansheng/derper",
+          "current_tag": "v1.99.0-pre",
+          "candidate_tag": "v1.101.0-pre",
+          "candidate_image": "ghcr.io/yangchuansheng/derper:v1.101.0-pre",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "derper",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+              "line": 110,
+              "key": "originImageName",
+              "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+              "repository": "ghcr.io/yangchuansheng/derper",
+              "tag": "v1.99.0-pre",
+              "digest": null
+            },
+            {
+              "template": "derper",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+              "line": 132,
+              "key": "image",
+              "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+              "repository": "ghcr.io/yangchuansheng/derper",
+              "tag": "v1.99.0-pre",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/derper/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "dify",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dify",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "current_tag": "1.37.0",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 112,
+              "key": "image",
+              "image": "busybox:1.37.0",
+              "repository": "busybox",
+              "tag": "1.37.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "current_tag": "1.11.2",
+          "candidate_tag": "1.15.0",
+          "candidate_image": "langgenius/dify-api:1.15.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 54,
+              "key": "originImageName",
+              "image": "langgenius/dify-api:1.11.2",
+              "repository": "langgenius/dify-api",
+              "tag": "1.11.2",
+              "digest": null
+            },
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 131,
+              "key": "image",
+              "image": "langgenius/dify-api:1.11.2",
+              "repository": "langgenius/dify-api",
+              "tag": "1.11.2",
+              "digest": null
+            },
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 273,
+              "key": "image",
+              "image": "langgenius/dify-api:1.11.2",
+              "repository": "langgenius/dify-api",
+              "tag": "1.11.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "repository": "langgenius/dify-plugin-daemon",
+          "current_tag": "0.5.2-local",
+          "candidate_tag": "0.6.3-local",
+          "candidate_image": "langgenius/dify-plugin-daemon:0.6.3-local",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 681,
+              "key": "originImageName",
+              "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+              "repository": "langgenius/dify-plugin-daemon",
+              "tag": "0.5.2-local",
+              "digest": null
+            },
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 740,
+              "key": "image",
+              "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+              "repository": "langgenius/dify-plugin-daemon",
+              "tag": "0.5.2-local",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "image": "langgenius/dify-sandbox:0.2.12",
+          "repository": "langgenius/dify-sandbox",
+          "current_tag": "0.2.12",
+          "candidate_tag": "0.2.15",
+          "candidate_image": "langgenius/dify-sandbox:0.2.15",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 601,
+              "key": "originImageName",
+              "image": "langgenius/dify-sandbox:0.2.12",
+              "repository": "langgenius/dify-sandbox",
+              "tag": "0.2.12",
+              "digest": null
+            },
+            {
+              "template": "dify",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+              "line": 624,
+              "key": "image",
+              "image": "langgenius/dify-sandbox:0.2.12",
+              "repository": "langgenius/dify-sandbox",
+              "tag": "0.2.12",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "directus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "directus",
+          "image": "directus/directus:11.17.4",
+          "repository": "directus/directus",
+          "current_tag": "11.17.4",
+          "candidate_tag": "12.1.1",
+          "candidate_image": "directus/directus:12.1.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "directus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+              "line": 332,
+              "key": "originImageName",
+              "image": "directus/directus:11.17.4",
+              "repository": "directus/directus",
+              "tag": "11.17.4",
+              "digest": null
+            },
+            {
+              "template": "directus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+              "line": 449,
+              "key": "image",
+              "image": "directus/directus:11.17.4",
+              "repository": "directus/directus",
+              "tag": "11.17.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        },
+        {
+          "template": "directus",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "directus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+              "line": 357,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        },
+        {
+          "template": "directus",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "directus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+              "line": 421,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "docuseal",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "docuseal",
+          "image": "docuseal/docuseal:3.0.1",
+          "repository": "docuseal/docuseal",
+          "current_tag": "3.0.1",
+          "candidate_tag": "3.1.3",
+          "candidate_image": "docuseal/docuseal:3.1.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "docuseal",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml",
+              "line": 184,
+              "key": "originImageName",
+              "image": "docuseal/docuseal:3.0.1",
+              "repository": "docuseal/docuseal",
+              "tag": "3.0.1",
+              "digest": null
+            },
+            {
+              "template": "docuseal",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml",
+              "line": 207,
+              "key": "image",
+              "image": "docuseal/docuseal:3.0.1",
+              "repository": "docuseal/docuseal",
+              "tag": "3.0.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml:203: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "dolibarr",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "dolibarr",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "dolibarr",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dolibarr/index.yaml",
+              "line": 161,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/dolibarr/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "drawdb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "drawdb",
+          "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "repository": "ghcr.io/drawdb-io/drawdb",
+          "current_tag": "v1.5.0",
+          "candidate_tag": "v1.8.1",
+          "candidate_image": "ghcr.io/drawdb-io/drawdb:v1.8.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "drawdb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml",
+              "line": 60,
+              "key": "originImageName",
+              "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+              "repository": "ghcr.io/drawdb-io/drawdb",
+              "tag": "v1.5.0",
+              "digest": null
+            },
+            {
+              "template": "drawdb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml",
+              "line": 81,
+              "key": "image",
+              "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+              "repository": "ghcr.io/drawdb-io/drawdb",
+              "tag": "v1.5.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml:72: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "edgequake",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "edgequake",
+          "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+          "current_tag": "0.12.2",
+          "candidate_tag": "0.15.0",
+          "candidate_image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.15.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "edgequake",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+              "line": 380,
+              "key": "originImageName",
+              "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+              "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+              "tag": "0.12.2",
+              "digest": null
+            },
+            {
+              "template": "edgequake",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+              "line": 400,
+              "key": "image",
+              "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+              "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+              "tag": "0.12.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:294: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:392: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "edgequake",
+          "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake",
+          "current_tag": "0.12.2",
+          "candidate_tag": "0.15.0",
+          "candidate_image": "ghcr.io/raphaelmansuy/edgequake:0.15.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "edgequake",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+              "line": 282,
+              "key": "originImageName",
+              "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+              "repository": "ghcr.io/raphaelmansuy/edgequake",
+              "tag": "0.12.2",
+              "digest": null
+            },
+            {
+              "template": "edgequake",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+              "line": 302,
+              "key": "image",
+              "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+              "repository": "ghcr.io/raphaelmansuy/edgequake",
+              "tag": "0.12.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:294: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:392: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "elasticsearch",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "elasticsearch",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "current_tag": "1.37.0",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "elasticsearch",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml",
+              "line": 63,
+              "key": "image",
+              "image": "busybox:1.37.0",
+              "repository": "busybox",
+              "tag": "1.37.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:57: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "emqx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "emqx",
+          "image": "emqx/emqx:5.8.9",
+          "repository": "emqx/emqx",
+          "current_tag": "5.8.9",
+          "candidate_tag": "6.2.2",
+          "candidate_image": "emqx/emqx:6.2.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "emqx",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml",
+              "line": 57,
+              "key": "originImageName",
+              "image": "emqx/emqx:5.8.9",
+              "repository": "emqx/emqx",
+              "tag": "5.8.9",
+              "digest": null
+            },
+            {
+              "template": "emqx",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml",
+              "line": 91,
+              "key": "image",
+              "image": "emqx/emqx:5.8.9",
+              "repository": "emqx/emqx",
+              "tag": "5.8.9",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml:81: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "erpnext",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "erpnext",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "current_tag": "v16.21.1",
+          "candidate_tag": "v16.26.2",
+          "candidate_image": "frappe/erpnext:v16.26.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 374,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 530,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 666,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 731,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 786,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 882,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 962,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1027,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1118,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1214,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1275,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1371,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1432,
+              "key": "originImageName",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1497,
+              "key": "image",
+              "image": "frappe/erpnext:v16.21.1",
+              "repository": "frappe/erpnext",
+              "tag": "v16.21.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "image": "mariadb:11.4.7",
+          "repository": "mariadb",
+          "current_tag": "11.4.7",
+          "candidate_tag": "12.3.2",
+          "candidate_image": "mariadb:12.3.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 66,
+              "key": "originImageName",
+              "image": "mariadb:11.4.7",
+              "repository": "mariadb",
+              "tag": "11.4.7",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 89,
+              "key": "image",
+              "image": "mariadb:11.4.7",
+              "repository": "mariadb",
+              "tag": "11.4.7",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 319,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 475,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 687,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 710,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 807,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 861,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 983,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1006,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1139,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1193,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1296,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1350,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1453,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1476,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 342,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 498,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 830,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1162,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "erpnext",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+              "line": 1319,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "ever-gauzy",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "ever-gauzy",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "ever-gauzy",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+              "line": 208,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:137: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:200: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:437: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:529: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "evolution-api",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "evolution-api",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "evolution-api",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+              "line": 340,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/evolution-api/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "evolution-api",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "evolution-api",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+              "line": 393,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/evolution-api/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "fastgpt",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1013,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1033,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.14.23",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1126,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1146,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "current_tag": "v0.6.2",
+          "candidate_tag": "v1.0.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 852,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            },
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 872,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 562,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 582,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "current_tag": "v0.5.8",
+          "candidate_tag": "v0.6.5",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1238,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            },
+            {
+              "template": "fastgpt",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+              "line": 1258,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "fastgpt-milvus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt-milvus",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 678,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 704,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.14.23",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 774,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 800,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "current_tag": "v0.6.2",
+          "candidate_tag": "v1.0.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 417,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 443,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 136,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 156,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "current_tag": "v0.5.8",
+          "candidate_tag": "v0.6.5",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 580,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-milvus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+              "line": 606,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "fastgpt-pro",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1161,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1181,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.14.23",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1274,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1294,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "current_tag": "v0.6.2",
+          "candidate_tag": "v1.0.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1000,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1020,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+              "tag": "v0.6.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 855,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 875,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "current_tag": "v4.14.22",
+          "candidate_tag": "v4.15.1",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 563,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 583,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+              "tag": "v4.14.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "current_tag": "v0.5.8",
+          "candidate_tag": "v0.6.5",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1386,
+              "key": "originImageName",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            },
+            {
+              "template": "fastgpt-pro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+              "line": 1406,
+              "key": "image",
+              "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+              "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+              "tag": "v0.5.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "featbit-standard",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "featbit-standard",
+          "image": "featbit/featbit-api-server:5.0.5",
+          "repository": "featbit/featbit-api-server",
+          "current_tag": "5.0.5",
+          "candidate_tag": "5.4.2",
+          "candidate_image": "featbit/featbit-api-server:5.4.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1118,
+              "key": "originImageName",
+              "image": "featbit/featbit-api-server:5.0.5",
+              "repository": "featbit/featbit-api-server",
+              "tag": "5.0.5",
+              "digest": null
+            },
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1179,
+              "key": "image",
+              "image": "featbit/featbit-api-server:5.0.5",
+              "repository": "featbit/featbit-api-server",
+              "tag": "5.0.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "image": "featbit/featbit-data-analytics-server:5.0.5",
+          "repository": "featbit/featbit-data-analytics-server",
+          "current_tag": "5.0.5",
+          "candidate_tag": "5.4.2",
+          "candidate_image": "featbit/featbit-data-analytics-server:5.4.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1247,
+              "key": "originImageName",
+              "image": "featbit/featbit-data-analytics-server:5.0.5",
+              "repository": "featbit/featbit-data-analytics-server",
+              "tag": "5.0.5",
+              "digest": null
+            },
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1308,
+              "key": "image",
+              "image": "featbit/featbit-data-analytics-server:5.0.5",
+              "repository": "featbit/featbit-data-analytics-server",
+              "tag": "5.0.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "image": "featbit/featbit-evaluation-server:5.0.5",
+          "repository": "featbit/featbit-evaluation-server",
+          "current_tag": "5.0.5",
+          "candidate_tag": "5.4.2",
+          "candidate_image": "featbit/featbit-evaluation-server:5.4.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1370,
+              "key": "originImageName",
+              "image": "featbit/featbit-evaluation-server:5.0.5",
+              "repository": "featbit/featbit-evaluation-server",
+              "tag": "5.0.5",
+              "digest": null
+            },
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1431,
+              "key": "image",
+              "image": "featbit/featbit-evaluation-server:5.0.5",
+              "repository": "featbit/featbit-evaluation-server",
+              "tag": "5.0.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "image": "featbit/featbit-ui:5.0.5",
+          "repository": "featbit/featbit-ui",
+          "current_tag": "5.0.5",
+          "candidate_tag": "5.4.2",
+          "candidate_image": "featbit/featbit-ui:5.4.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1497,
+              "key": "originImageName",
+              "image": "featbit/featbit-ui:5.0.5",
+              "repository": "featbit/featbit-ui",
+              "tag": "5.0.5",
+              "digest": null
+            },
+            {
+              "template": "featbit-standard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+              "line": 1519,
+              "key": "image",
+              "image": "featbit/featbit-ui:5.0.5",
+              "repository": "featbit/featbit-ui",
+              "tag": "5.0.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "firecrawl",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "firecrawl",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 258,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 702,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "firecrawl",
+          "image": "rabbitmq:3.13.7-management",
+          "repository": "rabbitmq",
+          "current_tag": "3.13.7-management",
+          "candidate_tag": "4.3.2-management",
+          "candidate_image": "rabbitmq:4.3.2-management",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 230,
+              "key": "originImageName",
+              "image": "rabbitmq:3.13.7-management",
+              "repository": "rabbitmq",
+              "tag": "3.13.7-management",
+              "digest": null
+            },
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 287,
+              "key": "image",
+              "image": "rabbitmq:3.13.7-management",
+              "repository": "rabbitmq",
+              "tag": "3.13.7-management",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "firecrawl",
+          "image": "redis:7.2.7-alpine",
+          "repository": "redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 145,
+              "key": "originImageName",
+              "image": "redis:7.2.7-alpine",
+              "repository": "redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 169,
+              "key": "image",
+              "image": "redis:7.2.7-alpine",
+              "repository": "redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "firecrawl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+              "line": 675,
+              "key": "image",
+              "image": "redis:7.2.7-alpine",
+              "repository": "redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "flarum",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "flarum",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "flarum",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml",
+              "line": 155,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml:150: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "flowise",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "flowise",
+          "image": "flowiseai/flowise:3.0.5",
+          "repository": "flowiseai/flowise",
+          "current_tag": "3.0.5",
+          "candidate_tag": "3.1.3",
+          "candidate_image": "flowiseai/flowise:3.1.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "flowise",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+              "line": 195,
+              "key": "originImageName",
+              "image": "flowiseai/flowise:3.0.5",
+              "repository": "flowiseai/flowise",
+              "tag": "3.0.5",
+              "digest": null
+            },
+            {
+              "template": "flowise",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+              "line": 257,
+              "key": "image",
+              "image": "flowiseai/flowise:3.0.5",
+              "repository": "flowiseai/flowise",
+              "tag": "3.0.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:147: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:157: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:400: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:403: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "formbricks",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "formbricks",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "current_tag": "4.9.7",
+          "candidate_tag": "5.1.4",
+          "candidate_image": "ghcr.io/formbricks/formbricks:5.1.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "formbricks",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+              "line": 344,
+              "key": "originImageName",
+              "image": "ghcr.io/formbricks/formbricks:4.9.7",
+              "repository": "ghcr.io/formbricks/formbricks",
+              "tag": "4.9.7",
+              "digest": null
+            },
+            {
+              "template": "formbricks",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+              "line": 370,
+              "key": "image",
+              "image": "ghcr.io/formbricks/formbricks:4.9.7",
+              "repository": "ghcr.io/formbricks/formbricks",
+              "tag": "4.9.7",
+              "digest": null
+            },
+            {
+              "template": "formbricks",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+              "line": 426,
+              "key": "image",
+              "image": "ghcr.io/formbricks/formbricks:4.9.7",
+              "repository": "ghcr.io/formbricks/formbricks",
+              "tag": "4.9.7",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:358: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:507: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:511: container ${{ defaults.app_name }} requests.memory must be 25Mi when limits.memory is 256Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "frp",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "frp",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "current_tag": "1.28.9",
+          "candidate_tag": "1.33.4",
+          "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "frp",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml",
+              "line": 299,
+              "key": "image",
+              "image": "bitnamilegacy/kubectl:1.28.9",
+              "repository": "bitnamilegacy/kubectl",
+              "tag": "1.28.9",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:17: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:53: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:55: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:79: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:104: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:156: Service metadata.name must match spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:157: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "ghost",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "ghost",
+          "image": "ghost:6.44.1-alpine",
+          "repository": "ghost",
+          "current_tag": "6.44.1-alpine",
+          "candidate_tag": "6.51.0-alpine",
+          "candidate_image": "ghost:6.51.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "ghost",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+              "line": 250,
+              "key": "originImageName",
+              "image": "ghost:6.44.1-alpine",
+              "repository": "ghost",
+              "tag": "6.44.1-alpine",
+              "digest": null
+            },
+            {
+              "template": "ghost",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+              "line": 339,
+              "key": "image",
+              "image": "ghost:6.44.1-alpine",
+              "repository": "ghost",
+              "tag": "6.44.1-alpine",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/ghost/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "ghost",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "ghost",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+              "line": 155,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+              "repository": "public.ecr.aws/docker/library/mysql",
+              "tag": "8.0.30",
+              "digest": null
+            },
+            {
+              "template": "ghost",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+              "line": 300,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+              "repository": "public.ecr.aws/docker/library/mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/ghost/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "gitea",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "gitea",
+          "image": "gitea/gitea:1.22.0-rootless",
+          "repository": "gitea/gitea",
+          "current_tag": "1.22.0-rootless",
+          "candidate_tag": "1.26.4-rootless",
+          "candidate_image": "gitea/gitea:1.26.4-rootless",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "gitea",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml",
+              "line": 36,
+              "key": "originImageName",
+              "image": "gitea/gitea:1.22.0-rootless",
+              "repository": "gitea/gitea",
+              "tag": "1.22.0-rootless",
+              "digest": null
+            },
+            {
+              "template": "gitea",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml",
+              "line": 63,
+              "key": "image",
+              "image": "gitea/gitea:1.22.0-rootless",
+              "repository": "gitea/gitea",
+              "tag": "1.22.0-rootless",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:67: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:71: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:140: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "glitchtip",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "glitchtip",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "current_tag": "v4.1.5",
+          "candidate_tag": "v6.0.3",
+          "candidate_image": "glitchtip/glitchtip:v6.0.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "glitchtip",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+              "line": 61,
+              "key": "originImageName",
+              "image": "glitchtip/glitchtip:v4.1.5",
+              "repository": "glitchtip/glitchtip",
+              "tag": "v4.1.5",
+              "digest": null
+            },
+            {
+              "template": "glitchtip",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+              "line": 86,
+              "key": "image",
+              "image": "glitchtip/glitchtip:v4.1.5",
+              "repository": "glitchtip/glitchtip",
+              "tag": "v4.1.5",
+              "digest": null
+            },
+            {
+              "template": "glitchtip",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+              "line": 175,
+              "key": "image",
+              "image": "glitchtip/glitchtip:v4.1.5",
+              "repository": "glitchtip/glitchtip",
+              "tag": "v4.1.5",
+              "digest": null
+            },
+            {
+              "template": "glitchtip",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+              "line": 265,
+              "key": "image",
+              "image": "glitchtip/glitchtip:v4.1.5",
+              "repository": "glitchtip/glitchtip",
+              "tag": "v4.1.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:52: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:363: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:366: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "grafana",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "grafana",
+          "image": "grafana/grafana:13.0.2",
+          "repository": "grafana/grafana",
+          "current_tag": "13.0.2",
+          "candidate_tag": "13.1.0",
+          "candidate_image": "grafana/grafana:13.1.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "grafana",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana/index.yaml",
+              "line": 193,
+              "key": "originImageName",
+              "image": "grafana/grafana:13.0.2",
+              "repository": "grafana/grafana",
+              "tag": "13.0.2",
+              "digest": null
+            },
+            {
+              "template": "grafana",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana/index.yaml",
+              "line": 217,
+              "key": "image",
+              "image": "grafana/grafana:13.0.2",
+              "repository": "grafana/grafana",
+              "tag": "13.0.2",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/grafana/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "grafana-otel",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "grafana-otel",
+          "image": "grafana/grafana:12.3.0",
+          "repository": "grafana/grafana",
+          "current_tag": "12.3.0",
+          "candidate_tag": "13.1.0",
+          "candidate_image": "grafana/grafana:13.1.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 351,
+              "key": "originImageName",
+              "image": "grafana/grafana:12.3.0",
+              "repository": "grafana/grafana",
+              "tag": "12.3.0",
+              "digest": null
+            },
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 384,
+              "key": "image",
+              "image": "grafana/grafana:12.3.0",
+              "repository": "grafana/grafana",
+              "tag": "12.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "grafana-otel",
+          "image": "otel/opentelemetry-collector:0.99.0",
+          "repository": "otel/opentelemetry-collector",
+          "current_tag": "0.99.0",
+          "candidate_tag": "0.156.0",
+          "candidate_image": "otel/opentelemetry-collector:0.156.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 70,
+              "key": "originImageName",
+              "image": "otel/opentelemetry-collector:0.99.0",
+              "repository": "otel/opentelemetry-collector",
+              "tag": "0.99.0",
+              "digest": null
+            },
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 91,
+              "key": "image",
+              "image": "otel/opentelemetry-collector:0.99.0",
+              "repository": "otel/opentelemetry-collector",
+              "tag": "0.99.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "grafana-otel",
+          "image": "prom/prometheus:v3.8.0",
+          "repository": "prom/prometheus",
+          "current_tag": "v3.8.0",
+          "candidate_tag": "v3.13.0",
+          "candidate_image": "prom/prometheus:v3.13.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 221,
+              "key": "originImageName",
+              "image": "prom/prometheus:v3.8.0",
+              "repository": "prom/prometheus",
+              "tag": "v3.8.0",
+              "digest": null
+            },
+            {
+              "template": "grafana-otel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+              "line": 254,
+              "key": "image",
+              "image": "prom/prometheus:v3.8.0",
+              "repository": "prom/prometheus",
+              "tag": "v3.8.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "halo",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "halo",
+          "image": "halohub/halo:2.18.0",
+          "repository": "halohub/halo",
+          "current_tag": "2.18.0",
+          "candidate_tag": "2.25.4",
+          "candidate_image": "halohub/halo:2.25.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "halo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml",
+              "line": 48,
+              "key": "originImageName",
+              "image": "halohub/halo:2.18.0",
+              "repository": "halohub/halo",
+              "tag": "2.18.0",
+              "digest": null
+            },
+            {
+              "template": "halo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml",
+              "line": 71,
+              "key": "image",
+              "image": "halohub/halo:2.18.0",
+              "repository": "halohub/halo",
+              "tag": "2.18.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:87: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:88: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:129: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:132: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:151: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "harbor",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "harbor",
+          "image": "goharbor/harbor-core:v2.14.4",
+          "repository": "goharbor/harbor-core",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/harbor-core:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 606,
+              "key": "originImageName",
+              "image": "goharbor/harbor-core:v2.14.4",
+              "repository": "goharbor/harbor-core",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 628,
+              "key": "image",
+              "image": "goharbor/harbor-core:v2.14.4",
+              "repository": "goharbor/harbor-core",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "image": "goharbor/harbor-jobservice:v2.14.4",
+          "repository": "goharbor/harbor-jobservice",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/harbor-jobservice:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 739,
+              "key": "originImageName",
+              "image": "goharbor/harbor-jobservice:v2.14.4",
+              "repository": "goharbor/harbor-jobservice",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 762,
+              "key": "image",
+              "image": "goharbor/harbor-jobservice:v2.14.4",
+              "repository": "goharbor/harbor-jobservice",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "image": "goharbor/harbor-portal:v2.14.4",
+          "repository": "goharbor/harbor-portal",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/harbor-portal:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 840,
+              "key": "originImageName",
+              "image": "goharbor/harbor-portal:v2.14.4",
+              "repository": "goharbor/harbor-portal",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 862,
+              "key": "image",
+              "image": "goharbor/harbor-portal:v2.14.4",
+              "repository": "goharbor/harbor-portal",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "image": "goharbor/harbor-registryctl:v2.14.4",
+          "repository": "goharbor/harbor-registryctl",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/harbor-registryctl:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 1041,
+              "key": "originImageName",
+              "image": "goharbor/harbor-registryctl:v2.14.4",
+              "repository": "goharbor/harbor-registryctl",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 1063,
+              "key": "image",
+              "image": "goharbor/harbor-registryctl:v2.14.4",
+              "repository": "goharbor/harbor-registryctl",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "image": "goharbor/registry-photon:v2.14.4",
+          "repository": "goharbor/registry-photon",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/registry-photon:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 903,
+              "key": "originImageName",
+              "image": "goharbor/registry-photon:v2.14.4",
+              "repository": "goharbor/registry-photon",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 926,
+              "key": "image",
+              "image": "goharbor/registry-photon:v2.14.4",
+              "repository": "goharbor/registry-photon",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "repository": "goharbor/trivy-adapter-photon",
+          "current_tag": "v2.14.4",
+          "candidate_tag": "v2.15.2",
+          "candidate_image": "goharbor/trivy-adapter-photon:v2.15.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 1121,
+              "key": "originImageName",
+              "image": "goharbor/trivy-adapter-photon:v2.14.4",
+              "repository": "goharbor/trivy-adapter-photon",
+              "tag": "v2.14.4",
+              "digest": null
+            },
+            {
+              "template": "harbor",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+              "line": 1146,
+              "key": "image",
+              "image": "goharbor/trivy-adapter-photon:v2.14.4",
+              "repository": "goharbor/trivy-adapter-photon",
+              "tag": "v2.14.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "hasura",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "hasura",
+          "image": "hasura/graphql-data-connector:v2.48.11",
+          "repository": "hasura/graphql-data-connector",
+          "current_tag": "v2.48.11",
+          "candidate_tag": "v2.49.4",
+          "candidate_image": "hasura/graphql-data-connector:v2.49.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "hasura",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+              "line": 215,
+              "key": "originImageName",
+              "image": "hasura/graphql-data-connector:v2.48.11",
+              "repository": "hasura/graphql-data-connector",
+              "tag": "v2.48.11",
+              "digest": null
+            },
+            {
+              "template": "hasura",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+              "line": 235,
+              "key": "image",
+              "image": "hasura/graphql-data-connector:v2.48.11",
+              "repository": "hasura/graphql-data-connector",
+              "tag": "v2.48.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:276: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:291: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "hasura",
+          "image": "hasura/graphql-engine:v2.48.11",
+          "repository": "hasura/graphql-engine",
+          "current_tag": "v2.48.11",
+          "candidate_tag": "v2.49.4",
+          "candidate_image": "hasura/graphql-engine:v2.49.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "hasura",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+              "line": 121,
+              "key": "originImageName",
+              "image": "hasura/graphql-engine:v2.48.11",
+              "repository": "hasura/graphql-engine",
+              "tag": "v2.48.11",
+              "digest": null
+            },
+            {
+              "template": "hasura",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+              "line": 141,
+              "key": "image",
+              "image": "hasura/graphql-engine:v2.48.11",
+              "repository": "hasura/graphql-engine",
+              "tag": "v2.48.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:276: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:291: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "headscale",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "headscale",
+          "image": "ghcr.io/tale/headplane:0.6.3",
+          "repository": "ghcr.io/tale/headplane",
+          "current_tag": "0.6.3",
+          "candidate_tag": "0.7.0",
+          "candidate_image": "ghcr.io/tale/headplane:0.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "headscale",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+              "line": 1042,
+              "key": "image",
+              "image": "ghcr.io/tale/headplane:0.6.3",
+              "repository": "ghcr.io/tale/headplane",
+              "tag": "0.6.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:221: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:223: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1156: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1158: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1240: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1242: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1257: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1282: Ingress backend service.name must match Ingress metadata.name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "illa-builder",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "illa-builder",
+          "image": "illasoft/illa-builder:v4.8.2",
+          "repository": "illasoft/illa-builder",
+          "current_tag": "v4.8.2",
+          "candidate_tag": "v4.8.5",
+          "candidate_image": "illasoft/illa-builder:v4.8.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "illa-builder",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml",
+              "line": 38,
+              "key": "originImageName",
+              "image": "illasoft/illa-builder:v4.8.2",
+              "repository": "illasoft/illa-builder",
+              "tag": "v4.8.2",
+              "digest": null
+            },
+            {
+              "template": "illa-builder",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml",
+              "line": 61,
+              "key": "image",
+              "image": "illasoft/illa-builder:v4.8.2",
+              "repository": "illasoft/illa-builder",
+              "tag": "v4.8.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "immich",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "immich",
+          "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-server",
+          "current_tag": "v2.7.5",
+          "candidate_tag": "v3.0.1",
+          "candidate_image": "ghcr.io/immich-app/immich-server:v3.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "immich",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+              "line": 319,
+              "key": "originImageName",
+              "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+              "repository": "ghcr.io/immich-app/immich-server",
+              "tag": "v2.7.5",
+              "digest": null
+            },
+            {
+              "template": "immich",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+              "line": 388,
+              "key": "image",
+              "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+              "repository": "ghcr.io/immich-app/immich-server",
+              "tag": "v2.7.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:223: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:224: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:226: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:227: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:238: PVC storage request must be <= 1Gi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "insforge",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "insforge",
+          "image": "apecloud/kubeblocks-tools:0.9.3",
+          "repository": "apecloud/kubeblocks-tools",
+          "current_tag": "0.9.3",
+          "candidate_tag": "1.0.2",
+          "candidate_image": "apecloud/kubeblocks-tools:1.0.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 265,
+              "key": "image",
+              "image": "apecloud/kubeblocks-tools:0.9.3",
+              "repository": "apecloud/kubeblocks-tools",
+              "tag": "0.9.3",
+              "digest": null
+            },
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 352,
+              "key": "image",
+              "image": "apecloud/kubeblocks-tools:0.9.3",
+              "repository": "apecloud/kubeblocks-tools",
+              "tag": "0.9.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "insforge",
+          "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "repository": "ghcr.io/insforge/insforge-oss",
+          "current_tag": "v2.1.8",
+          "candidate_tag": "v2.2.6",
+          "candidate_image": "ghcr.io/insforge/insforge-oss:v2.2.6",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 420,
+              "key": "originImageName",
+              "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+              "repository": "ghcr.io/insforge/insforge-oss",
+              "tag": "v2.1.8",
+              "digest": null
+            },
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 500,
+              "key": "image",
+              "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+              "repository": "ghcr.io/insforge/insforge-oss",
+              "tag": "v2.1.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "insforge",
+          "image": "postgrest/postgrest:v12.2.12",
+          "repository": "postgrest/postgrest",
+          "current_tag": "v12.2.12",
+          "candidate_tag": "v13.0.8",
+          "candidate_image": "postgrest/postgrest:v13.0.8",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 675,
+              "key": "originImageName",
+              "image": "postgrest/postgrest:v12.2.12",
+              "repository": "postgrest/postgrest",
+              "tag": "v12.2.12",
+              "digest": null
+            },
+            {
+              "template": "insforge",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+              "line": 695,
+              "key": "image",
+              "image": "postgrest/postgrest:v12.2.12",
+              "repository": "postgrest/postgrest",
+              "tag": "v12.2.12",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "jellyfin",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "jellyfin",
+          "image": "jellyfin/jellyfin:10.10.7",
+          "repository": "jellyfin/jellyfin",
+          "current_tag": "10.10.7",
+          "candidate_tag": "10.11.11",
+          "candidate_image": "jellyfin/jellyfin:10.11.11",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "jellyfin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jellyfin/index.yaml",
+              "line": 38,
+              "key": "originImageName",
+              "image": "jellyfin/jellyfin:10.10.7",
+              "repository": "jellyfin/jellyfin",
+              "tag": "10.10.7",
+              "digest": null
+            },
+            {
+              "template": "jellyfin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jellyfin/index.yaml",
+              "line": 63,
+              "key": "image",
+              "image": "jellyfin/jellyfin:10.10.7",
+              "repository": "jellyfin/jellyfin",
+              "tag": "10.10.7",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/jellyfin/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "kanboard",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kanboard",
+          "image": "kanboard/kanboard:v1.2.50",
+          "repository": "kanboard/kanboard",
+          "current_tag": "v1.2.50",
+          "candidate_tag": "v1.2.52",
+          "candidate_image": "kanboard/kanboard:v1.2.52",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "kanboard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml",
+              "line": 121,
+              "key": "originImageName",
+              "image": "kanboard/kanboard:v1.2.50",
+              "repository": "kanboard/kanboard",
+              "tag": "v1.2.50",
+              "digest": null
+            },
+            {
+              "template": "kanboard",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml",
+              "line": 141,
+              "key": "image",
+              "image": "kanboard/kanboard:v1.2.50",
+              "repository": "kanboard/kanboard",
+              "tag": "v1.2.50",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml:200: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "kaneo",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kaneo",
+          "image": "ghcr.io/usekaneo/api:1.1.8",
+          "repository": "ghcr.io/usekaneo/api",
+          "current_tag": "1.1.8",
+          "candidate_tag": "2.9.0",
+          "candidate_image": "ghcr.io/usekaneo/api:2.9.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "kaneo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+              "line": 170,
+              "key": "originImageName",
+              "image": "ghcr.io/usekaneo/api:1.1.8",
+              "repository": "ghcr.io/usekaneo/api",
+              "tag": "1.1.8",
+              "digest": null
+            },
+            {
+              "template": "kaneo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+              "line": 190,
+              "key": "image",
+              "image": "ghcr.io/usekaneo/api:1.1.8",
+              "repository": "ghcr.io/usekaneo/api",
+              "tag": "1.1.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:162: Service spec.ports entries must define a non-empty name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:182: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R037/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:199: PostgreSQL secret reference '${{ defaults.app_name}}-pg-conn-credential' must match the Cluster metadata.name-derived secret (${{ defaults.app_name }}-pg-conn-credential)"
+          ]
+        },
+        {
+          "template": "kaneo",
+          "image": "ghcr.io/usekaneo/web:1.1.8",
+          "repository": "ghcr.io/usekaneo/web",
+          "current_tag": "1.1.8",
+          "candidate_tag": "2.9.0",
+          "candidate_image": "ghcr.io/usekaneo/web:2.9.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "kaneo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+              "line": 234,
+              "key": "originImageName",
+              "image": "ghcr.io/usekaneo/web:1.1.8",
+              "repository": "ghcr.io/usekaneo/web",
+              "tag": "1.1.8",
+              "digest": null
+            },
+            {
+              "template": "kaneo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+              "line": 254,
+              "key": "image",
+              "image": "ghcr.io/usekaneo/web:1.1.8",
+              "repository": "ghcr.io/usekaneo/web",
+              "tag": "1.1.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:162: Service spec.ports entries must define a non-empty name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:182: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R037/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:199: PostgreSQL secret reference '${{ defaults.app_name}}-pg-conn-credential' must match the Cluster metadata.name-derived secret (${{ defaults.app_name }}-pg-conn-credential)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "keycloak",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "keycloak",
+          "image": "quay.io/keycloak/keycloak:26.3.2",
+          "repository": "quay.io/keycloak/keycloak",
+          "current_tag": "26.3.2",
+          "candidate_tag": "26.6.4",
+          "candidate_image": "quay.io/keycloak/keycloak:26.6.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "keycloak",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml",
+              "line": 177,
+              "key": "originImageName",
+              "image": "quay.io/keycloak/keycloak:26.3.2",
+              "repository": "quay.io/keycloak/keycloak",
+              "tag": "26.3.2",
+              "digest": null
+            },
+            {
+              "template": "keycloak",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml",
+              "line": 198,
+              "key": "image",
+              "image": "quay.io/keycloak/keycloak:26.3.2",
+              "repository": "quay.io/keycloak/keycloak",
+              "tag": "26.3.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:139: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:152: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:159: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:222: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:224: database env 'KC_DB_URL_HOST' must use secret key 'endpoint' from an approved database secret",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:294: Service metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:296: Service metadata.name must match spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "keystone",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "keystone",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "current_tag": "22.22.1-alpine",
+          "candidate_tag": "26.4.0-alpine",
+          "candidate_image": "node:26.4.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "keystone",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+              "line": 479,
+              "key": "originImageName",
+              "image": "node:22.22.1-alpine",
+              "repository": "node",
+              "tag": "22.22.1-alpine",
+              "digest": null
+            },
+            {
+              "template": "keystone",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+              "line": 544,
+              "key": "image",
+              "image": "node:22.22.1-alpine",
+              "repository": "node",
+              "tag": "22.22.1-alpine",
+              "digest": null
+            },
+            {
+              "template": "keystone",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+              "line": 620,
+              "key": "image",
+              "image": "node:22.22.1-alpine",
+              "repository": "node",
+              "tag": "22.22.1-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml:138: container pg-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "kuvasz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kuvasz",
+          "image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "repository": "kuvaszmonitoring/kuvasz",
+          "current_tag": "3.11.0",
+          "candidate_tag": "4.0.1",
+          "candidate_image": "kuvaszmonitoring/kuvasz:4.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "kuvasz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+              "line": 201,
+              "key": "originImageName",
+              "image": "kuvaszmonitoring/kuvasz:3.11.0",
+              "repository": "kuvaszmonitoring/kuvasz",
+              "tag": "3.11.0",
+              "digest": null
+            },
+            {
+              "template": "kuvasz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+              "line": 277,
+              "key": "image",
+              "image": "kuvaszmonitoring/kuvasz:3.11.0",
+              "repository": "kuvaszmonitoring/kuvasz",
+              "tag": "3.11.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:132: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:329: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "laf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "laf",
+          "image": "quay.io/prometheus/prometheus:v2.45.0",
+          "repository": "quay.io/prometheus/prometheus",
+          "current_tag": "v2.45.0",
+          "candidate_tag": "v3.13.0",
+          "candidate_image": "quay.io/prometheus/prometheus:v3.13.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "laf",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+              "line": 519,
+              "key": "image",
+              "image": "quay.io/prometheus/prometheus:v2.45.0",
+              "repository": "quay.io/prometheus/prometheus",
+              "tag": "v2.45.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:50: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:139: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:140: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:149: PVC storage request must be <= 1Gi",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:188: managed app workloads must define metadata.annotations.originImageName",
+            "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:193: managed app workloads must explicitly set revisionHistoryLimit: 1",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:203: automountServiceAccountToken must be false for managed app workloads"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "langflow",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "langflow",
+          "image": "langflowai/langflow:1.9.5",
+          "repository": "langflowai/langflow",
+          "current_tag": "1.9.5",
+          "candidate_tag": "1.10.2",
+          "candidate_image": "langflowai/langflow:1.10.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "langflow",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langflow/index.yaml",
+              "line": 219,
+              "key": "originImageName",
+              "image": "langflowai/langflow:1.9.5",
+              "repository": "langflowai/langflow",
+              "tag": "1.9.5",
+              "digest": null
+            },
+            {
+              "template": "langflow",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langflow/index.yaml",
+              "line": 247,
+              "key": "image",
+              "image": "langflowai/langflow:1.9.5",
+              "repository": "langflowai/langflow",
+              "tag": "1.9.5",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/langflow/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "langfuse",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "langfuse",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "current_tag": "25.4.2",
+          "candidate_tag": "26.6.1",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 385,
+              "key": "originImageName",
+              "image": "clickhouse/clickhouse-server:25.4.2",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.4.2",
+              "digest": null
+            },
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 409,
+              "key": "image",
+              "image": "clickhouse/clickhouse-server:25.4.2",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.4.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "repository": "docker.io/langfuse/langfuse-worker",
+          "current_tag": "3.180.0",
+          "candidate_tag": "3.207.0",
+          "candidate_image": "docker.io/langfuse/langfuse-worker:3.207.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 528,
+              "key": "originImageName",
+              "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+              "repository": "docker.io/langfuse/langfuse-worker",
+              "tag": "3.180.0",
+              "digest": null
+            },
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 622,
+              "key": "image",
+              "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+              "repository": "docker.io/langfuse/langfuse-worker",
+              "tag": "3.180.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "image": "docker.io/langfuse/langfuse:3.180.0",
+          "repository": "docker.io/langfuse/langfuse",
+          "current_tag": "3.180.0",
+          "candidate_tag": "3.207.0",
+          "candidate_image": "docker.io/langfuse/langfuse:3.207.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 786,
+              "key": "originImageName",
+              "image": "docker.io/langfuse/langfuse:3.180.0",
+              "repository": "docker.io/langfuse/langfuse",
+              "tag": "3.180.0",
+              "digest": null
+            },
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 839,
+              "key": "image",
+              "image": "docker.io/langfuse/langfuse:3.180.0",
+              "repository": "docker.io/langfuse/langfuse",
+              "tag": "3.180.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 591,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "langfuse",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+              "line": 808,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "librechat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "librechat",
+          "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "repository": "ghcr.io/danny-avila/librechat",
+          "current_tag": "v0.7.3",
+          "candidate_tag": "v0.8.7",
+          "candidate_image": "ghcr.io/danny-avila/librechat:v0.8.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "librechat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+              "line": 52,
+              "key": "originImageName",
+              "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+              "repository": "ghcr.io/danny-avila/librechat",
+              "tag": "v0.7.3",
+              "digest": null
+            },
+            {
+              "template": "librechat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+              "line": 75,
+              "key": "image",
+              "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+              "repository": "ghcr.io/danny-avila/librechat",
+              "tag": "v0.7.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:32: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:50: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:66: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:249: Service spec.ports entries must define a non-empty name",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:260: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:283: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "liebianbao",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "liebianbao",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "liebianbao",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+              "line": 99,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:8: Template spec.gitRepo must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:47: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:72: container initializer must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:77: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:131: container imagePullPolicy must be IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:221: container ${{ defaults.app_name }} requests.cpu must be 100m when limits.cpu is 1"
+          ]
+        },
+        {
+          "template": "liebianbao",
+          "image": "nginx:1.25.2",
+          "repository": "nginx",
+          "current_tag": "1.25.2",
+          "candidate_tag": "1.31.2",
+          "candidate_image": "nginx:1.31.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "liebianbao",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+              "line": 253,
+              "key": "image",
+              "image": "nginx:1.25.2",
+              "repository": "nginx",
+              "tag": "1.25.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:8: Template spec.gitRepo must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:47: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:72: container initializer must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:77: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:131: container imagePullPolicy must be IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:221: container ${{ defaults.app_name }} requests.cpu must be 100m when limits.cpu is 1"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "listmonk",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "listmonk",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "current_tag": "1.37.0",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "listmonk",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+              "line": 252,
+              "key": "image",
+              "image": "busybox:1.37.0",
+              "repository": "busybox",
+              "tag": "1.37.0",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/listmonk/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "listmonk",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "current_tag": "v6.1.0",
+          "candidate_tag": "v6.2.0",
+          "candidate_image": "listmonk/listmonk:v6.2.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "listmonk",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+              "line": 224,
+              "key": "originImageName",
+              "image": "listmonk/listmonk:v6.1.0",
+              "repository": "listmonk/listmonk",
+              "tag": "v6.1.0",
+              "digest": null
+            },
+            {
+              "template": "listmonk",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+              "line": 274,
+              "key": "image",
+              "image": "listmonk/listmonk:v6.1.0",
+              "repository": "listmonk/listmonk",
+              "tag": "v6.1.0",
+              "digest": null
+            },
+            {
+              "template": "listmonk",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+              "line": 343,
+              "key": "image",
+              "image": "listmonk/listmonk:v6.1.0",
+              "repository": "listmonk/listmonk",
+              "tag": "v6.1.0",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/listmonk/index.yaml"
+          ],
+          "replacement_count": 3,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "litellm",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "litellm",
+          "image": "litellm/litellm-database:v1.88.1",
+          "repository": "litellm/litellm-database",
+          "current_tag": "v1.88.1",
+          "candidate_tag": "v1.91.0",
+          "candidate_image": "litellm/litellm-database:v1.91.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "litellm",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+              "line": 255,
+              "key": "originImageName",
+              "image": "litellm/litellm-database:v1.88.1",
+              "repository": "litellm/litellm-database",
+              "tag": "v1.88.1",
+              "digest": null
+            },
+            {
+              "template": "litellm",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+              "line": 322,
+              "key": "image",
+              "image": "litellm/litellm-database:v1.88.1",
+              "repository": "litellm/litellm-database",
+              "tag": "v1.88.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/litellm/index.yaml"
+          ],
+          "replacement_count": 3,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "llmgateway",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "llmgateway",
+          "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-api",
+          "current_tag": "v1.3.0",
+          "candidate_tag": "v1.7.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-api:v1.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 357,
+              "key": "originImageName",
+              "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-api",
+              "tag": "v1.3.0",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 442,
+              "key": "image",
+              "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-api",
+              "tag": "v1.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-docs",
+          "current_tag": "v1.3.0",
+          "candidate_tag": "v1.7.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-docs:v1.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 1195,
+              "key": "originImageName",
+              "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-docs",
+              "tag": "v1.3.0",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 1217,
+              "key": "image",
+              "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-docs",
+              "tag": "v1.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-gateway",
+          "current_tag": "v1.3.0",
+          "candidate_tag": "v1.7.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-gateway:v1.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 590,
+              "key": "originImageName",
+              "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-gateway",
+              "tag": "v1.3.0",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 716,
+              "key": "image",
+              "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-gateway",
+              "tag": "v1.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-ui",
+          "current_tag": "v1.3.0",
+          "candidate_tag": "v1.7.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-ui:v1.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 1066,
+              "key": "originImageName",
+              "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-ui",
+              "tag": "v1.3.0",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 1087,
+              "key": "image",
+              "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-ui",
+              "tag": "v1.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-worker",
+          "current_tag": "v1.3.0",
+          "candidate_tag": "v1.7.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-worker:v1.7.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 874,
+              "key": "originImageName",
+              "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-worker",
+              "tag": "v1.3.0",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 1001,
+              "key": "image",
+              "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+              "repository": "ghcr.io/theopenco/llmgateway-worker",
+              "tag": "v1.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 419,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 693,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "llmgateway",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+              "line": 978,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "lobe-chat-db",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "lobe-chat-db",
+          "image": "lobehub/lobe-chat-database:1.143.2",
+          "repository": "lobehub/lobe-chat-database",
+          "current_tag": "1.143.2",
+          "candidate_tag": "1.143.3",
+          "candidate_image": "lobehub/lobe-chat-database:1.143.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "lobe-chat-db",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml",
+              "line": 212,
+              "key": "originImageName",
+              "image": "lobehub/lobe-chat-database:1.143.2",
+              "repository": "lobehub/lobe-chat-database",
+              "tag": "1.143.2",
+              "digest": null
+            },
+            {
+              "template": "lobe-chat-db",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml",
+              "line": 237,
+              "key": "image",
+              "image": "lobehub/lobe-chat-database:1.143.2",
+              "repository": "lobehub/lobe-chat-database",
+              "tag": "1.143.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:162: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:278: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:312: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:326: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:329: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:348: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "logto",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "logto",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "current_tag": "1.40.1",
+          "candidate_tag": "1.41.0",
+          "candidate_image": "svhd/logto:1.41.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "logto",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+              "line": 179,
+              "key": "originImageName",
+              "image": "svhd/logto:1.40.1",
+              "repository": "svhd/logto",
+              "tag": "1.40.1",
+              "digest": null
+            },
+            {
+              "template": "logto",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+              "line": 204,
+              "key": "image",
+              "image": "svhd/logto:1.40.1",
+              "repository": "svhd/logto",
+              "tag": "1.40.1",
+              "digest": null
+            },
+            {
+              "template": "logto",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+              "line": 253,
+              "key": "image",
+              "image": "svhd/logto:1.40.1",
+              "repository": "svhd/logto",
+              "tag": "1.40.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/logto/index.yaml"
+          ],
+          "replacement_count": 3,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "loki",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "loki",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "current_tag": "1.37.0",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "loki",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/loki/index.yaml",
+              "line": 57,
+              "key": "image",
+              "image": "busybox:1.37.0",
+              "repository": "busybox",
+              "tag": "1.37.0",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/loki/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "mastodon",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "mastodon",
+          "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon-streaming",
+          "current_tag": "v4.5.11",
+          "candidate_tag": "v4.6.3",
+          "candidate_image": "ghcr.io/mastodon/mastodon-streaming:v4.6.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 937,
+              "key": "originImageName",
+              "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon-streaming",
+              "tag": "v4.5.11",
+              "digest": null
+            },
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 1004,
+              "key": "image",
+              "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon-streaming",
+              "tag": "v4.5.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:561: container mastodon-setup limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:562: container mastodon-setup limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:590: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:742: container ${{ defaults.app_name }}-web limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:743: container ${{ defaults.app_name }}-web limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:768: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:926: container ${{ defaults.app_name }}-sidekiq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:927: container ${{ defaults.app_name }}-sidekiq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "mastodon",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "current_tag": "v4.5.11",
+          "candidate_tag": "v4.6.3",
+          "candidate_image": "ghcr.io/mastodon/mastodon:v4.6.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 455,
+              "key": "image",
+              "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon",
+              "tag": "v4.5.11",
+              "digest": null
+            },
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 572,
+              "key": "originImageName",
+              "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon",
+              "tag": "v4.5.11",
+              "digest": null
+            },
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 639,
+              "key": "image",
+              "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon",
+              "tag": "v4.5.11",
+              "digest": null
+            },
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 753,
+              "key": "originImageName",
+              "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon",
+              "tag": "v4.5.11",
+              "digest": null
+            },
+            {
+              "template": "mastodon",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+              "line": 817,
+              "key": "image",
+              "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+              "repository": "ghcr.io/mastodon/mastodon",
+              "tag": "v4.5.11",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:561: container mastodon-setup limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:562: container mastodon-setup limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:590: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:742: container ${{ defaults.app_name }}-web limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:743: container ${{ defaults.app_name }}-web limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:768: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:926: container ${{ defaults.app_name }}-sidekiq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:927: container ${{ defaults.app_name }}-sidekiq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "matomo",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "matomo",
+          "image": "matomo:5.10.0-apache",
+          "repository": "matomo",
+          "current_tag": "5.10.0-apache",
+          "candidate_tag": "5.11.2-apache",
+          "candidate_image": "matomo:5.11.2-apache",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "matomo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+              "line": 179,
+              "key": "originImageName",
+              "image": "matomo:5.10.0-apache",
+              "repository": "matomo",
+              "tag": "5.10.0-apache",
+              "digest": null
+            },
+            {
+              "template": "matomo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+              "line": 201,
+              "key": "image",
+              "image": "matomo:5.10.0-apache",
+              "repository": "matomo",
+              "tag": "5.10.0-apache",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/matomo/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "matomo",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "current_tag": "8.0.44",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "matomo",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+              "line": 135,
+              "key": "image",
+              "image": "mysql:8.0.44",
+              "repository": "mysql",
+              "tag": "8.0.44",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/matomo/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "mautic",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "mautic",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 473,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 597,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "mautic",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "current_tag": "7.1.2-apache",
+          "candidate_tag": "7.1.3-apache",
+          "candidate_image": "mautic/mautic:7.1.3-apache",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 242,
+              "key": "originImageName",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 266,
+              "key": "image",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 316,
+              "key": "image",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 343,
+              "key": "image",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 440,
+              "key": "originImageName",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 492,
+              "key": "image",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 564,
+              "key": "originImageName",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            },
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 616,
+              "key": "image",
+              "image": "mautic/mautic:7.1.2-apache",
+              "repository": "mautic/mautic",
+              "tag": "7.1.2-apache",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 8,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "mautic",
+          "image": "mysql:8.4.2",
+          "repository": "mysql",
+          "current_tag": "8.4.2",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mautic",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+              "line": 141,
+              "key": "image",
+              "image": "mysql:8.4.2",
+              "repository": "mysql",
+              "tag": "8.4.2",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "meilisearch",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "meilisearch",
+          "image": "getmeili/meilisearch:v1.45.1",
+          "repository": "getmeili/meilisearch",
+          "current_tag": "v1.45.1",
+          "candidate_tag": "v1.49.0",
+          "candidate_image": "getmeili/meilisearch:v1.49.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "meilisearch",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+              "line": 44,
+              "key": "originImageName",
+              "image": "getmeili/meilisearch:v1.45.1",
+              "repository": "getmeili/meilisearch",
+              "tag": "v1.45.1",
+              "digest": null
+            },
+            {
+              "template": "meilisearch",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+              "line": 68,
+              "key": "image",
+              "image": "getmeili/meilisearch:v1.45.1",
+              "repository": "getmeili/meilisearch",
+              "tag": "v1.45.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/meilisearch/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "metabase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "metabase",
+          "image": "metabase/metabase:v0.61.3",
+          "repository": "metabase/metabase",
+          "current_tag": "v0.61.3",
+          "candidate_tag": "v0.62.3",
+          "candidate_image": "metabase/metabase:v0.62.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "metabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml",
+              "line": 171,
+              "key": "originImageName",
+              "image": "metabase/metabase:v0.61.3",
+              "repository": "metabase/metabase",
+              "tag": "v0.61.3",
+              "digest": null
+            },
+            {
+              "template": "metabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml",
+              "line": 194,
+              "key": "image",
+              "image": "metabase/metabase:v0.61.3",
+              "repository": "metabase/metabase",
+              "tag": "v0.61.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml:251: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "minecraft",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "minecraft",
+          "image": "alpine:3.22.4",
+          "repository": "alpine",
+          "current_tag": "3.22.4",
+          "candidate_tag": "3.24.1",
+          "candidate_image": "alpine:3.24.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "minecraft",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+              "line": 71,
+              "key": "image",
+              "image": "alpine:3.22.4",
+              "repository": "alpine",
+              "tag": "3.22.4",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/minecraft/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "minecraft",
+          "image": "itzg/minecraft-server:2026.5.3-java25",
+          "repository": "itzg/minecraft-server",
+          "current_tag": "2026.5.3-java25",
+          "candidate_tag": "2026.7.0-java8",
+          "candidate_image": "itzg/minecraft-server:2026.7.0-java8",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "minecraft",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+              "line": 48,
+              "key": "originImageName",
+              "image": "itzg/minecraft-server:2026.5.3-java25",
+              "repository": "itzg/minecraft-server",
+              "tag": "2026.5.3-java25",
+              "digest": null
+            },
+            {
+              "template": "minecraft",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+              "line": 91,
+              "key": "image",
+              "image": "itzg/minecraft-server:2026.5.3-java25",
+              "repository": "itzg/minecraft-server",
+              "tag": "2026.5.3-java25",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/minecraft/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "mlflow",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "mlflow",
+          "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "repository": "ghcr.io/mlflow/mlflow",
+          "current_tag": "v3.12.0",
+          "candidate_tag": "v3.14.0",
+          "candidate_image": "ghcr.io/mlflow/mlflow:v3.14.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "mlflow",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+              "line": 201,
+              "key": "originImageName",
+              "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+              "repository": "ghcr.io/mlflow/mlflow",
+              "tag": "v3.12.0",
+              "digest": null
+            },
+            {
+              "template": "mlflow",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+              "line": 270,
+              "key": "image",
+              "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+              "repository": "ghcr.io/mlflow/mlflow",
+              "tag": "v3.12.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml:214: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "n8n",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "n8n",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "current_tag": "2.22.4",
+          "candidate_tag": "2.30.1",
+          "candidate_image": "n8nio/n8n:2.30.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 337,
+              "key": "originImageName",
+              "image": "n8nio/n8n:2.22.4",
+              "repository": "n8nio/n8n",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 370,
+              "key": "image",
+              "image": "n8nio/n8n:2.22.4",
+              "repository": "n8nio/n8n",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 583,
+              "key": "originImageName",
+              "image": "n8nio/n8n:2.22.4",
+              "repository": "n8nio/n8n",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 624,
+              "key": "image",
+              "image": "n8nio/n8n:2.22.4",
+              "repository": "n8nio/n8n",
+              "tag": "2.22.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:540: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:601: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:729: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "n8n",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "current_tag": "2.22.4",
+          "candidate_tag": "2.30.1",
+          "candidate_image": "n8nio/runners:2.30.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 522,
+              "key": "originImageName",
+              "image": "n8nio/runners:2.22.4",
+              "repository": "n8nio/runners",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 544,
+              "key": "image",
+              "image": "n8nio/runners:2.22.4",
+              "repository": "n8nio/runners",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 711,
+              "key": "originImageName",
+              "image": "n8nio/runners:2.22.4",
+              "repository": "n8nio/runners",
+              "tag": "2.22.4",
+              "digest": null
+            },
+            {
+              "template": "n8n",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+              "line": 733,
+              "key": "image",
+              "image": "n8nio/runners:2.22.4",
+              "repository": "n8nio/runners",
+              "tag": "2.22.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:540: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:601: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:729: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "nacos",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nacos",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "current_tag": "8.0.44",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "nacos",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+              "line": 347,
+              "key": "image",
+              "image": "mysql:8.0.44",
+              "repository": "mysql",
+              "tag": "8.0.44",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:494: container ${{ defaults.app_name }}-console limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:631: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "netbird",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "netbird",
+          "image": "netbirdio/dashboard:v2.38.1",
+          "repository": "netbirdio/dashboard",
+          "current_tag": "v2.38.1",
+          "candidate_tag": "v2.90.3",
+          "candidate_image": "netbirdio/dashboard:v2.90.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 150,
+              "key": "originImageName",
+              "image": "netbirdio/dashboard:v2.38.1",
+              "repository": "netbirdio/dashboard",
+              "tag": "v2.38.1",
+              "digest": null
+            },
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 170,
+              "key": "image",
+              "image": "netbirdio/dashboard:v2.38.1",
+              "repository": "netbirdio/dashboard",
+              "tag": "v2.38.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "image": "netbirdio/management:0.71.4",
+          "repository": "netbirdio/management",
+          "current_tag": "0.71.4",
+          "candidate_tag": "0.74.2",
+          "candidate_image": "netbirdio/management:0.74.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 217,
+              "key": "originImageName",
+              "image": "netbirdio/management:0.71.4",
+              "repository": "netbirdio/management",
+              "tag": "0.71.4",
+              "digest": null
+            },
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 238,
+              "key": "image",
+              "image": "netbirdio/management:0.71.4",
+              "repository": "netbirdio/management",
+              "tag": "0.71.4",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "image": "netbirdio/relay:0.71.4",
+          "repository": "netbirdio/relay",
+          "current_tag": "0.71.4",
+          "candidate_tag": "0.74.2",
+          "candidate_image": "netbirdio/relay:0.74.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 356,
+              "key": "originImageName",
+              "image": "netbirdio/relay:0.71.4",
+              "repository": "netbirdio/relay",
+              "tag": "0.71.4",
+              "digest": null
+            },
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 376,
+              "key": "image",
+              "image": "netbirdio/relay:0.71.4",
+              "repository": "netbirdio/relay",
+              "tag": "0.71.4",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "image": "netbirdio/signal:0.71.4",
+          "repository": "netbirdio/signal",
+          "current_tag": "0.71.4",
+          "candidate_tag": "0.74.2",
+          "candidate_image": "netbirdio/signal:0.74.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 295,
+              "key": "originImageName",
+              "image": "netbirdio/signal:0.71.4",
+              "repository": "netbirdio/signal",
+              "tag": "0.71.4",
+              "digest": null
+            },
+            {
+              "template": "netbird",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+              "line": 316,
+              "key": "image",
+              "image": "netbirdio/signal:0.71.4",
+              "repository": "netbirdio/signal",
+              "tag": "0.71.4",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "nexus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nexus",
+          "image": "alpine:3.22.2",
+          "repository": "alpine",
+          "current_tag": "3.22.2",
+          "candidate_tag": "3.24.1",
+          "candidate_image": "alpine:3.24.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "nexus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+              "line": 61,
+              "key": "image",
+              "image": "alpine:3.22.2",
+              "repository": "alpine",
+              "tag": "3.22.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml:94: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "nexus",
+          "image": "sonatype/nexus3:3.92.3",
+          "repository": "sonatype/nexus3",
+          "current_tag": "3.92.3",
+          "candidate_tag": "3.93.2",
+          "candidate_image": "sonatype/nexus3:3.93.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "nexus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+              "line": 37,
+              "key": "originImageName",
+              "image": "sonatype/nexus3:3.92.3",
+              "repository": "sonatype/nexus3",
+              "tag": "3.92.3",
+              "digest": null
+            },
+            {
+              "template": "nexus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+              "line": 79,
+              "key": "image",
+              "image": "sonatype/nexus3:3.92.3",
+              "repository": "sonatype/nexus3",
+              "tag": "3.92.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml:94: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "nocodb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nocodb",
+          "image": "nocodb/nocodb:2026.05.2",
+          "repository": "nocodb/nocodb",
+          "current_tag": "2026.05.2",
+          "candidate_tag": "2026.06.2",
+          "candidate_image": "nocodb/nocodb:2026.06.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "medium",
+          "reason": "newer compatible date tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "nocodb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml",
+              "line": 132,
+              "key": "originImageName",
+              "image": "nocodb/nocodb:2026.05.2",
+              "repository": "nocodb/nocodb",
+              "tag": "2026.05.2",
+              "digest": null
+            },
+            {
+              "template": "nocodb",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml",
+              "line": 156,
+              "key": "image",
+              "image": "nocodb/nocodb:2026.05.2",
+              "repository": "nocodb/nocodb",
+              "tag": "2026.05.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml:192: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "node-red",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "node-red",
+          "image": "nodered/node-red:4.1.10",
+          "repository": "nodered/node-red",
+          "current_tag": "4.1.10",
+          "candidate_tag": "5.0.1",
+          "candidate_image": "nodered/node-red:5.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "node-red",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/node-red/index.yaml",
+              "line": 36,
+              "key": "originImageName",
+              "image": "nodered/node-red:4.1.10",
+              "repository": "nodered/node-red",
+              "tag": "4.1.10",
+              "digest": null
+            },
+            {
+              "template": "node-red",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/node-red/index.yaml",
+              "line": 61,
+              "key": "image",
+              "image": "nodered/node-red:4.1.10",
+              "repository": "nodered/node-red",
+              "tag": "4.1.10",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/node-red/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "nofx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nofx",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "current_tag": "3.5.4",
+          "candidate_tag": "3.5.7",
+          "candidate_image": "alpine/openssl:3.5.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "nofx",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+              "line": 210,
+              "key": "image",
+              "image": "alpine/openssl:3.5.4",
+              "repository": "alpine/openssl",
+              "tag": "3.5.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:201: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:439: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "odysseus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "odysseus",
+          "image": "chromadb/chroma:1.0.15",
+          "repository": "chromadb/chroma",
+          "current_tag": "1.0.15",
+          "candidate_tag": "1.5.9",
+          "candidate_image": "chromadb/chroma:1.5.9",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "odysseus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+              "line": 73,
+              "key": "originImageName",
+              "image": "chromadb/chroma:1.0.15",
+              "repository": "chromadb/chroma",
+              "tag": "1.0.15",
+              "digest": null
+            },
+            {
+              "template": "odysseus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+              "line": 94,
+              "key": "image",
+              "image": "chromadb/chroma:1.0.15",
+              "repository": "chromadb/chroma",
+              "tag": "1.0.15",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:286: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:363: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "odysseus",
+          "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+          "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+          "current_tag": "1.0.0",
+          "candidate_tag": "1.0.1",
+          "candidate_image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "odysseus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+              "line": 272,
+              "key": "originImageName",
+              "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+              "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+              "tag": "1.0.0",
+              "digest": null
+            },
+            {
+              "template": "odysseus",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+              "line": 294,
+              "key": "image",
+              "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+              "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+              "tag": "1.0.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:286: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:363: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "open-webui",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "open-webui",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "current_tag": "v0.5.4",
+          "candidate_tag": "v0.10.2",
+          "candidate_image": "ghcr.io/open-webui/open-webui:v0.10.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "open-webui",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+              "line": 36,
+              "key": "originImageName",
+              "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+              "repository": "ghcr.io/open-webui/open-webui",
+              "tag": "v0.5.4",
+              "digest": null
+            },
+            {
+              "template": "open-webui",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+              "line": 59,
+              "key": "image",
+              "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+              "repository": "ghcr.io/open-webui/open-webui",
+              "tag": "v0.5.4",
+              "digest": null
+            },
+            {
+              "template": "open-webui",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+              "line": 65,
+              "key": "image",
+              "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+              "repository": "ghcr.io/open-webui/open-webui",
+              "tag": "v0.5.4",
+              "digest": null
+            },
+            {
+              "template": "open-webui",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+              "line": 74,
+              "key": "image",
+              "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+              "repository": "ghcr.io/open-webui/open-webui",
+              "tag": "v0.5.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container copy-data must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container init-data must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:89: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "openclaw",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "openclaw",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "current_tag": "2026.3.8",
+          "candidate_tag": "2026.6.11",
+          "candidate_image": "ghcr.io/openclaw/openclaw:2026.6.11",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "openclaw",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+              "line": 62,
+              "key": "originImageName",
+              "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+              "repository": "ghcr.io/openclaw/openclaw",
+              "tag": "2026.3.8",
+              "digest": null
+            },
+            {
+              "template": "openclaw",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+              "line": 102,
+              "key": "image",
+              "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+              "repository": "ghcr.io/openclaw/openclaw",
+              "tag": "2026.3.8",
+              "digest": null
+            },
+            {
+              "template": "openclaw",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+              "line": 160,
+              "key": "image",
+              "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+              "repository": "ghcr.io/openclaw/openclaw",
+              "tag": "2026.3.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:57: container init-openclaw-data must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:221: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:222: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "openlist",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "openlist",
+          "image": "openlistteam/openlist:v4.0.9-aria2",
+          "repository": "openlistteam/openlist",
+          "current_tag": "v4.0.9-aria2",
+          "candidate_tag": "v4.2.3-aria2",
+          "candidate_image": "openlistteam/openlist:v4.2.3-aria2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "openlist",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml",
+              "line": 49,
+              "key": "originImageName",
+              "image": "openlistteam/openlist:v4.0.9-aria2",
+              "repository": "openlistteam/openlist",
+              "tag": "v4.0.9-aria2",
+              "digest": null
+            },
+            {
+              "template": "openlist",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml",
+              "line": 72,
+              "key": "image",
+              "image": "openlistteam/openlist:v4.0.9-aria2",
+              "repository": "openlistteam/openlist",
+              "tag": "v4.0.9-aria2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:120: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:123: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "openobserve",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "openobserve",
+          "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "repository": "public.ecr.aws/zinclabs/openobserve",
+          "current_tag": "v0.90.3",
+          "candidate_tag": "v0.91.1",
+          "candidate_image": "public.ecr.aws/zinclabs/openobserve:v0.91.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "openobserve",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openobserve/index.yaml",
+              "line": 68,
+              "key": "originImageName",
+              "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+              "repository": "public.ecr.aws/zinclabs/openobserve",
+              "tag": "v0.90.3",
+              "digest": null
+            },
+            {
+              "template": "openobserve",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openobserve/index.yaml",
+              "line": 97,
+              "key": "image",
+              "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+              "repository": "public.ecr.aws/zinclabs/openobserve",
+              "tag": "v0.90.3",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/openobserve/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "outline",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "outline",
+          "image": "outlinewiki/outline:1.8.0-1",
+          "repository": "outlinewiki/outline",
+          "current_tag": "1.8.0-1",
+          "candidate_tag": "1.8.2-0",
+          "candidate_image": "outlinewiki/outline:1.8.2-0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "outline",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml",
+              "line": 427,
+              "key": "originImageName",
+              "image": "outlinewiki/outline:1.8.0-1",
+              "repository": "outlinewiki/outline",
+              "tag": "1.8.0-1",
+              "digest": null
+            },
+            {
+              "template": "outline",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml",
+              "line": 448,
+              "key": "image",
+              "image": "outlinewiki/outline:1.8.0-1",
+              "repository": "outlinewiki/outline",
+              "tag": "1.8.0-1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml:371: container pgsql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "overleaf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "overleaf",
+          "image": "sharelatex/sharelatex:6.1.2",
+          "repository": "sharelatex/sharelatex",
+          "current_tag": "6.1.2",
+          "candidate_tag": "6.2.1",
+          "candidate_image": "sharelatex/sharelatex:6.2.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "overleaf",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml",
+              "line": 260,
+              "key": "originImageName",
+              "image": "sharelatex/sharelatex:6.1.2",
+              "repository": "sharelatex/sharelatex",
+              "tag": "6.1.2",
+              "digest": null
+            },
+            {
+              "template": "overleaf",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml",
+              "line": 284,
+              "key": "image",
+              "image": "sharelatex/sharelatex:6.1.2",
+              "repository": "sharelatex/sharelatex",
+              "tag": "6.1.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:330: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:331: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:450: App resource spec.type must be 'link'"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pageplug",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pageplug",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "repository": "cloudtogouser/pageplug-ce",
+          "current_tag": "v1.9.35",
+          "candidate_tag": "v1.9.37",
+          "candidate_image": "cloudtogouser/pageplug-ce:v1.9.37",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pageplug",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml",
+              "line": 38,
+              "key": "originImageName",
+              "image": "cloudtogouser/pageplug-ce:v1.9.35",
+              "repository": "cloudtogouser/pageplug-ce",
+              "tag": "v1.9.35",
+              "digest": null
+            },
+            {
+              "template": "pageplug",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml",
+              "line": 61,
+              "key": "image",
+              "image": "cloudtogouser/pageplug-ce:v1.9.35",
+              "repository": "cloudtogouser/pageplug-ce",
+              "tag": "v1.9.35",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:119: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pangolin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pangolin",
+          "image": "docker.io/fosrl/pangolin:1.15.2",
+          "repository": "docker.io/fosrl/pangolin",
+          "current_tag": "1.15.2",
+          "candidate_tag": "1.19.4",
+          "candidate_image": "docker.io/fosrl/pangolin:1.19.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pangolin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml",
+              "line": 102,
+              "key": "originImageName",
+              "image": "docker.io/fosrl/pangolin:1.15.2",
+              "repository": "docker.io/fosrl/pangolin",
+              "tag": "1.15.2",
+              "digest": null
+            },
+            {
+              "template": "pangolin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml",
+              "line": 122,
+              "key": "image",
+              "image": "docker.io/fosrl/pangolin:1.15.2",
+              "repository": "docker.io/fosrl/pangolin",
+              "tag": "1.15.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:44: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:127: container ${{ defaults.app_name }}-pangolin limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:181: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "paperclip",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "paperclip",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "paperclip",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+              "line": 257,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+              "repository": "public.ecr.aws/docker/library/busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/paperclip/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pdf2zh",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pdf2zh",
+          "image": "byaidu/pdf2zh:1.9.6",
+          "repository": "byaidu/pdf2zh",
+          "current_tag": "1.9.6",
+          "candidate_tag": "1.9.11",
+          "candidate_image": "byaidu/pdf2zh:1.9.11",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pdf2zh",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml",
+              "line": 38,
+              "key": "originImageName",
+              "image": "byaidu/pdf2zh:1.9.6",
+              "repository": "byaidu/pdf2zh",
+              "tag": "1.9.6",
+              "digest": null
+            },
+            {
+              "template": "pdf2zh",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml",
+              "line": 63,
+              "key": "image",
+              "image": "byaidu/pdf2zh:1.9.6",
+              "repository": "byaidu/pdf2zh",
+              "tag": "1.9.6",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:70: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:81: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:84: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "penpot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "penpot",
+          "image": "penpotapp/backend:2.1.2",
+          "repository": "penpotapp/backend",
+          "current_tag": "2.1.2",
+          "candidate_tag": "2.16.2",
+          "candidate_image": "penpotapp/backend:2.16.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 281,
+              "key": "originImageName",
+              "image": "penpotapp/backend:2.1.2",
+              "repository": "penpotapp/backend",
+              "tag": "2.1.2",
+              "digest": null
+            },
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 307,
+              "key": "image",
+              "image": "penpotapp/backend:2.1.2",
+              "repository": "penpotapp/backend",
+              "tag": "2.1.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        },
+        {
+          "template": "penpot",
+          "image": "penpotapp/exporter:2.1.2",
+          "repository": "penpotapp/exporter",
+          "current_tag": "2.1.2",
+          "candidate_tag": "2.16.2",
+          "candidate_image": "penpotapp/exporter:2.16.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 422,
+              "key": "originImageName",
+              "image": "penpotapp/exporter:2.1.2",
+              "repository": "penpotapp/exporter",
+              "tag": "2.1.2",
+              "digest": null
+            },
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 447,
+              "key": "image",
+              "image": "penpotapp/exporter:2.1.2",
+              "repository": "penpotapp/exporter",
+              "tag": "2.1.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        },
+        {
+          "template": "penpot",
+          "image": "penpotapp/frontend:2.1.2",
+          "repository": "penpotapp/frontend",
+          "current_tag": "2.1.2",
+          "candidate_tag": "2.16.2",
+          "candidate_image": "penpotapp/frontend:2.16.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 496,
+              "key": "originImageName",
+              "image": "penpotapp/frontend:2.1.2",
+              "repository": "penpotapp/frontend",
+              "tag": "2.1.2",
+              "digest": null
+            },
+            {
+              "template": "penpot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+              "line": 523,
+              "key": "image",
+              "image": "penpotapp/frontend:2.1.2",
+              "repository": "penpotapp/frontend",
+              "tag": "2.1.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "perplexica",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "perplexica",
+          "image": "itzcrazykns1337/perplexica:v1.10.2",
+          "repository": "itzcrazykns1337/perplexica",
+          "current_tag": "v1.10.2",
+          "candidate_tag": "v1.12.0",
+          "candidate_image": "itzcrazykns1337/perplexica:v1.12.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "perplexica",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+              "line": 261,
+              "key": "originImageName",
+              "image": "itzcrazykns1337/perplexica:v1.10.2",
+              "repository": "itzcrazykns1337/perplexica",
+              "tag": "v1.10.2",
+              "digest": null
+            },
+            {
+              "template": "perplexica",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+              "line": 284,
+              "key": "image",
+              "image": "itzcrazykns1337/perplexica:v1.10.2",
+              "repository": "itzcrazykns1337/perplexica",
+              "tag": "v1.10.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:48: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:165: container ${{ defaults.app_name }}-searxng limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:207: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:210: Service spec.ports entries must define a non-empty name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:216: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:218: ConfigMap metadata.labels.app is required and must match metadata.name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "phpmyadmin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "phpmyadmin",
+          "image": "phpmyadmin:5.2.1",
+          "repository": "phpmyadmin",
+          "current_tag": "5.2.1",
+          "candidate_tag": "5.2.3",
+          "candidate_image": "phpmyadmin:5.2.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "phpmyadmin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml",
+              "line": 35,
+              "key": "originImageName",
+              "image": "phpmyadmin:5.2.1",
+              "repository": "phpmyadmin",
+              "tag": "5.2.1",
+              "digest": null
+            },
+            {
+              "template": "phpmyadmin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml",
+              "line": 55,
+              "key": "image",
+              "image": "phpmyadmin:5.2.1",
+              "repository": "phpmyadmin",
+              "tag": "5.2.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:85: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:116: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:119: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "planka",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "planka",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "planka",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml",
+              "line": 219,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml:211: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pocket-id",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pocket-id",
+          "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "repository": "ghcr.io/pocket-id/pocket-id",
+          "current_tag": "v2.2.0",
+          "candidate_tag": "v2.9.0",
+          "candidate_image": "ghcr.io/pocket-id/pocket-id:v2.9.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pocket-id",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml",
+              "line": 40,
+              "key": "originImageName",
+              "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+              "repository": "ghcr.io/pocket-id/pocket-id",
+              "tag": "v2.2.0",
+              "digest": null
+            },
+            {
+              "template": "pocket-id",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml",
+              "line": 60,
+              "key": "image",
+              "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+              "repository": "ghcr.io/pocket-id/pocket-id",
+              "tag": "v2.2.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:52: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:99: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:102: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pocketbase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pocketbase",
+          "image": "adrianmusante/pocketbase:0.29.3",
+          "repository": "adrianmusante/pocketbase",
+          "current_tag": "0.29.3",
+          "candidate_tag": "0.39.5",
+          "candidate_image": "adrianmusante/pocketbase:0.39.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pocketbase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml",
+              "line": 58,
+              "key": "originImageName",
+              "image": "adrianmusante/pocketbase:0.29.3",
+              "repository": "adrianmusante/pocketbase",
+              "tag": "0.29.3",
+              "digest": null
+            },
+            {
+              "template": "pocketbase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml",
+              "line": 87,
+              "key": "image",
+              "image": "adrianmusante/pocketbase:0.29.3",
+              "repository": "adrianmusante/pocketbase",
+              "tag": "0.29.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:147: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:151: Service spec.ports entries must define a non-empty name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:201: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:204: Ingress backend service.name must match Ingress metadata.name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "posthog",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "posthog",
+          "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "repository": "docker.redpanda.com/redpandadata/redpanda",
+          "current_tag": "v25.1.9",
+          "candidate_tag": "v26.1.12",
+          "candidate_image": "docker.redpanda.com/redpandadata/redpanda:v26.1.12",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "posthog",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+              "line": 339,
+              "key": "originImageName",
+              "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+              "repository": "docker.redpanda.com/redpandadata/redpanda",
+              "tag": "v25.1.9",
+              "digest": null
+            },
+            {
+              "template": "posthog",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+              "line": 360,
+              "key": "image",
+              "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+              "repository": "docker.redpanda.com/redpandadata/redpanda",
+              "tag": "v25.1.9",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:322: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:323: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:463: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:538: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:539: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:612: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:625: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:627: container ${{ defaults.app_name }} requests.cpu must be 50m when limits.cpu is 500m"
+          ]
+        },
+        {
+          "template": "posthog",
+          "image": "zookeeper:3.9.3",
+          "repository": "zookeeper",
+          "current_tag": "3.9.3",
+          "candidate_tag": "3.9.5",
+          "candidate_image": "zookeeper:3.9.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "posthog",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+              "line": 481,
+              "key": "originImageName",
+              "image": "zookeeper:3.9.3",
+              "repository": "zookeeper",
+              "tag": "3.9.3",
+              "digest": null
+            },
+            {
+              "template": "posthog",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+              "line": 502,
+              "key": "image",
+              "image": "zookeeper:3.9.3",
+              "repository": "zookeeper",
+              "tag": "3.9.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:322: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:323: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:463: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:538: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:539: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:612: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:625: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:627: container ${{ defaults.app_name }} requests.cpu must be 50m when limits.cpu is 500m"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "postiz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "postiz",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "current_tag": "1.36.1",
+          "candidate_tag": "1.38.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 326,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            },
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 531,
+              "key": "image",
+              "image": "busybox:1.36.1",
+              "repository": "busybox",
+              "tag": "1.36.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "image": "elasticsearch:7.17.27",
+          "repository": "elasticsearch",
+          "current_tag": "7.17.27",
+          "candidate_tag": "9.4.3",
+          "candidate_image": "elasticsearch:9.4.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 305,
+              "key": "originImageName",
+              "image": "elasticsearch:7.17.27",
+              "repository": "elasticsearch",
+              "tag": "7.17.27",
+              "digest": null
+            },
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 341,
+              "key": "image",
+              "image": "elasticsearch:7.17.27",
+              "repository": "elasticsearch",
+              "tag": "7.17.27",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "repository": "ghcr.io/gitroomhq/postiz-app",
+          "current_tag": "v2.21.8",
+          "candidate_tag": "v2.21.10",
+          "candidate_image": "ghcr.io/gitroomhq/postiz-app:v2.21.10",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 510,
+              "key": "originImageName",
+              "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+              "repository": "ghcr.io/gitroomhq/postiz-app",
+              "tag": "v2.21.8",
+              "digest": null
+            },
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 583,
+              "key": "image",
+              "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+              "repository": "ghcr.io/gitroomhq/postiz-app",
+              "tag": "v2.21.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "image": "temporalio/auto-setup:1.28.1",
+          "repository": "temporalio/auto-setup",
+          "current_tag": "1.28.1",
+          "candidate_tag": "1.29.7",
+          "candidate_image": "temporalio/auto-setup:1.29.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 400,
+              "key": "originImageName",
+              "image": "temporalio/auto-setup:1.28.1",
+              "repository": "temporalio/auto-setup",
+              "tag": "1.28.1",
+              "digest": null
+            },
+            {
+              "template": "postiz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+              "line": 420,
+              "key": "image",
+              "image": "temporalio/auto-setup:1.28.1",
+              "repository": "temporalio/auto-setup",
+              "tag": "1.28.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "presenton",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "presenton",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "repository": "ghcr.io/presenton/presenton",
+          "current_tag": "v0.8.2-beta",
+          "candidate_tag": "v0.8.9-beta",
+          "candidate_image": "ghcr.io/presenton/presenton:v0.8.9-beta",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "presenton",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml",
+              "line": 37,
+              "key": "originImageName",
+              "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+              "repository": "ghcr.io/presenton/presenton",
+              "tag": "v0.8.2-beta",
+              "digest": null
+            },
+            {
+              "template": "presenton",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml",
+              "line": 59,
+              "key": "image",
+              "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+              "repository": "ghcr.io/presenton/presenton",
+              "tag": "v0.8.2-beta",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:96: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "prestashop",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "prestashop",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "prestashop",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+              "line": 141,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/prestashop/index.yaml"
+          ],
+          "replacement_count": 1,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "prestashop",
+          "image": "prestashop/prestashop:9.1.3-apache",
+          "repository": "prestashop/prestashop",
+          "current_tag": "9.1.3-apache",
+          "candidate_tag": "9.1.4-apache",
+          "candidate_image": "prestashop/prestashop:9.1.4-apache",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "prestashop",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+              "line": 216,
+              "key": "originImageName",
+              "image": "prestashop/prestashop:9.1.3-apache",
+              "repository": "prestashop/prestashop",
+              "tag": "9.1.3-apache",
+              "digest": null
+            },
+            {
+              "template": "prestashop",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+              "line": 237,
+              "key": "image",
+              "image": "prestashop/prestashop:9.1.3-apache",
+              "repository": "prestashop/prestashop",
+              "tag": "9.1.3-apache",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/prestashop/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "privatebin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "privatebin",
+          "image": "ghcr.io/privatebin/fs:1.7.4",
+          "repository": "ghcr.io/privatebin/fs",
+          "current_tag": "1.7.4",
+          "candidate_tag": "2.0.4",
+          "candidate_image": "ghcr.io/privatebin/fs:2.0.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "privatebin",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml",
+              "line": 280,
+              "key": "image",
+              "image": "ghcr.io/privatebin/fs:1.7.4",
+              "repository": "ghcr.io/privatebin/fs",
+              "tag": "1.7.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:31: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:33: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:244: container take-data-dir-ownership must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:249: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:263: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:286: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "pterodactyl",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "pterodactyl",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "current_tag": "v1.12.4",
+          "candidate_tag": "v1.14.1",
+          "candidate_image": "ghcr.io/pterodactyl/panel:v1.14.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 399,
+              "key": "image",
+              "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+              "repository": "ghcr.io/pterodactyl/panel",
+              "tag": "v1.12.4",
+              "digest": null
+            },
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 545,
+              "key": "originImageName",
+              "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+              "repository": "ghcr.io/pterodactyl/panel",
+              "tag": "v1.12.4",
+              "digest": null
+            },
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 677,
+              "key": "image",
+              "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+              "repository": "ghcr.io/pterodactyl/panel",
+              "tag": "v1.12.4",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 3,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "pterodactyl",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 183,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+              "repository": "public.ecr.aws/docker/library/mysql",
+              "tag": "8.0.30",
+              "digest": null
+            },
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 568,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+              "repository": "public.ecr.aws/docker/library/mysql",
+              "tag": "8.0.30",
+              "digest": null
+            },
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 636,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+              "repository": "public.ecr.aws/docker/library/mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 3,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "pterodactyl",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 368,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "pterodactyl",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+              "line": 606,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "quay",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "quay",
+          "image": "python:3.12.8-alpine3.20",
+          "repository": "python",
+          "current_tag": "3.12.8-alpine3.20",
+          "candidate_tag": "3.14.6-alpine3.24",
+          "candidate_image": "python:3.14.6-alpine3.24",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "quay",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+              "line": 541,
+              "key": "image",
+              "image": "python:3.12.8-alpine3.20",
+              "repository": "python",
+              "tag": "3.12.8-alpine3.20",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:141: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:396: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:532: container ${{ defaults.app_name }}-init-admin must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "quay",
+          "image": "quay.io/projectquay/quay:v3.9.8",
+          "repository": "quay.io/projectquay/quay",
+          "current_tag": "v3.9.8",
+          "candidate_tag": "v3.17.3",
+          "candidate_image": "quay.io/projectquay/quay:v3.17.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "quay",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+              "line": 301,
+              "key": "originImageName",
+              "image": "quay.io/projectquay/quay:v3.9.8",
+              "repository": "quay.io/projectquay/quay",
+              "tag": "v3.9.8",
+              "digest": null
+            },
+            {
+              "template": "quay",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+              "line": 332,
+              "key": "image",
+              "image": "quay.io/projectquay/quay:v3.9.8",
+              "repository": "quay.io/projectquay/quay",
+              "tag": "v3.9.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:141: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:396: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:532: container ${{ defaults.app_name }}-init-admin must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "refly",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "refly",
+          "image": "mautic/mautic:5.2.3-fpm",
+          "repository": "mautic/mautic",
+          "current_tag": "5.2.3-fpm",
+          "candidate_tag": "7.1.3-fpm",
+          "candidate_image": "mautic/mautic:7.1.3-fpm",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "refly",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+              "line": 409,
+              "key": "image",
+              "image": "mautic/mautic:5.2.3-fpm",
+              "repository": "mautic/mautic",
+              "tag": "5.2.3-fpm",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:155: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:165: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:172: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:283: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:284: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:286: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:287: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:367: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "registry",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "registry",
+          "image": "joxit/docker-registry-ui:2.5.6-debian",
+          "repository": "joxit/docker-registry-ui",
+          "current_tag": "2.5.6-debian",
+          "candidate_tag": "2.6.0-debian",
+          "candidate_image": "joxit/docker-registry-ui:2.6.0-debian",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "registry",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+              "line": 206,
+              "key": "originImageName",
+              "image": "joxit/docker-registry-ui:2.5.6-debian",
+              "repository": "joxit/docker-registry-ui",
+              "tag": "2.5.6-debian",
+              "digest": null
+            },
+            {
+              "template": "registry",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+              "line": 230,
+              "key": "image",
+              "image": "joxit/docker-registry-ui:2.5.6-debian",
+              "repository": "joxit/docker-registry-ui",
+              "tag": "2.5.6-debian",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:49: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:153: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:156: Service spec.ports entries must define a non-empty name"
+          ]
+        },
+        {
+          "template": "registry",
+          "image": "registry:2.8.3",
+          "repository": "registry",
+          "current_tag": "2.8.3",
+          "candidate_tag": "3.1.1",
+          "candidate_image": "registry:3.1.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "registry",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+              "line": 35,
+              "key": "originImageName",
+              "image": "registry:2.8.3",
+              "repository": "registry",
+              "tag": "2.8.3",
+              "digest": null
+            },
+            {
+              "template": "registry",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+              "line": 57,
+              "key": "image",
+              "image": "registry:2.8.3",
+              "repository": "registry",
+              "tag": "2.8.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:49: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:153: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:156: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "rocketchat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rocketchat",
+          "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "registry.rocket.chat/rocketchat/rocket.chat:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml",
+              "line": 183,
+              "key": "originImageName",
+              "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+              "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml",
+              "line": 203,
+              "key": "image",
+              "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+              "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:196: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:260: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:261: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:283: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "rocketchat-micro",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rocketchat-micro",
+          "image": "natsio/nats-server-config-reloader:0.6.3",
+          "repository": "natsio/nats-server-config-reloader",
+          "current_tag": "0.6.3",
+          "candidate_tag": "0.23.0",
+          "candidate_image": "natsio/nats-server-config-reloader:0.23.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 438,
+              "key": "image",
+              "image": "natsio/nats-server-config-reloader:0.6.3",
+              "repository": "natsio/nats-server-config-reloader",
+              "tag": "0.6.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/account-service:7.9.0",
+          "repository": "rocketchat/account-service",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "rocketchat/account-service:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 517,
+              "key": "originImageName",
+              "image": "rocketchat/account-service:7.9.0",
+              "repository": "rocketchat/account-service",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 542,
+              "key": "image",
+              "image": "rocketchat/account-service:7.9.0",
+              "repository": "rocketchat/account-service",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/authorization-service:7.9.0",
+          "repository": "rocketchat/authorization-service",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "rocketchat/authorization-service:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 606,
+              "key": "originImageName",
+              "image": "rocketchat/authorization-service:7.9.0",
+              "repository": "rocketchat/authorization-service",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 631,
+              "key": "image",
+              "image": "rocketchat/authorization-service:7.9.0",
+              "repository": "rocketchat/authorization-service",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/ddp-streamer-service:7.9.0",
+          "repository": "rocketchat/ddp-streamer-service",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "rocketchat/ddp-streamer-service:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 695,
+              "key": "originImageName",
+              "image": "rocketchat/ddp-streamer-service:7.9.0",
+              "repository": "rocketchat/ddp-streamer-service",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 720,
+              "key": "image",
+              "image": "rocketchat/ddp-streamer-service:7.9.0",
+              "repository": "rocketchat/ddp-streamer-service",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/presence-service:7.9.0",
+          "repository": "rocketchat/presence-service",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "rocketchat/presence-service:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 793,
+              "key": "originImageName",
+              "image": "rocketchat/presence-service:7.9.0",
+              "repository": "rocketchat/presence-service",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 818,
+              "key": "image",
+              "image": "rocketchat/presence-service:7.9.0",
+              "repository": "rocketchat/presence-service",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/rocket.chat:7.9.0",
+          "repository": "rocketchat/rocket.chat",
+          "current_tag": "7.9.0",
+          "candidate_tag": "8.6.0",
+          "candidate_image": "rocketchat/rocket.chat:8.6.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 224,
+              "key": "originImageName",
+              "image": "rocketchat/rocket.chat:7.9.0",
+              "repository": "rocketchat/rocket.chat",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 249,
+              "key": "image",
+              "image": "rocketchat/rocket.chat:7.9.0",
+              "repository": "rocketchat/rocket.chat",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "image": "rocketchat/stream-hub-service:7.9.0",
+          "repository": "rocketchat/stream-hub-service",
+          "current_tag": "7.9.0",
+          "candidate_tag": "7.13.9",
+          "candidate_image": "rocketchat/stream-hub-service:7.13.9",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 882,
+              "key": "originImageName",
+              "image": "rocketchat/stream-hub-service:7.9.0",
+              "repository": "rocketchat/stream-hub-service",
+              "tag": "7.9.0",
+              "digest": null
+            },
+            {
+              "template": "rocketchat-micro",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+              "line": 907,
+              "key": "image",
+              "image": "rocketchat/stream-hub-service:7.9.0",
+              "repository": "rocketchat/stream-hub-service",
+              "tag": "7.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "rsshub",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rsshub",
+          "image": "diygod/rsshub:2024-07-06",
+          "repository": "diygod/rsshub",
+          "current_tag": "2024-07-06",
+          "candidate_tag": "2026-07-08",
+          "candidate_image": "diygod/rsshub:2026-07-08",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "medium",
+          "reason": "newer compatible date tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rsshub",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+              "line": 46,
+              "key": "originImageName",
+              "image": "diygod/rsshub:2024-07-06",
+              "repository": "diygod/rsshub",
+              "tag": "2024-07-06",
+              "digest": null
+            },
+            {
+              "template": "rsshub",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+              "line": 71,
+              "key": "image",
+              "image": "diygod/rsshub:2024-07-06",
+              "repository": "diygod/rsshub",
+              "tag": "2024-07-06",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:73: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:85: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:119: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:122: Service spec.ports entries must define a non-empty name",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:150: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:176: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "rybbit",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rybbit",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "current_tag": "25.4.2",
+          "candidate_tag": "26.6.1",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "rybbit",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+              "line": 234,
+              "key": "originImageName",
+              "image": "clickhouse/clickhouse-server:25.4.2",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.4.2",
+              "digest": null
+            },
+            {
+              "template": "rybbit",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+              "line": 258,
+              "key": "image",
+              "image": "clickhouse/clickhouse-server:25.4.2",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.4.2",
+              "digest": null
+            },
+            {
+              "template": "rybbit",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+              "line": 419,
+              "key": "image",
+              "image": "clickhouse/clickhouse-server:25.4.2",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.4.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:124: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:254: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:258: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:370: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-clickhouse must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-postgres must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "s-pdf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "s-pdf",
+          "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "repository": "ghcr.io/stirling-tools/stirling-pdf",
+          "current_tag": "1.2.0-fat",
+          "candidate_tag": "2.14.1-fat",
+          "candidate_image": "ghcr.io/stirling-tools/stirling-pdf:2.14.1-fat",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "s-pdf",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+              "line": 228,
+              "key": "originImageName",
+              "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+              "repository": "ghcr.io/stirling-tools/stirling-pdf",
+              "tag": "1.2.0-fat",
+              "digest": null
+            },
+            {
+              "template": "s-pdf",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+              "line": 259,
+              "key": "image",
+              "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+              "repository": "ghcr.io/stirling-tools/stirling-pdf",
+              "tag": "1.2.0-fat",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:82: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:428: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:431: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "signoz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "signoz",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "current_tag": "25.5.6",
+          "candidate_tag": "26.6.1",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 524,
+              "key": "originImageName",
+              "image": "clickhouse/clickhouse-server:25.5.6",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.5.6",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 548,
+              "key": "image",
+              "image": "clickhouse/clickhouse-server:25.5.6",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.5.6",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 570,
+              "key": "image",
+              "image": "clickhouse/clickhouse-server:25.5.6",
+              "repository": "clickhouse/clickhouse-server",
+              "tag": "25.5.6",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "current_tag": "v0.144.2",
+          "candidate_tag": "v0.144.5",
+          "candidate_image": "signoz/signoz-otel-collector:v0.144.5",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 687,
+              "key": "image",
+              "image": "signoz/signoz-otel-collector:v0.144.2",
+              "repository": "signoz/signoz-otel-collector",
+              "tag": "v0.144.2",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 821,
+              "key": "originImageName",
+              "image": "signoz/signoz-otel-collector:v0.144.2",
+              "repository": "signoz/signoz-otel-collector",
+              "tag": "v0.144.2",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 844,
+              "key": "image",
+              "image": "signoz/signoz-otel-collector:v0.144.2",
+              "repository": "signoz/signoz-otel-collector",
+              "tag": "v0.144.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "image": "signoz/signoz:v0.117.0",
+          "repository": "signoz/signoz",
+          "current_tag": "v0.117.0",
+          "candidate_tag": "v0.132.0",
+          "candidate_image": "signoz/signoz:v0.132.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 719,
+              "key": "originImageName",
+              "image": "signoz/signoz:v0.117.0",
+              "repository": "signoz/signoz",
+              "tag": "v0.117.0",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 744,
+              "key": "image",
+              "image": "signoz/signoz:v0.117.0",
+              "repository": "signoz/signoz",
+              "tag": "v0.117.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "image": "signoz/zookeeper:3.7.1",
+          "repository": "signoz/zookeeper",
+          "current_tag": "3.7.1",
+          "candidate_tag": "3.9.3",
+          "candidate_image": "signoz/zookeeper:3.9.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 421,
+              "key": "originImageName",
+              "image": "signoz/zookeeper:3.7.1",
+              "repository": "signoz/zookeeper",
+              "tag": "3.7.1",
+              "digest": null
+            },
+            {
+              "template": "signoz",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+              "line": 454,
+              "key": "image",
+              "image": "signoz/zookeeper:3.7.1",
+              "repository": "signoz/zookeeper",
+              "tag": "3.7.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "skardi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "skardi",
+          "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+          "current_tag": "0.3.0",
+          "candidate_tag": "0.4.0",
+          "candidate_image": "ghcr.io/skardilabs/skardi/skardi-server:0.4.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "skardi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml",
+              "line": 123,
+              "key": "originImageName",
+              "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+              "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+              "tag": "0.3.0",
+              "digest": null
+            },
+            {
+              "template": "skardi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml",
+              "line": 143,
+              "key": "image",
+              "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+              "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+              "tag": "0.3.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml:135: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "stalwart",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "stalwart",
+          "image": "stalwartlabs/stalwart:v0.16.7",
+          "repository": "stalwartlabs/stalwart",
+          "current_tag": "v0.16.7",
+          "candidate_tag": "v0.16.12",
+          "candidate_image": "stalwartlabs/stalwart:v0.16.12",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "stalwart",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+              "line": 234,
+              "key": "originImageName",
+              "image": "stalwartlabs/stalwart:v0.16.7",
+              "repository": "stalwartlabs/stalwart",
+              "tag": "v0.16.7",
+              "digest": null
+            },
+            {
+              "template": "stalwart",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+              "line": 302,
+              "key": "image",
+              "image": "stalwartlabs/stalwart:v0.16.7",
+              "repository": "stalwartlabs/stalwart",
+              "tag": "v0.16.7",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/stalwart/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "strapi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "strapi",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "current_tag": "5.33.0",
+          "candidate_tag": "5.50.0",
+          "candidate_image": "vshadbolt/strapi:5.50.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "strapi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+              "line": 611,
+              "key": "originImageName",
+              "image": "vshadbolt/strapi:5.33.0",
+              "repository": "vshadbolt/strapi",
+              "tag": "5.33.0",
+              "digest": null
+            },
+            {
+              "template": "strapi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+              "line": 632,
+              "key": "image",
+              "image": "vshadbolt/strapi:5.33.0",
+              "repository": "vshadbolt/strapi",
+              "tag": "5.33.0",
+              "digest": null
+            },
+            {
+              "template": "strapi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+              "line": 706,
+              "key": "image",
+              "image": "vshadbolt/strapi:5.33.0",
+              "repository": "vshadbolt/strapi",
+              "tag": "5.33.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:153: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:164: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:171: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:183: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:185: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:702: container strapi-build limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:703: container strapi-build limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:784: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "sub2api",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "sub2api",
+          "image": "weishaw/sub2api:0.1.104",
+          "repository": "weishaw/sub2api",
+          "current_tag": "0.1.104",
+          "candidate_tag": "0.1.146",
+          "candidate_image": "weishaw/sub2api:0.1.146",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "sub2api",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml",
+              "line": 368,
+              "key": "originImageName",
+              "image": "weishaw/sub2api:0.1.104",
+              "repository": "weishaw/sub2api",
+              "tag": "0.1.104",
+              "digest": null
+            },
+            {
+              "template": "sub2api",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml",
+              "line": 397,
+              "key": "image",
+              "image": "weishaw/sub2api:0.1.104",
+              "repository": "weishaw/sub2api",
+              "tag": "0.1.104",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml:205: container pgsql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "supabase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "supabase",
+          "image": "darthsim/imgproxy:v3.30.1",
+          "repository": "darthsim/imgproxy",
+          "current_tag": "v3.30.1",
+          "candidate_tag": "v4.0.11",
+          "candidate_image": "darthsim/imgproxy:v4.0.11",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1353,
+              "key": "originImageName",
+              "image": "darthsim/imgproxy:v3.30.1",
+              "repository": "darthsim/imgproxy",
+              "tag": "v3.30.1",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1373,
+              "key": "image",
+              "image": "darthsim/imgproxy:v3.30.1",
+              "repository": "darthsim/imgproxy",
+              "tag": "v3.30.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "kong:2.8.1",
+          "repository": "kong",
+          "current_tag": "2.8.1",
+          "candidate_tag": "3.9.3",
+          "candidate_image": "kong:3.9.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 848,
+              "key": "originImageName",
+              "image": "kong:2.8.1",
+              "repository": "kong",
+              "tag": "2.8.1",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 868,
+              "key": "image",
+              "image": "kong:2.8.1",
+              "repository": "kong",
+              "tag": "2.8.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/edge-runtime:v1.70.3",
+          "repository": "supabase/edge-runtime",
+          "current_tag": "v1.70.3",
+          "candidate_tag": "v1.74.2",
+          "candidate_image": "supabase/edge-runtime:v1.74.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1492,
+              "key": "originImageName",
+              "image": "supabase/edge-runtime:v1.70.3",
+              "repository": "supabase/edge-runtime",
+              "tag": "v1.70.3",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1512,
+              "key": "image",
+              "image": "supabase/edge-runtime:v1.70.3",
+              "repository": "supabase/edge-runtime",
+              "tag": "v1.70.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/gotrue:v2.186.0",
+          "repository": "supabase/gotrue",
+          "current_tag": "v2.186.0",
+          "candidate_tag": "v2.192.0",
+          "candidate_image": "supabase/gotrue:v2.192.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 934,
+              "key": "originImageName",
+              "image": "supabase/gotrue:v2.186.0",
+              "repository": "supabase/gotrue",
+              "tag": "v2.186.0",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 954,
+              "key": "image",
+              "image": "supabase/gotrue:v2.186.0",
+              "repository": "supabase/gotrue",
+              "tag": "v2.186.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/logflare:1.31.2",
+          "repository": "supabase/logflare",
+          "current_tag": "1.31.2",
+          "candidate_tag": "1.46.0",
+          "candidate_image": "supabase/logflare:1.46.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1594,
+              "key": "originImageName",
+              "image": "supabase/logflare:1.31.2",
+              "repository": "supabase/logflare",
+              "tag": "1.31.2",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1614,
+              "key": "image",
+              "image": "supabase/logflare:1.31.2",
+              "repository": "supabase/logflare",
+              "tag": "1.31.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/postgres-meta:v0.95.2",
+          "repository": "supabase/postgres-meta",
+          "current_tag": "v0.95.2",
+          "candidate_tag": "v0.96.6",
+          "candidate_image": "supabase/postgres-meta:v0.96.6",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1430,
+              "key": "originImageName",
+              "image": "supabase/postgres-meta:v0.95.2",
+              "repository": "supabase/postgres-meta",
+              "tag": "v0.95.2",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1450,
+              "key": "image",
+              "image": "supabase/postgres-meta:v0.95.2",
+              "repository": "supabase/postgres-meta",
+              "tag": "v0.95.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/realtime:v2.76.5",
+          "repository": "supabase/realtime",
+          "current_tag": "v2.76.5",
+          "candidate_tag": "v2.112.9",
+          "candidate_image": "supabase/realtime:v2.112.9",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1133,
+              "key": "originImageName",
+              "image": "supabase/realtime:v2.76.5",
+              "repository": "supabase/realtime",
+              "tag": "v2.76.5",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1153,
+              "key": "image",
+              "image": "supabase/realtime:v2.76.5",
+              "repository": "supabase/realtime",
+              "tag": "v2.76.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/storage-api:v1.37.8",
+          "repository": "supabase/storage-api",
+          "current_tag": "v1.37.8",
+          "candidate_tag": "v1.64.0",
+          "candidate_image": "supabase/storage-api:v1.64.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1234,
+              "key": "originImageName",
+              "image": "supabase/storage-api:v1.37.8",
+              "repository": "supabase/storage-api",
+              "tag": "v1.37.8",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1254,
+              "key": "image",
+              "image": "supabase/storage-api:v1.37.8",
+              "repository": "supabase/storage-api",
+              "tag": "v1.37.8",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/studio:2026.02.16-sha-26c615c",
+          "repository": "supabase/studio",
+          "current_tag": "2026.02.16-sha-26c615c",
+          "candidate_tag": "2026.07.07-sha-a6a04f2",
+          "candidate_image": "supabase/studio:2026.07.07-sha-a6a04f2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "medium",
+          "reason": "newer compatible date tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 707,
+              "key": "originImageName",
+              "image": "supabase/studio:2026.02.16-sha-26c615c",
+              "repository": "supabase/studio",
+              "tag": "2026.02.16-sha-26c615c",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 727,
+              "key": "image",
+              "image": "supabase/studio:2026.02.16-sha-26c615c",
+              "repository": "supabase/studio",
+              "tag": "2026.02.16-sha-26c615c",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "supabase/supavisor:2.7.4",
+          "repository": "supabase/supavisor",
+          "current_tag": "2.7.4",
+          "candidate_tag": "2.9.7",
+          "candidate_image": "supabase/supavisor:2.9.7",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1766,
+              "key": "originImageName",
+              "image": "supabase/supavisor:2.7.4",
+              "repository": "supabase/supavisor",
+              "tag": "2.7.4",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1786,
+              "key": "image",
+              "image": "supabase/supavisor:2.7.4",
+              "repository": "supabase/supavisor",
+              "tag": "2.7.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "image": "timberio/vector:0.53.0-alpine",
+          "repository": "timberio/vector",
+          "current_tag": "0.53.0-alpine",
+          "candidate_tag": "0.56.0-alpine",
+          "candidate_image": "timberio/vector:0.56.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1700,
+              "key": "originImageName",
+              "image": "timberio/vector:0.53.0-alpine",
+              "repository": "timberio/vector",
+              "tag": "0.53.0-alpine",
+              "digest": null
+            },
+            {
+              "template": "supabase",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+              "line": 1720,
+              "key": "image",
+              "image": "timberio/vector:0.53.0-alpine",
+              "repository": "timberio/vector",
+              "tag": "0.53.0-alpine",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "surveyking",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "surveyking",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "current_tag": "8.0.30",
+          "candidate_tag": "8.0.44",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "surveyking",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+              "line": 129,
+              "key": "image",
+              "image": "joseluisq/mysql-client:8.0.30",
+              "repository": "joseluisq/mysql-client",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:212: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:219: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:220: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:247: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:250: Service spec.ports entries must define a non-empty name"
+          ]
+        },
+        {
+          "template": "surveyking",
+          "image": "surveyking/surveyking:v1.9.0",
+          "repository": "surveyking/surveyking",
+          "current_tag": "v1.9.0",
+          "candidate_tag": "v1.12.0",
+          "candidate_image": "surveyking/surveyking:v1.12.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "surveyking",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+              "line": 170,
+              "key": "originImageName",
+              "image": "surveyking/surveyking:v1.9.0",
+              "repository": "surveyking/surveyking",
+              "tag": "v1.9.0",
+              "digest": null
+            },
+            {
+              "template": "surveyking",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+              "line": 193,
+              "key": "image",
+              "image": "surveyking/surveyking:v1.9.0",
+              "repository": "surveyking/surveyking",
+              "tag": "v1.9.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:212: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:219: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:220: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:247: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:250: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tailchat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tailchat",
+          "image": "moonrailgun/tailchat:1.11.5",
+          "repository": "moonrailgun/tailchat",
+          "current_tag": "1.11.5",
+          "candidate_tag": "1.11.11",
+          "candidate_image": "moonrailgun/tailchat:1.11.11",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tailchat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+              "line": 66,
+              "key": "originImageName",
+              "image": "moonrailgun/tailchat:1.11.5",
+              "repository": "moonrailgun/tailchat",
+              "tag": "1.11.5",
+              "digest": null
+            },
+            {
+              "template": "tailchat",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+              "line": 86,
+              "key": "image",
+              "image": "moonrailgun/tailchat:1.11.5",
+              "repository": "moonrailgun/tailchat",
+              "tag": "1.11.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:87: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:96: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:108: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:110: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:123: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tianji",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tianji",
+          "image": "moonrailgun/tianji:1.18.5",
+          "repository": "moonrailgun/tianji",
+          "current_tag": "1.18.5",
+          "candidate_tag": "1.32.16",
+          "candidate_image": "moonrailgun/tianji:1.32.16",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tianji",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml",
+              "line": 50,
+              "key": "originImageName",
+              "image": "moonrailgun/tianji:1.18.5",
+              "repository": "moonrailgun/tianji",
+              "tag": "1.18.5",
+              "digest": null
+            },
+            {
+              "template": "tianji",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml",
+              "line": 74,
+              "key": "image",
+              "image": "moonrailgun/tianji:1.18.5",
+              "repository": "moonrailgun/tianji",
+              "tag": "1.18.5",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:67: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:81: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:91: container ${{ defaults.app_name }} requests.cpu must be 20m when limits.cpu is 200m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:92: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tolgee",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tolgee",
+          "image": "tolgee/tolgee:v3.113.0",
+          "repository": "tolgee/tolgee",
+          "current_tag": "v3.113.0",
+          "candidate_tag": "v3.209.3",
+          "candidate_image": "tolgee/tolgee:v3.209.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tolgee",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml",
+              "line": 219,
+              "key": "originImageName",
+              "image": "tolgee/tolgee:v3.113.0",
+              "repository": "tolgee/tolgee",
+              "tag": "v3.113.0",
+              "digest": null
+            },
+            {
+              "template": "tolgee",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml",
+              "line": 244,
+              "key": "image",
+              "image": "tolgee/tolgee:v3.113.0",
+              "repository": "tolgee/tolgee",
+              "tag": "v3.113.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:185: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:195: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:273: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:285: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:290: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:316: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tooljet",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tooljet",
+          "image": "postgrest/postgrest:v12.0.2",
+          "repository": "postgrest/postgrest",
+          "current_tag": "v12.0.2",
+          "candidate_tag": "v13.0.8",
+          "candidate_image": "postgrest/postgrest:v13.0.8",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tooljet",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+              "line": 455,
+              "key": "originImageName",
+              "image": "postgrest/postgrest:v12.0.2",
+              "repository": "postgrest/postgrest",
+              "tag": "v12.0.2",
+              "digest": null
+            },
+            {
+              "template": "tooljet",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+              "line": 475,
+              "key": "image",
+              "image": "postgrest/postgrest:v12.0.2",
+              "repository": "postgrest/postgrest",
+              "tag": "v12.0.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:243: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:291: container wait-for-postgres must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:443: container tooljet-migrate limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:445: container tooljet-migrate requests.cpu must be 100m when limits.cpu is 1",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:756: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:829: App resource spec.type must be 'link'"
+          ]
+        },
+        {
+          "template": "tooljet",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "current_tag": "v3.20.170-lts",
+          "candidate_tag": "v3.20.192-lts",
+          "candidate_image": "tooljet/tooljet-ce:v3.20.192-lts",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tooljet",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+              "line": 333,
+              "key": "image",
+              "image": "tooljet/tooljet-ce:v3.20.170-lts",
+              "repository": "tooljet/tooljet-ce",
+              "tag": "v3.20.170-lts",
+              "digest": null
+            },
+            {
+              "template": "tooljet",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+              "line": 548,
+              "key": "originImageName",
+              "image": "tooljet/tooljet-ce:v3.20.170-lts",
+              "repository": "tooljet/tooljet-ce",
+              "tag": "v3.20.170-lts",
+              "digest": null
+            },
+            {
+              "template": "tooljet",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+              "line": 616,
+              "key": "image",
+              "image": "tooljet/tooljet-ce:v3.20.170-lts",
+              "repository": "tooljet/tooljet-ce",
+              "tag": "v3.20.170-lts",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:243: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:291: container wait-for-postgres must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:443: container tooljet-migrate limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:445: container tooljet-migrate requests.cpu must be 100m when limits.cpu is 1",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:756: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:829: App resource spec.type must be 'link'"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tradingagents",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tradingagents",
+          "image": "alpine/git:2.49.1",
+          "repository": "alpine/git",
+          "current_tag": "2.49.1",
+          "candidate_tag": "2.54.0",
+          "candidate_image": "alpine/git:2.54.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tradingagents",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml",
+              "line": 244,
+              "key": "image",
+              "image": "alpine/git:2.49.1",
+              "repository": "alpine/git",
+              "tag": "2.49.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container install-runtime limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "trendradar",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "trendradar",
+          "image": "wantcat/trendradar:6.9.1",
+          "repository": "wantcat/trendradar",
+          "current_tag": "6.9.1",
+          "candidate_tag": "6.10.0",
+          "candidate_image": "wantcat/trendradar:6.10.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "trendradar",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/trendradar/index.yaml",
+              "line": 133,
+              "key": "originImageName",
+              "image": "wantcat/trendradar:6.9.1",
+              "repository": "wantcat/trendradar",
+              "tag": "6.9.1",
+              "digest": null
+            },
+            {
+              "template": "trendradar",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/trendradar/index.yaml",
+              "line": 154,
+              "key": "image",
+              "image": "wantcat/trendradar:6.9.1",
+              "repository": "wantcat/trendradar",
+              "tag": "6.9.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/trendradar/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "tududi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tududi",
+          "image": "chrisvel/tududi:1.1.0",
+          "repository": "chrisvel/tududi",
+          "current_tag": "1.1.0",
+          "candidate_tag": "1.2.0",
+          "candidate_image": "chrisvel/tududi:1.2.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "tududi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml",
+              "line": 50,
+              "key": "originImageName",
+              "image": "chrisvel/tududi:1.1.0",
+              "repository": "chrisvel/tududi",
+              "tag": "1.1.0",
+              "digest": null
+            },
+            {
+              "template": "tududi",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml",
+              "line": 73,
+              "key": "image",
+              "image": "chrisvel/tududi:1.1.0",
+              "repository": "chrisvel/tududi",
+              "tag": "1.1.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml:239: App resource spec.type must be 'link'"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "twenty",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "twenty",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "current_tag": "v1.12.0",
+          "candidate_tag": "v2.19.0",
+          "candidate_image": "twentycrm/twenty:v2.19.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "twenty",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+              "line": 316,
+              "key": "originImageName",
+              "image": "twentycrm/twenty:v1.12.0",
+              "repository": "twentycrm/twenty",
+              "tag": "v1.12.0",
+              "digest": null
+            },
+            {
+              "template": "twenty",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+              "line": 349,
+              "key": "image",
+              "image": "twentycrm/twenty:v1.12.0",
+              "repository": "twentycrm/twenty",
+              "tag": "v1.12.0",
+              "digest": null
+            },
+            {
+              "template": "twenty",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+              "line": 452,
+              "key": "originImageName",
+              "image": "twentycrm/twenty:v1.12.0",
+              "repository": "twentycrm/twenty",
+              "tag": "v1.12.0",
+              "digest": null
+            },
+            {
+              "template": "twenty",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+              "line": 472,
+              "key": "image",
+              "image": "twentycrm/twenty:v1.12.0",
+              "repository": "twentycrm/twenty",
+              "tag": "v1.12.0",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:141: PVC storage request must be <= 1Gi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:145: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R027/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:180: pg-init Job for non-default PostgreSQL databases must include readiness wait (for example pg_isready) and idempotent create logic (exists check before create)",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:282: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:283: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:285: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:286: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:311: container fix-permissions must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "typebot",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "typebot",
+          "image": "axllent/mailpit:v1.30.1",
+          "repository": "axllent/mailpit",
+          "current_tag": "v1.30.1",
+          "candidate_tag": "v1.30.3",
+          "candidate_image": "axllent/mailpit:v1.30.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 824,
+              "key": "originImageName",
+              "image": "axllent/mailpit:v1.30.1",
+              "repository": "axllent/mailpit",
+              "tag": "v1.30.1",
+              "digest": null
+            },
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 846,
+              "key": "image",
+              "image": "axllent/mailpit:v1.30.1",
+              "repository": "axllent/mailpit",
+              "tag": "v1.30.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "image": "baptistearno/typebot-builder:3.17.1",
+          "repository": "baptistearno/typebot-builder",
+          "current_tag": "3.17.1",
+          "candidate_tag": "3.17.2",
+          "candidate_image": "baptistearno/typebot-builder:3.17.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 431,
+              "key": "originImageName",
+              "image": "baptistearno/typebot-builder:3.17.1",
+              "repository": "baptistearno/typebot-builder",
+              "tag": "3.17.1",
+              "digest": null
+            },
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 484,
+              "key": "image",
+              "image": "baptistearno/typebot-builder:3.17.1",
+              "repository": "baptistearno/typebot-builder",
+              "tag": "3.17.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "image": "baptistearno/typebot-viewer:3.17.1",
+          "repository": "baptistearno/typebot-viewer",
+          "current_tag": "3.17.1",
+          "candidate_tag": "3.17.2",
+          "candidate_image": "baptistearno/typebot-viewer:3.17.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 656,
+              "key": "originImageName",
+              "image": "baptistearno/typebot-viewer:3.17.1",
+              "repository": "baptistearno/typebot-viewer",
+              "tag": "3.17.1",
+              "digest": null
+            },
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 709,
+              "key": "image",
+              "image": "baptistearno/typebot-viewer:3.17.1",
+              "repository": "baptistearno/typebot-viewer",
+              "tag": "3.17.1",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "current_tag": "7.2.7-alpine",
+          "candidate_tag": "8.8.0-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 453,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            },
+            {
+              "template": "typebot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+              "line": 678,
+              "key": "image",
+              "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+              "repository": "public.ecr.aws/docker/library/redis",
+              "tag": "7.2.7-alpine",
+              "digest": null
+            }
+          ],
+          "status": "updated",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "missing_records": [],
+          "validation_sample_issues": []
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "typo3",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "typo3",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "typo3",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml",
+              "line": 154,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml:143: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "umami",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "umami",
+          "image": "ghcr.io/umami-software/umami:3.0.2",
+          "repository": "ghcr.io/umami-software/umami",
+          "current_tag": "3.0.2",
+          "candidate_tag": "3.2.0",
+          "candidate_image": "ghcr.io/umami-software/umami:3.2.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "umami",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml",
+              "line": 58,
+              "key": "originImageName",
+              "image": "ghcr.io/umami-software/umami:3.0.2",
+              "repository": "ghcr.io/umami-software/umami",
+              "tag": "3.0.2",
+              "digest": null
+            },
+            {
+              "template": "umami",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml",
+              "line": 83,
+              "key": "image",
+              "image": "ghcr.io/umami-software/umami:3.0.2",
+              "repository": "ghcr.io/umami-software/umami",
+              "tag": "3.0.2",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:90: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:103: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:104: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:120: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "uptime-kuma",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "uptime-kuma",
+          "image": "louislam/uptime-kuma:1.23.13",
+          "repository": "louislam/uptime-kuma",
+          "current_tag": "1.23.13",
+          "candidate_tag": "2.4.0",
+          "candidate_image": "louislam/uptime-kuma:2.4.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "uptime-kuma",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml",
+              "line": 38,
+              "key": "originImageName",
+              "image": "louislam/uptime-kuma:1.23.13",
+              "repository": "louislam/uptime-kuma",
+              "tag": "1.23.13",
+              "digest": null
+            },
+            {
+              "template": "uptime-kuma",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml",
+              "line": 61,
+              "key": "image",
+              "image": "louislam/uptime-kuma:1.23.13",
+              "repository": "louislam/uptime-kuma",
+              "tag": "1.23.13",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "webos",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "webos",
+          "image": "fs185085781/webos:v1.4.1",
+          "repository": "fs185085781/webos",
+          "current_tag": "v1.4.1",
+          "candidate_tag": "v1.4.4",
+          "candidate_image": "fs185085781/webos:v1.4.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "webos",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml",
+              "line": 37,
+              "key": "originImageName",
+              "image": "fs185085781/webos:v1.4.1",
+              "repository": "fs185085781/webos",
+              "tag": "v1.4.1",
+              "digest": null
+            },
+            {
+              "template": "webos",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml",
+              "line": 60,
+              "key": "image",
+              "image": "fs185085781/webos:v1.4.1",
+              "repository": "fs185085781/webos",
+              "tag": "v1.4.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:114: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:117: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "wewe-rss",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wewe-rss",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "current_tag": "8.0.30",
+          "candidate_tag": "8.0.44",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wewe-rss",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml",
+              "line": 134,
+              "key": "image",
+              "image": "joseluisq/mysql-client:8.0.30",
+              "repository": "joseluisq/mysql-client",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:33: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:124: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:180: managed app workloads must explicitly set revisionHistoryLimit: 1",
+            "- [R028/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:192: container name 'app' must exactly match metadata.name '${{ defaults.app_name }}' for managed app workloads",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:205: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:215: container app requests.cpu must be 50m when limits.cpu is 500m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:216: container app requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:227: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "woocommerce",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "woocommerce",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "woocommerce",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+              "line": 150,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml:141: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "woocommerce",
+          "image": "wordpress:6.9.1-php8.3-apache",
+          "repository": "wordpress",
+          "current_tag": "6.9.1-php8.3-apache",
+          "candidate_tag": "7.0.0-php8.5-apache",
+          "candidate_image": "wordpress:7.0.0-php8.5-apache",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "woocommerce",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+              "line": 194,
+              "key": "originImageName",
+              "image": "wordpress:6.9.1-php8.3-apache",
+              "repository": "wordpress",
+              "tag": "6.9.1-php8.3-apache",
+              "digest": null
+            },
+            {
+              "template": "woocommerce",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+              "line": 333,
+              "key": "image",
+              "image": "wordpress:6.9.1-php8.3-apache",
+              "repository": "wordpress",
+              "tag": "6.9.1-php8.3-apache",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml:141: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "wordpress",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wordpress",
+          "image": "wordpress:6.5.4",
+          "repository": "wordpress",
+          "current_tag": "6.5.4",
+          "candidate_tag": "7.0.0",
+          "candidate_image": "wordpress:7.0.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wordpress",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml",
+              "line": 48,
+              "key": "originImageName",
+              "image": "wordpress:6.5.4",
+              "repository": "wordpress",
+              "tag": "6.5.4",
+              "digest": null
+            },
+            {
+              "template": "wordpress",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml",
+              "line": 71,
+              "key": "image",
+              "image": "wordpress:6.5.4",
+              "repository": "wordpress",
+              "tag": "6.5.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:72: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:74: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:88: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:89: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:118: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:121: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "wrenai",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wrenai",
+          "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "repository": "ghcr.io/canner/wren-ai-service",
+          "current_tag": "0.15.17",
+          "candidate_tag": "0.29.3",
+          "candidate_image": "ghcr.io/canner/wren-ai-service:0.29.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 206,
+              "key": "originImageName",
+              "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+              "repository": "ghcr.io/canner/wren-ai-service",
+              "tag": "0.15.17",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 228,
+              "key": "image",
+              "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+              "repository": "ghcr.io/canner/wren-ai-service",
+              "tag": "0.15.17",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine-ibis",
+          "current_tag": "0.14.3",
+          "candidate_tag": "0.25.0",
+          "candidate_image": "ghcr.io/canner/wren-engine-ibis:0.25.0",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 383,
+              "key": "originImageName",
+              "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+              "repository": "ghcr.io/canner/wren-engine-ibis",
+              "tag": "0.14.3",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 405,
+              "key": "image",
+              "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+              "repository": "ghcr.io/canner/wren-engine-ibis",
+              "tag": "0.14.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "image": "ghcr.io/canner/wren-engine:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine",
+          "current_tag": "0.14.3",
+          "candidate_tag": "0.24.6",
+          "candidate_image": "ghcr.io/canner/wren-engine:0.24.6",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 291,
+              "key": "originImageName",
+              "image": "ghcr.io/canner/wren-engine:0.14.3",
+              "repository": "ghcr.io/canner/wren-engine",
+              "tag": "0.14.3",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 325,
+              "key": "image",
+              "image": "ghcr.io/canner/wren-engine:0.14.3",
+              "repository": "ghcr.io/canner/wren-engine",
+              "tag": "0.14.3",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "image": "ghcr.io/canner/wren-ui:0.20.1",
+          "repository": "ghcr.io/canner/wren-ui",
+          "current_tag": "0.20.1",
+          "candidate_tag": "0.32.2",
+          "candidate_image": "ghcr.io/canner/wren-ui:0.32.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 644,
+              "key": "originImageName",
+              "image": "ghcr.io/canner/wren-ui:0.20.1",
+              "repository": "ghcr.io/canner/wren-ui",
+              "tag": "0.20.1",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 666,
+              "key": "image",
+              "image": "ghcr.io/canner/wren-ui:0.20.1",
+              "repository": "ghcr.io/canner/wren-ui",
+              "tag": "0.20.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "current_tag": "v1.13.4",
+          "candidate_tag": "v1.18.2",
+          "candidate_image": "qdrant/qdrant:v1.18.2",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 466,
+              "key": "originImageName",
+              "image": "qdrant/qdrant:v1.13.4",
+              "repository": "qdrant/qdrant",
+              "tag": "v1.13.4",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 488,
+              "key": "image",
+              "image": "qdrant/qdrant:v1.13.4",
+              "repository": "qdrant/qdrant",
+              "tag": "v1.13.4",
+              "digest": null
+            },
+            {
+              "template": "wrenai",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+              "line": 516,
+              "key": "image",
+              "image": "qdrant/qdrant:v1.13.4",
+              "repository": "qdrant/qdrant",
+              "tag": "v1.13.4",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "yourls",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "yourls",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "current_tag": "8.0.30",
+          "candidate_tag": "9.7.1",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "yourls",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+              "line": 140,
+              "key": "image",
+              "image": "mysql:8.0.30",
+              "repository": "mysql",
+              "tag": "8.0.30",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:130: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:302: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:304: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name"
+          ]
+        },
+        {
+          "template": "yourls",
+          "image": "yourls:1.10.1",
+          "repository": "yourls",
+          "current_tag": "1.10.1",
+          "candidate_tag": "1.10.4",
+          "candidate_image": "yourls:1.10.4",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "yourls",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+              "line": 178,
+              "key": "originImageName",
+              "image": "yourls:1.10.1",
+              "repository": "yourls",
+              "tag": "1.10.1",
+              "digest": null
+            },
+            {
+              "template": "yourls",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+              "line": 203,
+              "key": "image",
+              "image": "yourls:1.10.1",
+              "repository": "yourls",
+              "tag": "1.10.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:130: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:302: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:304: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "zitadel",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "zitadel",
+          "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "repository": "ghcr.io/zitadel/zitadel",
+          "current_tag": "v4.10.1",
+          "candidate_tag": "v4.15.3",
+          "candidate_image": "ghcr.io/zitadel/zitadel:v4.15.3",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "zitadel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml",
+              "line": 135,
+              "key": "originImageName",
+              "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+              "repository": "ghcr.io/zitadel/zitadel",
+              "tag": "v4.10.1",
+              "digest": null
+            },
+            {
+              "template": "zitadel",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml",
+              "line": 155,
+              "key": "image",
+              "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+              "repository": "ghcr.io/zitadel/zitadel",
+              "tag": "v4.10.1",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:147: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:253: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    },
+    {
+      "template": "zot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "zot",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "current_tag": "v2.1.14",
+          "candidate_tag": "v2.1.18",
+          "candidate_image": "ghcr.io/project-zot/zot:v2.1.18",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "zot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+              "line": 144,
+              "key": "originImageName",
+              "image": "ghcr.io/project-zot/zot:v2.1.14",
+              "repository": "ghcr.io/project-zot/zot",
+              "tag": "v2.1.14",
+              "digest": null
+            },
+            {
+              "template": "zot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+              "line": 234,
+              "key": "image",
+              "image": "ghcr.io/project-zot/zot:v2.1.14",
+              "repository": "ghcr.io/project-zot/zot",
+              "tag": "v2.1.14",
+              "digest": null
+            },
+            {
+              "template": "zot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+              "line": 296,
+              "key": "originImageName",
+              "image": "ghcr.io/project-zot/zot:v2.1.14",
+              "repository": "ghcr.io/project-zot/zot",
+              "tag": "v2.1.14",
+              "digest": null
+            },
+            {
+              "template": "zot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+              "line": 316,
+              "key": "image",
+              "image": "ghcr.io/project-zot/zot:v2.1.14",
+              "repository": "ghcr.io/project-zot/zot",
+              "tag": "v2.1.14",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "zot",
+          "image": "httpd:2.4.63-alpine3.22",
+          "repository": "httpd",
+          "current_tag": "2.4.63-alpine3.22",
+          "candidate_tag": "2.4.68-alpine3.24",
+          "candidate_image": "httpd:2.4.68-alpine3.24",
+          "action": "update",
+          "intended_action": "update",
+          "confidence": "high",
+          "reason": "newer compatible semver tag found",
+          "evidence": "crane ls",
+          "records": [
+            {
+              "template": "zot",
+              "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+              "line": 164,
+              "key": "image",
+              "image": "httpd:2.4.63-alpine3.22",
+              "repository": "httpd",
+              "tag": "2.4.63-alpine3.22",
+              "digest": null
+            }
+          ],
+          "status": "blocked",
+          "processed_at": "2026-07-08T11:08:05+00:00",
+          "status_reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "changed_files": [],
+          "replacement_count": 0,
+          "missing_records": [],
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        }
+      ],
+      "processed_at": "2026-07-08T11:08:05+00:00"
+    }
+  ],
+  "processed_at": "2026-07-08T11:08:05+00:00",
+  "validation_gate": "docker-to-sealos per-artifact validation"
+}

--- a/.sealos/update-reports/template-update-status.json
+++ b/.sealos/update-reports/template-update-status.json
@@ -1,0 +1,9428 @@
+{
+  "generated_at": "2026-07-08T11:08:05+00:00",
+  "repo": "/Users/longnv/bin/repo/templates-version-refresh-20260708",
+  "source_queue": "template-update-queue.json",
+  "validation_evidence": "docker-to-sealos-artifact-validation.json",
+  "summary": {
+    "updated": 45,
+    "blocked": 228,
+    "skipped": 0,
+    "validation-needed": 0
+  },
+  "templates": [
+    {
+      "template": "Reactive-Resume",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "Reactive-Resume",
+          "current_image": "amruthpillai/reactive-resume:v4.1.2",
+          "candidate_image": "amruthpillai/reactive-resume:v5.2.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/Reactive-Resume/index.yaml",
+              "line": 351,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:34: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:165: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:182: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:212: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:217: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:231: container ${{ defaults.app_name }}-minio limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        },
+        {
+          "template": "Reactive-Resume",
+          "current_image": "ghcr.io/browserless/chromium:v2.11.0",
+          "candidate_image": "ghcr.io/browserless/chromium:v2.54.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/Reactive-Resume/index.yaml",
+              "line": 290,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:34: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:165: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:182: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:212: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:217: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml:231: container ${{ defaults.app_name }}-minio limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "Readeck",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "Readeck",
+          "current_image": "codeberg.org/readeck/readeck:0.16.0",
+          "candidate_image": "codeberg.org/readeck/readeck:0.22.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/Readeck/index.yaml",
+              "line": 36,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/Readeck/index.yaml",
+              "line": 64,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R004/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:4: Template metadata.name must be hardcoded lowercase and must not use variables",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:75: container imagePullPolicy must be IfNotPresent",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "anything-llm",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "anything-llm",
+          "current_image": "mintplexlabs/anythingllm:1.14.0",
+          "candidate_image": "mintplexlabs/anythingllm:1.15.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/anything-llm/index.yaml",
+              "line": 75,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/anything-llm/index.yaml",
+              "line": 100,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml:156: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "appflowy",
+          "current_image": "appflowyinc/appflowy_cloud:0.15.22",
+          "candidate_image": "appflowyinc/appflowy_cloud:0.16.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 491,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 511,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "current_image": "appflowyinc/appflowy_web:0.14.9",
+          "candidate_image": "appflowyinc/appflowy_web:0.15.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 820,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 840,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "current_image": "appflowyinc/appflowy_worker:0.15.22",
+          "candidate_image": "appflowyinc/appflowy_worker:0.16.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 692,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 712,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "appflowy",
+          "current_image": "appflowyinc/gotrue:0.15.22",
+          "candidate_image": "appflowyinc/gotrue:0.16.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 356,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appflowy/index.yaml",
+              "line": 376,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "appwrite",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "appwrite",
+          "current_image": "appwrite/appwrite:1.9.0",
+          "candidate_image": "appwrite/appwrite:1.9.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 285,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 356,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "appwrite",
+          "current_image": "appwrite/console:7.8.26",
+          "candidate_image": "appwrite/console:8.7.19",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 556,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 577,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "appwrite",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 311,
+              "key": "image"
+            },
+            {
+              "path": "template/appwrite/index.yaml",
+              "line": 333,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/appwrite/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "authentik",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "authentik",
+          "current_image": "ghcr.io/goauthentik/server:2025.12.3",
+          "candidate_image": "ghcr.io/goauthentik/server:2026.5.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/authentik/index.yaml",
+              "line": 175,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/authentik/index.yaml",
+              "line": 195,
+              "key": "image"
+            },
+            {
+              "path": "template/authentik/index.yaml",
+              "line": 290,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/authentik/index.yaml",
+              "line": 310,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:119: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:187: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:302: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:417: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml:439: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "billionmail",
+          "current_image": "alpine/openssl:3.5.4",
+          "candidate_image": "alpine/openssl:3.5.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/billionmail/index.yaml",
+              "line": 6468,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "current_image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "candidate_image": "billionmail/core:4.9.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/billionmail/index.yaml",
+              "line": 6434,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/billionmail/index.yaml",
+              "line": 7033,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "current_image": "python:3.12.12-alpine",
+          "candidate_image": "python:3.14.6-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/billionmail/index.yaml",
+              "line": 6672,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "billionmail",
+          "current_image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+          "candidate_image": "roundcube/roundcubemail:1.7.2-fpm-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/billionmail/index.yaml",
+              "line": 6974,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6454: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6499: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container prepare-billionmail-data requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6502: container wait-billionmail-db-init requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6681: container docker-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-socket-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container pgsql-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml:6718: container redis-tcp-proxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "budibase",
+          "current_image": "budibase/apps:3.15.0",
+          "candidate_image": "budibase/apps:3.39.27",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 429,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 449,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "current_image": "budibase/proxy:3.15.0",
+          "candidate_image": "budibase/proxy:3.39.27",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 821,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 841,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "current_image": "budibase/worker:3.15.0",
+          "candidate_image": "budibase/worker:3.39.27",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 625,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 645,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        },
+        {
+          "template": "budibase",
+          "current_image": "busybox:1.37.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/budibase/index.yaml",
+              "line": 276,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:186: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:187: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:189: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:190: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:237: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:249: container init-copy must define resources limits/requests from the Sealos ladder",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml:301: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "bunkerweb",
+          "current_image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "candidate_image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.12",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 607,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 680,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "current_image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "candidate_image": "docker.io/bunkerity/bunkerweb-ui:1.6.12",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 855,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 937,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "current_image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "candidate_image": "docker.io/bunkerity/bunkerweb:1.6.12",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 418,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 511,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        },
+        {
+          "template": "bunkerweb",
+          "current_image": "docker.io/library/busybox:1.36.1",
+          "candidate_image": "docker.io/library/busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 487,
+              "key": "image"
+            },
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 633,
+              "key": "image"
+            },
+            {
+              "path": "template/bunkerweb/index.yaml",
+              "line": 656,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:577: container ${{ defaults.app_name }}-bunkerweb limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml:1018: container ${{ defaults.app_name }}-ui requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "bytebase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "bytebase",
+          "current_image": "bytebase/bytebase:3.6.1",
+          "candidate_image": "bytebase/bytebase:3.20.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/bytebase/index.yaml",
+              "line": 45,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/bytebase/index.yaml",
+              "line": 68,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:75: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:124: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:127: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml:140: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "casdoor",
+          "current_image": "casbin/casdoor:v1.702.0",
+          "candidate_image": "casbin/casdoor:v2.190.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/casdoor/index.yaml",
+              "line": 425,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:48: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:513: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "casdoor",
+          "current_image": "casbin/casdoor:v2.32.0",
+          "candidate_image": "casbin/casdoor:v2.190.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/casdoor/index.yaml",
+              "line": 334,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/casdoor/index.yaml",
+              "line": 355,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:48: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml:513: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "changedetection",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "changedetection",
+          "current_image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "candidate_image": "ghcr.io/dgtlmoon/changedetection.io:0.55.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/changedetection/index.yaml",
+              "line": 43,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/changedetection/index.yaml",
+              "line": 64,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:56: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml:111: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-next-web",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatgpt-next-web",
+          "current_image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "candidate_image": "yidadaa/chatgpt-next-web:v2.16.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/chatgpt-next-web/index.yaml",
+              "line": 89,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/chatgpt-next-web/index.yaml",
+              "line": 114,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:79: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:141: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:142: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:158: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml:176: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-on-wechat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatgpt-on-wechat",
+          "current_image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "candidate_image": "zhayujie/chatgpt-on-wechat:2.1.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/chatgpt-on-wechat/index.yaml",
+              "line": 78,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/chatgpt-on-wechat/index.yaml",
+              "line": 98,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:68: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:169: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml:172: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "chatnio",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatnio",
+          "current_image": "joseluisq/mysql-client:8.0.30",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/chatnio/index.yaml",
+              "line": 290,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:79: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:98: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:149: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:152: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml:165: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "chatwoot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "chatwoot",
+          "current_image": "chatwoot/chatwoot:v4.7.0",
+          "candidate_image": "chatwoot/chatwoot:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/chatwoot/index.yaml",
+              "line": 171,
+              "key": "image"
+            },
+            {
+              "path": "template/chatwoot/index.yaml",
+              "line": 383,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/chatwoot/index.yaml",
+              "line": 404,
+              "key": "image"
+            },
+            {
+              "path": "template/chatwoot/index.yaml",
+              "line": 507,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/chatwoot/index.yaml",
+              "line": 528,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:130: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:172: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:190: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:200: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:203: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:348: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:349: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml:351: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "cobalt",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "cobalt",
+          "current_image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "candidate_image": "ghcr.io/imputnet/cobalt:11.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/cobalt/index.yaml",
+              "line": 62,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/cobalt/index.yaml",
+              "line": 83,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/cobalt/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "code-server",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "code-server",
+          "current_image": "codercom/code-server:4.90.3-39",
+          "candidate_image": "codercom/code-server:4.127.0-39",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/code-server/index.yaml",
+              "line": 45,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/code-server/index.yaml",
+              "line": 72,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:35: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:120: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml:178: App resource spec.type must be 'link'"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "coze-studio",
+          "current_image": "alpine/curl:8.12.1",
+          "candidate_image": "alpine/curl:8.21.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 1042,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "current_image": "bitnamilegacy/elasticsearch:8.18.0",
+          "candidate_image": "bitnamilegacy/elasticsearch:9.1.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 633,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 666,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 540,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 655,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 908,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 982,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 989,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 996,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 1148,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "current_image": "milvusdb/milvus:v2.5.10",
+          "candidate_image": "milvusdb/milvus:v2.6.19",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 755,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 775,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "current_image": "mysql:8.0.36",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 937,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "coze-studio",
+          "current_image": "nsqio/nsq:v1.2.1",
+          "candidate_image": "nsqio/nsq:v1.3.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 378,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 394,
+              "key": "image"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 447,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/coze-studio/index.yaml",
+              "line": 463,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:510: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:625: container init-data-dir must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:703: container ${{ defaults.app_name }}-elasticsearch limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:843: container ${{ defaults.app_name }}-milvus limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container apply-db-migrations must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container init-elasticsearch-indices must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container sync-storage-assets must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml:880: container wait-for-elasticsearch must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "crawl4ai",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "crawl4ai",
+          "current_image": "unclecode/crawl4ai:0.8.9",
+          "candidate_image": "unclecode/crawl4ai:0.9.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/crawl4ai/index.yaml",
+              "line": 37,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/crawl4ai/index.yaml",
+              "line": 59,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:96: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml:97: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "crmeb",
+          "current_image": "joseluisq/mysql-client:8.0.30",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/crmeb/index.yaml",
+              "line": 129,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:226: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:227: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:229: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:230: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:279: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml:281: ConfigMap metadata.labels.app is required and must match metadata.name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "cronicle",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "cronicle",
+          "current_image": "soulteary/cronicle:0.9.46",
+          "candidate_image": "soulteary/cronicle:0.9.80",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/cronicle/index.yaml",
+              "line": 34,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/cronicle/index.yaml",
+              "line": 62,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:25: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:121: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:138: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml:141: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dataease",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dataease/index.yaml",
+              "line": 63,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:30: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:34: container init-config must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:120: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:210: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:213: Service spec.ports entries must define a non-empty name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:348: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R001/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: forbidden ':latest' image tag",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "dataease",
+          "current_image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "candidate_image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dataease/index.yaml",
+              "line": 39,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/dataease/index.yaml",
+              "line": 113,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:30: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:34: container init-config must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:120: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:210: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:213: Service spec.ports entries must define a non-empty name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:348: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R001/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: forbidden ':latest' image tag",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml:358: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "dbgate",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dbgate",
+          "current_image": "dbgate/dbgate:5.3.1-alpine",
+          "candidate_image": "dbgate/dbgate:7.2.1-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dbgate/index.yaml",
+              "line": 50,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/dbgate/index.yaml",
+              "line": 78,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:134: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:137: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml:173: App resource spec.type must be 'link'"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "deeplx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "deeplx",
+          "current_image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "candidate_image": "ghcr.io/owo-network/deeplx:v1.2.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/deeplx/index.yaml",
+              "line": 40,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/deeplx/index.yaml",
+              "line": 65,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:57: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:75: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:88: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:91: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml:111: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "derper",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "derper",
+          "current_image": "bitnamilegacy/kubectl:1.28.9",
+          "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/derper/index.yaml",
+              "line": 196,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/derper/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "derper",
+          "current_image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "candidate_image": "ghcr.io/yangchuansheng/derper:v1.101.0-pre",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/derper/index.yaml",
+              "line": 110,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/derper/index.yaml",
+              "line": 132,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/derper/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "dify",
+          "current_image": "busybox:1.37.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dify/index.yaml",
+              "line": 112,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "current_image": "langgenius/dify-api:1.11.2",
+          "candidate_image": "langgenius/dify-api:1.15.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dify/index.yaml",
+              "line": 54,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/dify/index.yaml",
+              "line": 131,
+              "key": "image"
+            },
+            {
+              "path": "template/dify/index.yaml",
+              "line": 273,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "current_image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "candidate_image": "langgenius/dify-plugin-daemon:0.6.3-local",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dify/index.yaml",
+              "line": 681,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/dify/index.yaml",
+              "line": 740,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "dify",
+          "current_image": "langgenius/dify-sandbox:0.2.12",
+          "candidate_image": "langgenius/dify-sandbox:0.2.15",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dify/index.yaml",
+              "line": 601,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/dify/index.yaml",
+              "line": 624,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container init-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:49: container wait-db must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:95: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:175: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-api limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:263: container ${{ defaults.app_name }}-worker limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml:264: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "directus",
+          "current_image": "directus/directus:11.17.4",
+          "candidate_image": "directus/directus:12.1.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/directus/index.yaml",
+              "line": 332,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/directus/index.yaml",
+              "line": 449,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        },
+        {
+          "template": "directus",
+          "current_image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/directus/index.yaml",
+              "line": 357,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        },
+        {
+          "template": "directus",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/directus/index.yaml",
+              "line": 421,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:138: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:139: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:141: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:142: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:284: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml:285: database component redis-sentinel resources.limits.memory must be 512Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "docuseal",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "docuseal",
+          "current_image": "docuseal/docuseal:3.0.1",
+          "candidate_image": "docuseal/docuseal:3.1.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/docuseal/index.yaml",
+              "line": 184,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/docuseal/index.yaml",
+              "line": 207,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml:203: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "dolibarr",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "dolibarr",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/dolibarr/index.yaml",
+              "line": 161,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/dolibarr/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "drawdb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "drawdb",
+          "current_image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "candidate_image": "ghcr.io/drawdb-io/drawdb:v1.8.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/drawdb/index.yaml",
+              "line": 60,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/drawdb/index.yaml",
+              "line": 81,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml:72: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "edgequake",
+          "current_image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "candidate_image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.15.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/edgequake/index.yaml",
+              "line": 380,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/edgequake/index.yaml",
+              "line": 400,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:294: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:392: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "edgequake",
+          "current_image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "candidate_image": "ghcr.io/raphaelmansuy/edgequake:0.15.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/edgequake/index.yaml",
+              "line": 282,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/edgequake/index.yaml",
+              "line": 302,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:294: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml:392: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "elasticsearch",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "elasticsearch",
+          "current_image": "busybox:1.37.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/elasticsearch/index.yaml",
+              "line": 63,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:57: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "emqx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "emqx",
+          "current_image": "emqx/emqx:5.8.9",
+          "candidate_image": "emqx/emqx:6.2.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/emqx/index.yaml",
+              "line": 57,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/emqx/index.yaml",
+              "line": 91,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml:81: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "erpnext",
+          "current_image": "frappe/erpnext:v16.21.1",
+          "candidate_image": "frappe/erpnext:v16.26.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 374,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 530,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 666,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 731,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 786,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 882,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 962,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1027,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1118,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1214,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1275,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1371,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1432,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1497,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "current_image": "mariadb:11.4.7",
+          "candidate_image": "mariadb:12.3.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 66,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 89,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "current_image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 319,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 475,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 687,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 710,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 807,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 861,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 983,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1006,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1139,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1193,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1296,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1350,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1453,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1476,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "erpnext",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 342,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 498,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 830,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1162,
+              "key": "image"
+            },
+            {
+              "path": "template/erpnext/index.yaml",
+              "line": 1319,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:89: raw Kubernetes StatefulSet runs database image 'mariadb'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:144: container ${{ defaults.app_name }}-mysql limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:157: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:446: container configure requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:645: container create-site limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:646: container create-site limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:749: container ${{ defaults.app_name }}-backend limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml:750: container ${{ defaults.app_name }}-backend limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "ever-gauzy",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/ever-gauzy/index.yaml",
+              "line": 208,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:137: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:200: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:437: container ${{ defaults.app_name }}-api limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml:529: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "evolution-api",
+          "current_image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/evolution-api/index.yaml",
+              "line": 340,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/evolution-api/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "evolution-api",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/evolution-api/index.yaml",
+              "line": 393,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/evolution-api/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1013,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1033,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1126,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1146,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 852,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 872,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 562,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 582,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1238,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt/index.yaml",
+              "line": 1258,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:151: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:152: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:154: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:155: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:238: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:239: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:241: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml:242: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt-milvus",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 678,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 704,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 774,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 800,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 417,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 443,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 136,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 156,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "fastgpt-milvus",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 580,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-milvus/index.yaml",
+              "line": 606,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:18: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:609: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:614: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:619: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:624: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:646: container ${{ defaults.app_name }}-aiproxy limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:647: container ${{ defaults.app_name }}-aiproxy limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml:744: container ${{ defaults.app_name }}-code-sandbox limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1161,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1181,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1274,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1294,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1000,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1020,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 855,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 875,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 563,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 583,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        },
+        {
+          "template": "fastgpt-pro",
+          "current_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1386,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/fastgpt-pro/index.yaml",
+              "line": 1406,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:152: database component mongodb resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:153: database component mongodb resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:155: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:156: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:239: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:240: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:242: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml:243: database component postgresql resources.requests.memory must be 51Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "featbit-standard",
+          "current_image": "featbit/featbit-api-server:5.0.5",
+          "candidate_image": "featbit/featbit-api-server:5.4.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1118,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1179,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "current_image": "featbit/featbit-data-analytics-server:5.0.5",
+          "candidate_image": "featbit/featbit-data-analytics-server:5.4.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1247,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1308,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "current_image": "featbit/featbit-evaluation-server:5.0.5",
+          "candidate_image": "featbit/featbit-evaluation-server:5.4.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1370,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1431,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "featbit-standard",
+          "current_image": "featbit/featbit-ui:5.0.5",
+          "candidate_image": "featbit/featbit-ui:5.4.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1497,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/featbit-standard/index.yaml",
+              "line": 1519,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1136: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1265: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1388: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml:1515: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "firecrawl",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 258,
+              "key": "image"
+            },
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 702,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "firecrawl",
+          "current_image": "rabbitmq:3.13.7-management",
+          "candidate_image": "rabbitmq:4.3.2-management",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 230,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 287,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "firecrawl",
+          "current_image": "redis:7.2.7-alpine",
+          "candidate_image": "redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 145,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 169,
+              "key": "image"
+            },
+            {
+              "path": "template/firecrawl/index.yaml",
+              "line": 675,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:169: raw Kubernetes StatefulSet runs database image 'redis'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:211: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:304: container ${{ defaults.app_name }}-rabbitmq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:305: container ${{ defaults.app_name }}-rabbitmq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:378: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:463: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:810: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml:811: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "flarum",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "flarum",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/flarum/index.yaml",
+              "line": 155,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml:150: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "flowise",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "flowise",
+          "current_image": "flowiseai/flowise:3.0.5",
+          "candidate_image": "flowiseai/flowise:3.1.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/flowise/index.yaml",
+              "line": 195,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/flowise/index.yaml",
+              "line": 257,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:147: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:157: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:400: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml:403: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "formbricks",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "formbricks",
+          "current_image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "candidate_image": "ghcr.io/formbricks/formbricks:5.1.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/formbricks/index.yaml",
+              "line": 344,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/formbricks/index.yaml",
+              "line": 370,
+              "key": "image"
+            },
+            {
+              "path": "template/formbricks/index.yaml",
+              "line": 426,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:358: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:507: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml:511: container ${{ defaults.app_name }} requests.memory must be 25Mi when limits.memory is 256Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "frp",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "frp",
+          "current_image": "bitnamilegacy/kubectl:1.28.9",
+          "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/frp/index.yaml",
+              "line": 299,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:17: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:53: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:55: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:79: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:104: floating image tag '0.59' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:156: Service metadata.name must match spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml:157: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "ghost",
+          "current_image": "ghost:6.44.1-alpine",
+          "candidate_image": "ghost:6.51.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/ghost/index.yaml",
+              "line": 250,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/ghost/index.yaml",
+              "line": 339,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/ghost/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "ghost",
+          "current_image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/ghost/index.yaml",
+              "line": 155,
+              "key": "image"
+            },
+            {
+              "path": "template/ghost/index.yaml",
+              "line": 300,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/ghost/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "gitea",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "gitea",
+          "current_image": "gitea/gitea:1.22.0-rootless",
+          "candidate_image": "gitea/gitea:1.26.4-rootless",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/gitea/index.yaml",
+              "line": 36,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/gitea/index.yaml",
+              "line": 63,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:67: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:71: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:140: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml:162: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "glitchtip",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "glitchtip",
+          "current_image": "glitchtip/glitchtip:v4.1.5",
+          "candidate_image": "glitchtip/glitchtip:v6.0.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/glitchtip/index.yaml",
+              "line": 61,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/glitchtip/index.yaml",
+              "line": 86,
+              "key": "image"
+            },
+            {
+              "path": "template/glitchtip/index.yaml",
+              "line": 175,
+              "key": "image"
+            },
+            {
+              "path": "template/glitchtip/index.yaml",
+              "line": 265,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:52: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:363: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:366: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml:378: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-buffer-size' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "grafana",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "grafana",
+          "current_image": "grafana/grafana:13.0.2",
+          "candidate_image": "grafana/grafana:13.1.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/grafana/index.yaml",
+              "line": 193,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/grafana/index.yaml",
+              "line": 217,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/grafana/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "grafana-otel",
+          "current_image": "grafana/grafana:12.3.0",
+          "candidate_image": "grafana/grafana:13.1.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 351,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 384,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "grafana-otel",
+          "current_image": "otel/opentelemetry-collector:0.99.0",
+          "candidate_image": "otel/opentelemetry-collector:0.156.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 70,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 91,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "grafana-otel",
+          "current_image": "prom/prometheus:v3.8.0",
+          "candidate_image": "prom/prometheus:v3.13.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 221,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/grafana-otel/index.yaml",
+              "line": 254,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R034/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:75: metadata.labels.app must exactly match metadata.name for managed app workloads",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:143: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:209: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:216: container init-step must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml:304: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "halo",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "halo",
+          "current_image": "halohub/halo:2.18.0",
+          "candidate_image": "halohub/halo:2.25.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/halo/index.yaml",
+              "line": 48,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/halo/index.yaml",
+              "line": 71,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:87: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:88: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:129: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:132: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:145: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml:151: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "harbor",
+          "current_image": "goharbor/harbor-core:v2.14.4",
+          "candidate_image": "goharbor/harbor-core:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 606,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 628,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "current_image": "goharbor/harbor-jobservice:v2.14.4",
+          "candidate_image": "goharbor/harbor-jobservice:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 739,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 762,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "current_image": "goharbor/harbor-portal:v2.14.4",
+          "candidate_image": "goharbor/harbor-portal:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 840,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 862,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "current_image": "goharbor/harbor-registryctl:v2.14.4",
+          "candidate_image": "goharbor/harbor-registryctl:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 1041,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 1063,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "current_image": "goharbor/registry-photon:v2.14.4",
+          "candidate_image": "goharbor/registry-photon:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 903,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 926,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "harbor",
+          "current_image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "candidate_image": "goharbor/trivy-adapter-photon:v2.15.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 1121,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/harbor/index.yaml",
+              "line": 1146,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:624: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:758: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:858: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:922: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1059: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml:1142: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "hasura",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "hasura",
+          "current_image": "hasura/graphql-data-connector:v2.48.11",
+          "candidate_image": "hasura/graphql-data-connector:v2.49.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/hasura/index.yaml",
+              "line": 215,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/hasura/index.yaml",
+              "line": 235,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:276: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:291: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        },
+        {
+          "template": "hasura",
+          "current_image": "hasura/graphql-engine:v2.48.11",
+          "candidate_image": "hasura/graphql-engine:v2.49.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/hasura/index.yaml",
+              "line": 121,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/hasura/index.yaml",
+              "line": 141,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:276: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml:291: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "headscale",
+          "current_image": "ghcr.io/tale/headplane:0.6.3",
+          "candidate_image": "ghcr.io/tale/headplane:0.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/headscale/index.yaml",
+              "line": 1042,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:221: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:223: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1156: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1158: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1240: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1242: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1257: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml:1282: Ingress backend service.name must match Ingress metadata.name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "illa-builder",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "illa-builder",
+          "current_image": "illasoft/illa-builder:v4.8.2",
+          "candidate_image": "illasoft/illa-builder:v4.8.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/illa-builder/index.yaml",
+              "line": 38,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/illa-builder/index.yaml",
+              "line": 61,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "immich",
+          "current_image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "candidate_image": "ghcr.io/immich-app/immich-server:v3.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/immich/index.yaml",
+              "line": 319,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/immich/index.yaml",
+              "line": 388,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:223: database component postgresql resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:224: database component postgresql resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:226: database component postgresql resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:227: database component postgresql resources.requests.memory must be 51Mi",
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml:238: PVC storage request must be <= 1Gi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "insforge",
+          "current_image": "apecloud/kubeblocks-tools:0.9.3",
+          "candidate_image": "apecloud/kubeblocks-tools:1.0.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 265,
+              "key": "image"
+            },
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 352,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "insforge",
+          "current_image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "candidate_image": "ghcr.io/insforge/insforge-oss:v2.2.6",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 420,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 500,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "insforge",
+          "current_image": "postgrest/postgrest:v12.2.12",
+          "candidate_image": "postgrest/postgrest:v13.0.8",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 675,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/insforge/index.yaml",
+              "line": 695,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:433: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml:779: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "jellyfin",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "jellyfin",
+          "current_image": "jellyfin/jellyfin:10.10.7",
+          "candidate_image": "jellyfin/jellyfin:10.11.11",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/jellyfin/index.yaml",
+              "line": 38,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/jellyfin/index.yaml",
+              "line": 63,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/jellyfin/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "kanboard",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kanboard",
+          "current_image": "kanboard/kanboard:v1.2.50",
+          "candidate_image": "kanboard/kanboard:v1.2.52",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/kanboard/index.yaml",
+              "line": 121,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/kanboard/index.yaml",
+              "line": 141,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml:200: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kaneo",
+          "current_image": "ghcr.io/usekaneo/api:1.1.8",
+          "candidate_image": "ghcr.io/usekaneo/api:2.9.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/kaneo/index.yaml",
+              "line": 170,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/kaneo/index.yaml",
+              "line": 190,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:162: Service spec.ports entries must define a non-empty name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:182: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R037/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:199: PostgreSQL secret reference '${{ defaults.app_name}}-pg-conn-credential' must match the Cluster metadata.name-derived secret (${{ defaults.app_name }}-pg-conn-credential)"
+          ]
+        },
+        {
+          "template": "kaneo",
+          "current_image": "ghcr.io/usekaneo/web:1.1.8",
+          "candidate_image": "ghcr.io/usekaneo/web:2.9.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/kaneo/index.yaml",
+              "line": 234,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/kaneo/index.yaml",
+              "line": 254,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:155: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:162: Service spec.ports entries must define a non-empty name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:182: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R037/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml:199: PostgreSQL secret reference '${{ defaults.app_name}}-pg-conn-credential' must match the Cluster metadata.name-derived secret (${{ defaults.app_name }}-pg-conn-credential)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "keycloak",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "keycloak",
+          "current_image": "quay.io/keycloak/keycloak:26.3.2",
+          "candidate_image": "quay.io/keycloak/keycloak:26.6.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/keycloak/index.yaml",
+              "line": 177,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/keycloak/index.yaml",
+              "line": 198,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:20: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:139: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:152: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:159: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:222: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:224: database env 'KC_DB_URL_HOST' must use secret key 'endpoint' from an approved database secret",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:294: Service metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml:296: Service metadata.name must match spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "keystone",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "keystone",
+          "current_image": "node:22.22.1-alpine",
+          "candidate_image": "node:26.4.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/keystone/index.yaml",
+              "line": 479,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/keystone/index.yaml",
+              "line": 544,
+              "key": "image"
+            },
+            {
+              "path": "template/keystone/index.yaml",
+              "line": 620,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml:138: container pg-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "kuvasz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "kuvasz",
+          "current_image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "candidate_image": "kuvaszmonitoring/kuvasz:4.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/kuvasz/index.yaml",
+              "line": 201,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/kuvasz/index.yaml",
+              "line": 277,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:132: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml:329: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "laf",
+          "current_image": "quay.io/prometheus/prometheus:v2.45.0",
+          "candidate_image": "quay.io/prometheus/prometheus:v3.13.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/laf/index.yaml",
+              "line": 519,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:50: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:139: database component mongodb resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:140: database component mongodb resources.requests.memory must be 51Mi",
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:149: PVC storage request must be <= 1Gi",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:188: managed app workloads must define metadata.annotations.originImageName",
+            "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:193: managed app workloads must explicitly set revisionHistoryLimit: 1",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml:203: automountServiceAccountToken must be false for managed app workloads"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "langflow",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "langflow",
+          "current_image": "langflowai/langflow:1.9.5",
+          "candidate_image": "langflowai/langflow:1.10.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/langflow/index.yaml",
+              "line": 219,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/langflow/index.yaml",
+              "line": 247,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/langflow/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "langfuse",
+          "current_image": "clickhouse/clickhouse-server:25.4.2",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 385,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 409,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "current_image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "candidate_image": "docker.io/langfuse/langfuse-worker:3.207.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 528,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 622,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "current_image": "docker.io/langfuse/langfuse:3.180.0",
+          "candidate_image": "docker.io/langfuse/langfuse:3.207.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 786,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 839,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        },
+        {
+          "template": "langfuse",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 591,
+              "key": "image"
+            },
+            {
+              "path": "template/langfuse/index.yaml",
+              "line": 808,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:409: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml:505: raw Kubernetes database Service is forbidden; use Kubeblocks database resources"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "librechat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "librechat",
+          "current_image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "candidate_image": "ghcr.io/danny-avila/librechat:v0.8.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/librechat/index.yaml",
+              "line": 52,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/librechat/index.yaml",
+              "line": 75,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:32: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:50: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:66: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:249: Service spec.ports entries must define a non-empty name",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:260: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest",
+            "- [R016/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml:283: floating image tag 'v1.5' is not allowed; use an explicit version tag (e.g. v2.2.0) or digest"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "liebianbao",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/liebianbao/index.yaml",
+              "line": 99,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:8: Template spec.gitRepo must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:47: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:72: container initializer must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:77: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:131: container imagePullPolicy must be IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:221: container ${{ defaults.app_name }} requests.cpu must be 100m when limits.cpu is 1"
+          ]
+        },
+        {
+          "template": "liebianbao",
+          "current_image": "nginx:1.25.2",
+          "candidate_image": "nginx:1.31.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/liebianbao/index.yaml",
+              "line": 253,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:8: Template spec.gitRepo must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:47: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:72: container initializer must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:77: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:131: container imagePullPolicy must be IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml:221: container ${{ defaults.app_name }} requests.cpu must be 100m when limits.cpu is 1"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "listmonk",
+          "current_image": "busybox:1.37.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/listmonk/index.yaml",
+              "line": 252,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/listmonk/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "listmonk",
+          "current_image": "listmonk/listmonk:v6.1.0",
+          "candidate_image": "listmonk/listmonk:v6.2.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/listmonk/index.yaml",
+              "line": 224,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/listmonk/index.yaml",
+              "line": 274,
+              "key": "image"
+            },
+            {
+              "path": "template/listmonk/index.yaml",
+              "line": 343,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/listmonk/index.yaml"
+          ],
+          "replacement_count": 3,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "litellm",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "litellm",
+          "current_image": "litellm/litellm-database:v1.88.1",
+          "candidate_image": "litellm/litellm-database:v1.91.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/litellm/index.yaml",
+              "line": 255,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/litellm/index.yaml",
+              "line": 322,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/litellm/index.yaml"
+          ],
+          "replacement_count": 3,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "llmgateway",
+          "current_image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-api:v1.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 357,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 442,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "current_image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-docs:v1.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 1195,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 1217,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "current_image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-gateway:v1.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 590,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 716,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "current_image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-ui:v1.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 1066,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 1087,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "current_image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "candidate_image": "ghcr.io/theopenco/llmgateway-worker:v1.7.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 874,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 1001,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        },
+        {
+          "template": "llmgateway",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 419,
+              "key": "image"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 693,
+              "key": "image"
+            },
+            {
+              "path": "template/llmgateway/index.yaml",
+              "line": 978,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:369: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:602: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:887: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:935: container ${{ defaults.app_name }}-worker requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1078: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1208: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1231: container ${{ defaults.app_name }}-docs requests.cpu must be 10m when limits.cpu is 100m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml:1232: container ${{ defaults.app_name }}-docs requests.memory must be 12Mi when limits.memory is 128Mi"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat-db",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "lobe-chat-db",
+          "current_image": "lobehub/lobe-chat-database:1.143.2",
+          "candidate_image": "lobehub/lobe-chat-database:1.143.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/lobe-chat-db/index.yaml",
+              "line": 212,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/lobe-chat-db/index.yaml",
+              "line": 237,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:162: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:278: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:312: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:326: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:329: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml:348: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "logto",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "logto",
+          "current_image": "svhd/logto:1.40.1",
+          "candidate_image": "svhd/logto:1.41.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/logto/index.yaml",
+              "line": 179,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/logto/index.yaml",
+              "line": 204,
+              "key": "image"
+            },
+            {
+              "path": "template/logto/index.yaml",
+              "line": 253,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/logto/index.yaml"
+          ],
+          "replacement_count": 3,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "loki",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "loki",
+          "current_image": "busybox:1.37.0",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/loki/index.yaml",
+              "line": 57,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/loki/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "mastodon",
+          "current_image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "candidate_image": "ghcr.io/mastodon/mastodon-streaming:v4.6.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 937,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 1004,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:561: container mastodon-setup limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:562: container mastodon-setup limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:590: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:742: container ${{ defaults.app_name }}-web limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:743: container ${{ defaults.app_name }}-web limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:768: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:926: container ${{ defaults.app_name }}-sidekiq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:927: container ${{ defaults.app_name }}-sidekiq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "mastodon",
+          "current_image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "candidate_image": "ghcr.io/mastodon/mastodon:v4.6.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 455,
+              "key": "image"
+            },
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 572,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 639,
+              "key": "image"
+            },
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 753,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mastodon/index.yaml",
+              "line": 817,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:561: container mastodon-setup limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:562: container mastodon-setup limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:590: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:742: container ${{ defaults.app_name }}-web limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:743: container ${{ defaults.app_name }}-web limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:768: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:926: container ${{ defaults.app_name }}-sidekiq limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml:927: container ${{ defaults.app_name }}-sidekiq limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "matomo",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "matomo",
+          "current_image": "matomo:5.10.0-apache",
+          "candidate_image": "matomo:5.11.2-apache",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/matomo/index.yaml",
+              "line": 179,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/matomo/index.yaml",
+              "line": 201,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/matomo/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "matomo",
+          "current_image": "mysql:8.0.44",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/matomo/index.yaml",
+              "line": 135,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/matomo/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "mautic",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 473,
+              "key": "image"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 597,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "mautic",
+          "current_image": "mautic/mautic:7.1.2-apache",
+          "candidate_image": "mautic/mautic:7.1.3-apache",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 242,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 266,
+              "key": "image"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 316,
+              "key": "image"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 343,
+              "key": "image"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 440,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 492,
+              "key": "image"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 564,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 616,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 8,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "mautic",
+          "current_image": "mysql:8.4.2",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mautic/index.yaml",
+              "line": 141,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/mautic/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "meilisearch",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "meilisearch",
+          "current_image": "getmeili/meilisearch:v1.45.1",
+          "candidate_image": "getmeili/meilisearch:v1.49.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/meilisearch/index.yaml",
+              "line": 44,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/meilisearch/index.yaml",
+              "line": 68,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/meilisearch/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "metabase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "metabase",
+          "current_image": "metabase/metabase:v0.61.3",
+          "candidate_image": "metabase/metabase:v0.62.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/metabase/index.yaml",
+              "line": 171,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/metabase/index.yaml",
+              "line": 194,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml:251: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "minecraft",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "minecraft",
+          "current_image": "alpine:3.22.4",
+          "candidate_image": "alpine:3.24.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/minecraft/index.yaml",
+              "line": 71,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/minecraft/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "minecraft",
+          "current_image": "itzg/minecraft-server:2026.5.3-java25",
+          "candidate_image": "itzg/minecraft-server:2026.7.0-java8",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/minecraft/index.yaml",
+              "line": 48,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/minecraft/index.yaml",
+              "line": 91,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/minecraft/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "mlflow",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "mlflow",
+          "current_image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "candidate_image": "ghcr.io/mlflow/mlflow:v3.14.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/mlflow/index.yaml",
+              "line": 201,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/mlflow/index.yaml",
+              "line": 270,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml:214: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "n8n",
+          "current_image": "n8nio/n8n:2.22.4",
+          "candidate_image": "n8nio/n8n:2.30.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 337,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 370,
+              "key": "image"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 583,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 624,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:540: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:601: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:729: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "n8n",
+          "current_image": "n8nio/runners:2.22.4",
+          "candidate_image": "n8nio/runners:2.30.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 522,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 544,
+              "key": "image"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 711,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/n8n/index.yaml",
+              "line": 733,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:540: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:601: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml:729: public-image managed app workloads must omit template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "nacos",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nacos",
+          "current_image": "mysql:8.0.44",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/nacos/index.yaml",
+              "line": 347,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:494: container ${{ defaults.app_name }}-console limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml:631: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "netbird",
+          "current_image": "netbirdio/dashboard:v2.38.1",
+          "candidate_image": "netbirdio/dashboard:v2.90.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 150,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 170,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "current_image": "netbirdio/management:0.71.4",
+          "candidate_image": "netbirdio/management:0.74.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 217,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 238,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "current_image": "netbirdio/relay:0.71.4",
+          "candidate_image": "netbirdio/relay:0.74.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 356,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 376,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "netbird",
+          "current_image": "netbirdio/signal:0.71.4",
+          "candidate_image": "netbirdio/signal:0.74.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 295,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/netbird/index.yaml",
+              "line": 316,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/netbird/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "nexus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nexus",
+          "current_image": "alpine:3.22.2",
+          "candidate_image": "alpine:3.24.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/nexus/index.yaml",
+              "line": 61,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml:94: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "nexus",
+          "current_image": "sonatype/nexus3:3.92.3",
+          "candidate_image": "sonatype/nexus3:3.93.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/nexus/index.yaml",
+              "line": 37,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/nexus/index.yaml",
+              "line": 79,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml:94: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "nocodb",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nocodb",
+          "current_image": "nocodb/nocodb:2026.05.2",
+          "candidate_image": "nocodb/nocodb:2026.06.2",
+          "action": "update",
+          "confidence": "medium",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/nocodb/index.yaml",
+              "line": 132,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/nocodb/index.yaml",
+              "line": 156,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml:192: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "node-red",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "node-red",
+          "current_image": "nodered/node-red:4.1.10",
+          "candidate_image": "nodered/node-red:5.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/node-red/index.yaml",
+              "line": 36,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/node-red/index.yaml",
+              "line": 61,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/node-red/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "nofx",
+          "current_image": "alpine/openssl:3.5.4",
+          "candidate_image": "alpine/openssl:3.5.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/nofx/index.yaml",
+              "line": 210,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:201: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml:439: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "odysseus",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "odysseus",
+          "current_image": "chromadb/chroma:1.0.15",
+          "candidate_image": "chromadb/chroma:1.5.9",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/odysseus/index.yaml",
+              "line": 73,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/odysseus/index.yaml",
+              "line": 94,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:286: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:363: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "odysseus",
+          "current_image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+          "candidate_image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/odysseus/index.yaml",
+              "line": 272,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/odysseus/index.yaml",
+              "line": 294,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:286: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml:363: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "open-webui",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "open-webui",
+          "current_image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "candidate_image": "ghcr.io/open-webui/open-webui:v0.10.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/open-webui/index.yaml",
+              "line": 36,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/open-webui/index.yaml",
+              "line": 59,
+              "key": "image"
+            },
+            {
+              "path": "template/open-webui/index.yaml",
+              "line": 65,
+              "key": "image"
+            },
+            {
+              "path": "template/open-webui/index.yaml",
+              "line": 74,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container copy-data must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:31: container init-data must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:83: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:84: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml:89: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "openclaw",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "openclaw",
+          "current_image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "candidate_image": "ghcr.io/openclaw/openclaw:2026.6.11",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/openclaw/index.yaml",
+              "line": 62,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/openclaw/index.yaml",
+              "line": 102,
+              "key": "image"
+            },
+            {
+              "path": "template/openclaw/index.yaml",
+              "line": 160,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:57: container init-openclaw-data must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:221: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml:222: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "openlist",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "openlist",
+          "current_image": "openlistteam/openlist:v4.0.9-aria2",
+          "candidate_image": "openlistteam/openlist:v4.2.3-aria2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/openlist/index.yaml",
+              "line": 49,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/openlist/index.yaml",
+              "line": 72,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:120: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml:123: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "openobserve",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "openobserve",
+          "current_image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "candidate_image": "public.ecr.aws/zinclabs/openobserve:v0.91.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/openobserve/index.yaml",
+              "line": 68,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/openobserve/index.yaml",
+              "line": 97,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/openobserve/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "outline",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "outline",
+          "current_image": "outlinewiki/outline:1.8.0-1",
+          "candidate_image": "outlinewiki/outline:1.8.2-0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/outline/index.yaml",
+              "line": 427,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/outline/index.yaml",
+              "line": 448,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml:371: container pgsql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "overleaf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "overleaf",
+          "current_image": "sharelatex/sharelatex:6.1.2",
+          "candidate_image": "sharelatex/sharelatex:6.2.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/overleaf/index.yaml",
+              "line": 260,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/overleaf/index.yaml",
+              "line": 284,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:330: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:331: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml:450: App resource spec.type must be 'link'"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "pageplug",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pageplug",
+          "current_image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "candidate_image": "cloudtogouser/pageplug-ce:v1.9.37",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pageplug/index.yaml",
+              "line": 38,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pageplug/index.yaml",
+              "line": 61,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml:119: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "pangolin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pangolin",
+          "current_image": "docker.io/fosrl/pangolin:1.15.2",
+          "candidate_image": "docker.io/fosrl/pangolin:1.19.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pangolin/index.yaml",
+              "line": 102,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pangolin/index.yaml",
+              "line": 122,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:44: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:127: container ${{ defaults.app_name }}-pangolin limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml:181: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "paperclip",
+          "current_image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/paperclip/index.yaml",
+              "line": 257,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/paperclip/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "pdf2zh",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pdf2zh",
+          "current_image": "byaidu/pdf2zh:1.9.6",
+          "candidate_image": "byaidu/pdf2zh:1.9.11",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pdf2zh/index.yaml",
+              "line": 38,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pdf2zh/index.yaml",
+              "line": 63,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:70: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:81: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml:84: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "penpot",
+          "current_image": "penpotapp/backend:2.1.2",
+          "candidate_image": "penpotapp/backend:2.16.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 281,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 307,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        },
+        {
+          "template": "penpot",
+          "current_image": "penpotapp/exporter:2.1.2",
+          "candidate_image": "penpotapp/exporter:2.16.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 422,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 447,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        },
+        {
+          "template": "penpot",
+          "current_image": "penpotapp/frontend:2.1.2",
+          "candidate_image": "penpotapp/frontend:2.16.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 496,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/penpot/index.yaml",
+              "line": 523,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:122: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:139: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:215: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:216: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml:218: database component redis-sentinel resources.requests.cpu must be 50m"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "perplexica",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "perplexica",
+          "current_image": "itzcrazykns1337/perplexica:v1.10.2",
+          "candidate_image": "itzcrazykns1337/perplexica:v1.12.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/perplexica/index.yaml",
+              "line": 261,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/perplexica/index.yaml",
+              "line": 284,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:48: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:165: container ${{ defaults.app_name }}-searxng limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:207: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:210: Service spec.ports entries must define a non-empty name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:216: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml:218: ConfigMap metadata.labels.app is required and must match metadata.name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "phpmyadmin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "phpmyadmin",
+          "current_image": "phpmyadmin:5.2.1",
+          "candidate_image": "phpmyadmin:5.2.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/phpmyadmin/index.yaml",
+              "line": 35,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/phpmyadmin/index.yaml",
+              "line": 55,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:79: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:85: Ingress annotation 'nginx.ingress.kubernetes.io/ssl-redirect' must match the required HTTP default",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:116: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml:119: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "planka",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/planka/index.yaml",
+              "line": 219,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml:211: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "pocket-id",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pocket-id",
+          "current_image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "candidate_image": "ghcr.io/pocket-id/pocket-id:v2.9.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pocket-id/index.yaml",
+              "line": 40,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pocket-id/index.yaml",
+              "line": 60,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:52: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:99: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:102: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/backend-protocol' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/client-body-buffer-size' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/configuration-snippet' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml:116: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-body-size' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "pocketbase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "pocketbase",
+          "current_image": "adrianmusante/pocketbase:0.29.3",
+          "candidate_image": "adrianmusante/pocketbase:0.39.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pocketbase/index.yaml",
+              "line": 58,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pocketbase/index.yaml",
+              "line": 87,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:147: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:151: Service spec.ports entries must define a non-empty name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:201: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml:204: Ingress backend service.name must match Ingress metadata.name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "posthog",
+          "current_image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "candidate_image": "docker.redpanda.com/redpandadata/redpanda:v26.1.12",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/posthog/index.yaml",
+              "line": 339,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/posthog/index.yaml",
+              "line": 360,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:322: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:323: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:463: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:538: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:539: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:612: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:625: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:627: container ${{ defaults.app_name }} requests.cpu must be 50m when limits.cpu is 500m"
+          ]
+        },
+        {
+          "template": "posthog",
+          "current_image": "zookeeper:3.9.3",
+          "candidate_image": "zookeeper:3.9.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/posthog/index.yaml",
+              "line": 481,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/posthog/index.yaml",
+              "line": 502,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:322: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:323: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:463: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:538: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:539: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:612: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:625: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml:627: container ${{ defaults.app_name }} requests.cpu must be 50m when limits.cpu is 500m"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "postiz",
+          "current_image": "busybox:1.36.1",
+          "candidate_image": "busybox:1.38.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 326,
+              "key": "image"
+            },
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 531,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "current_image": "elasticsearch:7.17.27",
+          "candidate_image": "elasticsearch:9.4.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 305,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 341,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "current_image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "candidate_image": "ghcr.io/gitroomhq/postiz-app:v2.21.10",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 510,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 583,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "postiz",
+          "current_image": "temporalio/auto-setup:1.28.1",
+          "candidate_image": "temporalio/auto-setup:1.29.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 400,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/postiz/index.yaml",
+              "line": 420,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:373: container ${{ defaults.app_name }}-temporal-es limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:523: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml:729: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "presenton",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "presenton",
+          "current_image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "candidate_image": "ghcr.io/presenton/presenton:v0.8.9-beta",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/presenton/index.yaml",
+              "line": 37,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/presenton/index.yaml",
+              "line": 59,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:50: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml:96: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "prestashop",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "prestashop",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/prestashop/index.yaml",
+              "line": 141,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/prestashop/index.yaml"
+          ],
+          "replacement_count": 1,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "prestashop",
+          "current_image": "prestashop/prestashop:9.1.3-apache",
+          "candidate_image": "prestashop/prestashop:9.1.4-apache",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/prestashop/index.yaml",
+              "line": 216,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/prestashop/index.yaml",
+              "line": 237,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/prestashop/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "privatebin",
+          "current_image": "ghcr.io/privatebin/fs:1.7.4",
+          "candidate_image": "ghcr.io/privatebin/fs:2.0.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/privatebin/index.yaml",
+              "line": 280,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:31: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:33: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:244: container take-data-dir-ownership must define resources limits/requests from the Sealos ladder",
+            "- [R015/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:249: metadata.annotations.originImageName must match a container image in the workload",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:263: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml:286: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "pterodactyl",
+          "current_image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "candidate_image": "ghcr.io/pterodactyl/panel:v1.14.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 399,
+              "key": "image"
+            },
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 545,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 677,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 3,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "pterodactyl",
+          "current_image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 183,
+              "key": "image"
+            },
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 568,
+              "key": "image"
+            },
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 636,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 3,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "pterodactyl",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 368,
+              "key": "image"
+            },
+            {
+              "path": "template/pterodactyl/index.yaml",
+              "line": 606,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/pterodactyl/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "quay",
+          "current_image": "python:3.12.8-alpine3.20",
+          "candidate_image": "python:3.14.6-alpine3.24",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/quay/index.yaml",
+              "line": 541,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:141: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:396: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:532: container ${{ defaults.app_name }}-init-admin must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "quay",
+          "current_image": "quay.io/projectquay/quay:v3.9.8",
+          "candidate_image": "quay.io/projectquay/quay:v3.17.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/quay/index.yaml",
+              "line": 301,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/quay/index.yaml",
+              "line": 332,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:141: container ${{ defaults.app_name }}-pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:396: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml:532: container ${{ defaults.app_name }}-init-admin must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "refly",
+          "current_image": "mautic/mautic:5.2.3-fpm",
+          "candidate_image": "mautic/mautic:7.1.3-fpm",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/refly/index.yaml",
+              "line": 409,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:155: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:165: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:172: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:283: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:284: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:286: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:287: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml:367: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "registry",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "registry",
+          "current_image": "joxit/docker-registry-ui:2.5.6-debian",
+          "candidate_image": "joxit/docker-registry-ui:2.6.0-debian",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/registry/index.yaml",
+              "line": 206,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/registry/index.yaml",
+              "line": 230,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:49: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:153: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:156: Service spec.ports entries must define a non-empty name"
+          ]
+        },
+        {
+          "template": "registry",
+          "current_image": "registry:2.8.3",
+          "candidate_image": "registry:3.1.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/registry/index.yaml",
+              "line": 35,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/registry/index.yaml",
+              "line": 57,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:26: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:49: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:108: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:153: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml:156: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "rocketchat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rocketchat",
+          "current_image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "candidate_image": "registry.rocket.chat/rocketchat/rocket.chat:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat/index.yaml",
+              "line": 183,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat/index.yaml",
+              "line": 203,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:132: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:196: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:260: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:261: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml:283: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rocketchat-micro",
+          "current_image": "natsio/nats-server-config-reloader:0.6.3",
+          "candidate_image": "natsio/nats-server-config-reloader:0.23.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 438,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/account-service:7.9.0",
+          "candidate_image": "rocketchat/account-service:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 517,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 542,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/authorization-service:7.9.0",
+          "candidate_image": "rocketchat/authorization-service:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 606,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 631,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/ddp-streamer-service:7.9.0",
+          "candidate_image": "rocketchat/ddp-streamer-service:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 695,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 720,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/presence-service:7.9.0",
+          "candidate_image": "rocketchat/presence-service:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 793,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 818,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/rocket.chat:7.9.0",
+          "candidate_image": "rocketchat/rocket.chat:8.6.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 224,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 249,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "rocketchat-micro",
+          "current_image": "rocketchat/stream-hub-service:7.9.0",
+          "candidate_image": "rocketchat/stream-hub-service:7.13.9",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 882,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rocketchat-micro/index.yaml",
+              "line": 907,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:130: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:181: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:322: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:323: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R005/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:361: emptyDir is not allowed; use persistent storage",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats requests.memory must be 12Mi when limits.memory is 128Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml:372: container ${{ defaults.app_name }}-nats-reloader limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "rsshub",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rsshub",
+          "current_image": "diygod/rsshub:2024-07-06",
+          "candidate_image": "diygod/rsshub:2026-07-08",
+          "action": "update",
+          "confidence": "medium",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rsshub/index.yaml",
+              "line": 46,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rsshub/index.yaml",
+              "line": 71,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:27: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:73: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:85: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:119: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:122: Service spec.ports entries must define a non-empty name",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:150: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml:176: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "rybbit",
+          "current_image": "clickhouse/clickhouse-server:25.4.2",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/rybbit/index.yaml",
+              "line": 234,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/rybbit/index.yaml",
+              "line": 258,
+              "key": "image"
+            },
+            {
+              "path": "template/rybbit/index.yaml",
+              "line": 419,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:124: container pg-init must define resources limits/requests from the Sealos ladder",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:254: public-image managed app workloads must omit template.spec.imagePullSecrets",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:258: raw Kubernetes StatefulSet runs database image 'clickhouse-server'; use Kubeblocks database resources and keep database images only in client init/migration gates",
+            "- [R039/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:370: raw Kubernetes database Service is forbidden; use Kubeblocks database resources",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-clickhouse must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml:387: container wait-for-postgres must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "s-pdf",
+          "current_image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "candidate_image": "ghcr.io/stirling-tools/stirling-pdf:2.14.1-fat",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/s-pdf/index.yaml",
+              "line": 228,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/s-pdf/index.yaml",
+              "line": 259,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:82: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:428: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml:431: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "signoz",
+          "current_image": "clickhouse/clickhouse-server:25.5.6",
+          "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 524,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 548,
+              "key": "image"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 570,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "current_image": "signoz/signoz-otel-collector:v0.144.2",
+          "candidate_image": "signoz/signoz-otel-collector:v0.144.5",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 687,
+              "key": "image"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 821,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 844,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "current_image": "signoz/signoz:v0.117.0",
+          "candidate_image": "signoz/signoz:v0.132.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 719,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 744,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        },
+        {
+          "template": "signoz",
+          "current_image": "signoz/zookeeper:3.7.1",
+          "candidate_image": "signoz/zookeeper:3.9.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 421,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/signoz/index.yaml",
+              "line": 454,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:31: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:35: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:37: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:317: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:416: container volume-permissions must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml:447: container must explicitly set imagePullPolicy: IfNotPresent"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "skardi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "skardi",
+          "current_image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "candidate_image": "ghcr.io/skardilabs/skardi/skardi-server:0.4.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/skardi/index.yaml",
+              "line": 123,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/skardi/index.yaml",
+              "line": 143,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml:135: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "stalwart",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "stalwart",
+          "current_image": "stalwartlabs/stalwart:v0.16.7",
+          "candidate_image": "stalwartlabs/stalwart:v0.16.12",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/stalwart/index.yaml",
+              "line": 234,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/stalwart/index.yaml",
+              "line": 302,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/stalwart/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "strapi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "strapi",
+          "current_image": "vshadbolt/strapi:5.33.0",
+          "candidate_image": "vshadbolt/strapi:5.50.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/strapi/index.yaml",
+              "line": 611,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/strapi/index.yaml",
+              "line": 632,
+              "key": "image"
+            },
+            {
+              "path": "template/strapi/index.yaml",
+              "line": 706,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:153: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:164: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:171: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:183: ConfigMap metadata.labels.cloud.sealos.io/app-deploy-manager is required and must match metadata.name",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:185: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:702: container strapi-build limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:703: container strapi-build limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml:784: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "sub2api",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "sub2api",
+          "current_image": "weishaw/sub2api:0.1.104",
+          "candidate_image": "weishaw/sub2api:0.1.146",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/sub2api/index.yaml",
+              "line": 368,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/sub2api/index.yaml",
+              "line": 397,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml:205: container pgsql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "supabase",
+          "current_image": "darthsim/imgproxy:v3.30.1",
+          "candidate_image": "darthsim/imgproxy:v4.0.11",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1353,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1373,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "kong:2.8.1",
+          "candidate_image": "kong:3.9.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 848,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 868,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/edge-runtime:v1.70.3",
+          "candidate_image": "supabase/edge-runtime:v1.74.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1492,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1512,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/gotrue:v2.186.0",
+          "candidate_image": "supabase/gotrue:v2.192.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 934,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 954,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/logflare:1.31.2",
+          "candidate_image": "supabase/logflare:1.46.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1594,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1614,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/postgres-meta:v0.95.2",
+          "candidate_image": "supabase/postgres-meta:v0.96.6",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1430,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1450,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/realtime:v2.76.5",
+          "candidate_image": "supabase/realtime:v2.112.9",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1133,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1153,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/storage-api:v1.37.8",
+          "candidate_image": "supabase/storage-api:v1.64.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1234,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1254,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/studio:2026.02.16-sha-26c615c",
+          "candidate_image": "supabase/studio:2026.07.07-sha-a6a04f2",
+          "action": "update",
+          "confidence": "medium",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 707,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 727,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "supabase/supavisor:2.7.4",
+          "candidate_image": "supabase/supavisor:2.9.7",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1766,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1786,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        },
+        {
+          "template": "supabase",
+          "current_image": "timberio/vector:0.53.0-alpine",
+          "candidate_image": "timberio/vector:0.56.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1700,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/supabase/index.yaml",
+              "line": 1720,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml:1619: container ${{ defaults.app_name }}-analytics limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "surveyking",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "surveyking",
+          "current_image": "joseluisq/mysql-client:8.0.30",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/surveyking/index.yaml",
+              "line": 129,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:212: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:219: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:220: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:247: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:250: Service spec.ports entries must define a non-empty name"
+          ]
+        },
+        {
+          "template": "surveyking",
+          "current_image": "surveyking/surveyking:v1.9.0",
+          "candidate_image": "surveyking/surveyking:v1.12.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/surveyking/index.yaml",
+              "line": 170,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/surveyking/index.yaml",
+              "line": 193,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:119: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:212: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:219: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:220: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:247: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml:250: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "tailchat",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tailchat",
+          "current_image": "moonrailgun/tailchat:1.11.5",
+          "candidate_image": "moonrailgun/tailchat:1.11.11",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tailchat/index.yaml",
+              "line": 66,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tailchat/index.yaml",
+              "line": 86,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:87: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:96: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:108: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:110: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:123: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:124: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml:139: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "tianji",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tianji",
+          "current_image": "moonrailgun/tianji:1.18.5",
+          "candidate_image": "moonrailgun/tianji:1.32.16",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tianji/index.yaml",
+              "line": 50,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tianji/index.yaml",
+              "line": 74,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.categories must be defined and non-empty",
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:41: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R010/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:67: managed app workloads must explicitly set automountServiceAccountToken: false",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:81: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:91: container ${{ defaults.app_name }} requests.cpu must be 20m when limits.cpu is 200m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:92: container ${{ defaults.app_name }} requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml:108: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "tolgee",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tolgee",
+          "current_image": "tolgee/tolgee:v3.113.0",
+          "candidate_image": "tolgee/tolgee:v3.209.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tolgee/index.yaml",
+              "line": 219,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tolgee/index.yaml",
+              "line": 244,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R022/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:17: Template spec.i18n.zh.title should be omitted when it is identical to spec.title",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:185: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R006/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:195: container must explicitly set imagePullPolicy: IfNotPresent",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:202: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:273: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:285: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R007/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:290: business workload secret references must not use custom secrets unless they reference an approved database or object storage secret",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml:316: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tooljet",
+          "current_image": "postgrest/postgrest:v12.0.2",
+          "candidate_image": "postgrest/postgrest:v13.0.8",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tooljet/index.yaml",
+              "line": 455,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tooljet/index.yaml",
+              "line": 475,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:243: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:291: container wait-for-postgres must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:443: container tooljet-migrate limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:445: container tooljet-migrate requests.cpu must be 100m when limits.cpu is 1",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:756: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:829: App resource spec.type must be 'link'"
+          ]
+        },
+        {
+          "template": "tooljet",
+          "current_image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "candidate_image": "tooljet/tooljet-ce:v3.20.192-lts",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tooljet/index.yaml",
+              "line": 333,
+              "key": "image"
+            },
+            {
+              "path": "template/tooljet/index.yaml",
+              "line": 548,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tooljet/index.yaml",
+              "line": 616,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:243: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:291: container wait-for-postgres must define resources limits/requests from the Sealos ladder",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:443: container tooljet-migrate limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:445: container tooljet-migrate requests.cpu must be 100m when limits.cpu is 1",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:756: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml:829: App resource spec.type must be 'link'"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "tradingagents",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tradingagents",
+          "current_image": "alpine/git:2.49.1",
+          "candidate_image": "alpine/git:2.54.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tradingagents/index.yaml",
+              "line": 244,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml:295: container install-runtime limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "trendradar",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "trendradar",
+          "current_image": "wantcat/trendradar:6.9.1",
+          "candidate_image": "wantcat/trendradar:6.10.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/trendradar/index.yaml",
+              "line": 133,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/trendradar/index.yaml",
+              "line": 154,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/trendradar/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "tududi",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "tududi",
+          "current_image": "chrisvel/tududi:1.1.0",
+          "candidate_image": "chrisvel/tududi:1.2.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/tududi/index.yaml",
+              "line": 50,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/tududi/index.yaml",
+              "line": 73,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R033/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml:239: App resource spec.type must be 'link'"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "twenty",
+          "current_image": "twentycrm/twenty:v1.12.0",
+          "candidate_image": "twentycrm/twenty:v2.19.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/twenty/index.yaml",
+              "line": 316,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/twenty/index.yaml",
+              "line": 349,
+              "key": "image"
+            },
+            {
+              "path": "template/twenty/index.yaml",
+              "line": 452,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/twenty/index.yaml",
+              "line": 472,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R011/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:141: PVC storage request must be <= 1Gi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:145: container pgsql-init must define resources limits/requests from the Sealos ladder",
+            "- [R027/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:180: pg-init Job for non-default PostgreSQL databases must include readiness wait (for example pg_isready) and idempotent create logic (exists check before create)",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:282: database component redis-sentinel resources.limits.cpu must be 500m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:283: database component redis-sentinel resources.limits.memory must be 512Mi",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:285: database component redis-sentinel resources.requests.cpu must be 50m",
+            "- [R019/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:286: database component redis-sentinel resources.requests.memory must be 51Mi",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml:311: container fix-permissions must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "status": "updated",
+      "candidates": [
+        {
+          "template": "typebot",
+          "current_image": "axllent/mailpit:v1.30.1",
+          "candidate_image": "axllent/mailpit:v1.30.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 824,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 846,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "current_image": "baptistearno/typebot-builder:3.17.1",
+          "candidate_image": "baptistearno/typebot-builder:3.17.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 431,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 484,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "current_image": "baptistearno/typebot-viewer:3.17.1",
+          "candidate_image": "baptistearno/typebot-viewer:3.17.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 656,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 709,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        },
+        {
+          "template": "typebot",
+          "current_image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 453,
+              "key": "image"
+            },
+            {
+              "path": "template/typebot/index.yaml",
+              "line": 678,
+              "key": "image"
+            }
+          ],
+          "changed_files": [
+            "template/typebot/index.yaml"
+          ],
+          "replacement_count": 2,
+          "status": "updated",
+          "reason": "Queued image references were updated and docker-to-sealos artifact validation passed.",
+          "validation_sample_issues": []
+        }
+      ]
+    },
+    {
+      "template": "typo3",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "typo3",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/typo3/index.yaml",
+              "line": 154,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml:143: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "umami",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "umami",
+          "current_image": "ghcr.io/umami-software/umami:3.0.2",
+          "candidate_image": "ghcr.io/umami-software/umami:3.2.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/umami/index.yaml",
+              "line": 58,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/umami/index.yaml",
+              "line": 83,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:39: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:75: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:90: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:103: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:104: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:117: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml:120: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "uptime-kuma",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "uptime-kuma",
+          "current_image": "louislam/uptime-kuma:1.23.13",
+          "candidate_image": "louislam/uptime-kuma:2.4.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/uptime-kuma/index.yaml",
+              "line": 38,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/uptime-kuma/index.yaml",
+              "line": 61,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:29: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:68: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:69: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:97: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:100: Service spec.ports entries must define a non-empty name",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-read-timeout' must match the required HTTP default",
+            "- [R026/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml:113: Ingress annotation 'nginx.ingress.kubernetes.io/proxy-send-timeout' must match the required HTTP default"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "webos",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "webos",
+          "current_image": "fs185085781/webos:v1.4.1",
+          "candidate_image": "fs185085781/webos:v1.4.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/webos/index.yaml",
+              "line": 37,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/webos/index.yaml",
+              "line": 60,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:114: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml:117: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "wewe-rss",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wewe-rss",
+          "current_image": "joseluisq/mysql-client:8.0.30",
+          "candidate_image": "joseluisq/mysql-client:8.0.44",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wewe-rss/index.yaml",
+              "line": 134,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:33: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:124: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R009/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:180: managed app workloads must explicitly set revisionHistoryLimit: 1",
+            "- [R028/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:192: container name 'app' must exactly match metadata.name '${{ defaults.app_name }}' for managed app workloads",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:205: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:215: container app requests.cpu must be 50m when limits.cpu is 500m",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:216: container app requests.memory must be 51Mi when limits.memory is 512Mi",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml:227: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "woocommerce",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/woocommerce/index.yaml",
+              "line": 150,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml:141: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        },
+        {
+          "template": "woocommerce",
+          "current_image": "wordpress:6.9.1-php8.3-apache",
+          "candidate_image": "wordpress:7.0.0-php8.5-apache",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/woocommerce/index.yaml",
+              "line": 194,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/woocommerce/index.yaml",
+              "line": 333,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml:141: container ${{ defaults.app_name }}-mysql-init must define resources limits/requests from the Sealos ladder"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "wordpress",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wordpress",
+          "current_image": "wordpress:6.5.4",
+          "candidate_image": "wordpress:7.0.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wordpress/index.yaml",
+              "line": 48,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wordpress/index.yaml",
+              "line": 71,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:28: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:72: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R017/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:74: database connection env fields (endpoint/host/port/username/password) must use valueFrom.secretKeyRef",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:88: container ${{ defaults.app_name }} limits.cpu must use Sealos ladder (100m/200m/500m/1/2/3/4/8)",
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:89: container ${{ defaults.app_name }} limits.memory must use Sealos ladder (128Mi/256Mi/512Mi/1G/2G/4G/8G/16G)",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:118: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R020/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml:121: Service spec.ports entries must define a non-empty name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "wrenai",
+          "current_image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "candidate_image": "ghcr.io/canner/wren-ai-service:0.29.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 206,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 228,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "current_image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "candidate_image": "ghcr.io/canner/wren-engine-ibis:0.25.0",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 383,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 405,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "current_image": "ghcr.io/canner/wren-engine:0.14.3",
+          "candidate_image": "ghcr.io/canner/wren-engine:0.24.6",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 291,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 325,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "current_image": "ghcr.io/canner/wren-ui:0.20.1",
+          "candidate_image": "ghcr.io/canner/wren-ui:0.32.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 644,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 666,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        },
+        {
+          "template": "wrenai",
+          "current_image": "qdrant/qdrant:v1.13.4",
+          "candidate_image": "qdrant/qdrant:v1.18.2",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 466,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 488,
+              "key": "image"
+            },
+            {
+              "path": "template/wrenai/index.yaml",
+              "line": 516,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R012/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:5: Template spec.locale must be defined and non-empty",
+            "- [R021/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:42: Template spec.i18n.zh.description must be provided in Simplified Chinese",
+            "- [R030/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:50: ConfigMap metadata.labels.app is required and must match metadata.name",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:85: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:94: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:99: invalid YAML snippet: ScannerError",
+            "- [R000/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:107: invalid YAML snippet: ScannerError",
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml:219: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "yourls",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "yourls",
+          "current_image": "mysql:8.0.30",
+          "candidate_image": "mysql:9.7.1",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/yourls/index.yaml",
+              "line": 140,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:130: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:302: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:304: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name"
+          ]
+        },
+        {
+          "template": "yourls",
+          "current_image": "yourls:1.10.1",
+          "candidate_image": "yourls:1.10.4",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/yourls/index.yaml",
+              "line": 178,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/yourls/index.yaml",
+              "line": 203,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R038/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:130: container mysql-init must define resources limits/requests from the Sealos ladder",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:246: Service metadata.labels.app is required and must match metadata.name/spec.selector.app",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:302: Ingress backend service.name must match Ingress metadata.name",
+            "- [R031/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml:304: Ingress metadata.labels.cloud.sealos.io/app-deploy-manager must match metadata.name"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "zitadel",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "zitadel",
+          "current_image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "candidate_image": "ghcr.io/zitadel/zitadel:v4.15.3",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/zitadel/index.yaml",
+              "line": 135,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/zitadel/index.yaml",
+              "line": 155,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R035/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:147: private-registry managed app workloads must reference only the app-scoped image pull secret `${{ defaults.app_name }}` via template.spec.imagePullSecrets",
+            "- [R029/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml:253: Service metadata.labels.app is required and must match metadata.name/spec.selector.app"
+          ]
+        }
+      ]
+    },
+    {
+      "template": "zot",
+      "status": "blocked",
+      "candidates": [
+        {
+          "template": "zot",
+          "current_image": "ghcr.io/project-zot/zot:v2.1.14",
+          "candidate_image": "ghcr.io/project-zot/zot:v2.1.18",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/zot/index.yaml",
+              "line": 144,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/zot/index.yaml",
+              "line": 234,
+              "key": "image"
+            },
+            {
+              "path": "template/zot/index.yaml",
+              "line": 296,
+              "key": "originImageName"
+            },
+            {
+              "path": "template/zot/index.yaml",
+              "line": 316,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        },
+        {
+          "template": "zot",
+          "current_image": "httpd:2.4.63-alpine3.22",
+          "candidate_image": "httpd:2.4.68-alpine3.24",
+          "action": "update",
+          "confidence": "high",
+          "evidence": "crane ls",
+          "record_locations": [
+            {
+              "path": "template/zot/index.yaml",
+              "line": 164,
+              "key": "image"
+            }
+          ],
+          "changed_files": [],
+          "replacement_count": 0,
+          "status": "blocked",
+          "reason": "Docker-to-sealos artifact validation reported existing template rule failures beyond this image refresh.",
+          "validation_sample_issues": [
+            "- [R040/error] /Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml:56: external S3/object-storage inputs require metadata.annotations.docker-to-sealos.external-object-storage-source with source or user-request evidence"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.sealos/update-reports/template-update-status.md
+++ b/.sealos/update-reports/template-update-status.md
@@ -1,0 +1,164 @@
+# Template Update Status
+
+Generated at: 2026-07-08T11:08:05+00:00
+Repo: /Users/longnv/bin/repo/templates-version-refresh-20260708
+
+## Summary
+
+- updated: 45
+- blocked: 228
+- validation-needed: 0
+- skipped: 0
+
+## Updated Templates
+
+- appwrite: 3 candidates
+- cobalt: 1 candidates
+- derper: 2 candidates
+- dolibarr: 1 candidates
+- evolution-api: 2 candidates
+- ghost: 2 candidates
+- grafana: 1 candidates
+- jellyfin: 1 candidates
+- langflow: 1 candidates
+- listmonk: 2 candidates
+- litellm: 1 candidates
+- logto: 1 candidates
+- loki: 1 candidates
+- matomo: 2 candidates
+- mautic: 3 candidates
+- meilisearch: 1 candidates
+- minecraft: 2 candidates
+- netbird: 4 candidates
+- node-red: 1 candidates
+- openobserve: 1 candidates
+- paperclip: 1 candidates
+- prestashop: 2 candidates
+- pterodactyl: 3 candidates
+- stalwart: 1 candidates
+- trendradar: 1 candidates
+- typebot: 4 candidates
+
+## Blocked Templates
+
+- Reactive-Resume: docker-to-sealos artifact validation reported existing template rule failures
+- Readeck: docker-to-sealos artifact validation reported existing template rule failures
+- anything-llm: docker-to-sealos artifact validation reported existing template rule failures
+- appflowy: docker-to-sealos artifact validation reported existing template rule failures
+- authentik: docker-to-sealos artifact validation reported existing template rule failures
+- billionmail: docker-to-sealos artifact validation reported existing template rule failures
+- budibase: docker-to-sealos artifact validation reported existing template rule failures
+- bunkerweb: docker-to-sealos artifact validation reported existing template rule failures
+- bytebase: docker-to-sealos artifact validation reported existing template rule failures
+- casdoor: docker-to-sealos artifact validation reported existing template rule failures
+- changedetection: docker-to-sealos artifact validation reported existing template rule failures
+- chatgpt-next-web: docker-to-sealos artifact validation reported existing template rule failures
+- chatgpt-on-wechat: docker-to-sealos artifact validation reported existing template rule failures
+- chatnio: docker-to-sealos artifact validation reported existing template rule failures
+- chatwoot: docker-to-sealos artifact validation reported existing template rule failures
+- code-server: docker-to-sealos artifact validation reported existing template rule failures
+- coze-studio: docker-to-sealos artifact validation reported existing template rule failures
+- crawl4ai: docker-to-sealos artifact validation reported existing template rule failures
+- crmeb: docker-to-sealos artifact validation reported existing template rule failures
+- cronicle: docker-to-sealos artifact validation reported existing template rule failures
+- dataease: docker-to-sealos artifact validation reported existing template rule failures
+- dbgate: docker-to-sealos artifact validation reported existing template rule failures
+- deeplx: docker-to-sealos artifact validation reported existing template rule failures
+- dify: docker-to-sealos artifact validation reported existing template rule failures
+- directus: docker-to-sealos artifact validation reported existing template rule failures
+- docuseal: docker-to-sealos artifact validation reported existing template rule failures
+- drawdb: docker-to-sealos artifact validation reported existing template rule failures
+- edgequake: docker-to-sealos artifact validation reported existing template rule failures
+- elasticsearch: docker-to-sealos artifact validation reported existing template rule failures
+- emqx: docker-to-sealos artifact validation reported existing template rule failures
+- erpnext: docker-to-sealos artifact validation reported existing template rule failures
+- ever-gauzy: docker-to-sealos artifact validation reported existing template rule failures
+- fastgpt: docker-to-sealos artifact validation reported existing template rule failures
+- fastgpt-milvus: docker-to-sealos artifact validation reported existing template rule failures
+- fastgpt-pro: docker-to-sealos artifact validation reported existing template rule failures
+- featbit-standard: docker-to-sealos artifact validation reported existing template rule failures
+- firecrawl: docker-to-sealos artifact validation reported existing template rule failures
+- flarum: docker-to-sealos artifact validation reported existing template rule failures
+- flowise: docker-to-sealos artifact validation reported existing template rule failures
+- formbricks: docker-to-sealos artifact validation reported existing template rule failures
+- frp: docker-to-sealos artifact validation reported existing template rule failures
+- gitea: docker-to-sealos artifact validation reported existing template rule failures
+- glitchtip: docker-to-sealos artifact validation reported existing template rule failures
+- grafana-otel: docker-to-sealos artifact validation reported existing template rule failures
+- halo: docker-to-sealos artifact validation reported existing template rule failures
+- harbor: docker-to-sealos artifact validation reported existing template rule failures
+- hasura: docker-to-sealos artifact validation reported existing template rule failures
+- headscale: docker-to-sealos artifact validation reported existing template rule failures
+- illa-builder: docker-to-sealos artifact validation reported existing template rule failures
+- immich: docker-to-sealos artifact validation reported existing template rule failures
+- insforge: docker-to-sealos artifact validation reported existing template rule failures
+- kanboard: docker-to-sealos artifact validation reported existing template rule failures
+- kaneo: docker-to-sealos artifact validation reported existing template rule failures
+- keycloak: docker-to-sealos artifact validation reported existing template rule failures
+- keystone: docker-to-sealos artifact validation reported existing template rule failures
+- kuvasz: docker-to-sealos artifact validation reported existing template rule failures
+- laf: docker-to-sealos artifact validation reported existing template rule failures
+- langfuse: docker-to-sealos artifact validation reported existing template rule failures
+- librechat: docker-to-sealos artifact validation reported existing template rule failures
+- liebianbao: docker-to-sealos artifact validation reported existing template rule failures
+- llmgateway: docker-to-sealos artifact validation reported existing template rule failures
+- lobe-chat-db: docker-to-sealos artifact validation reported existing template rule failures
+- mastodon: docker-to-sealos artifact validation reported existing template rule failures
+- metabase: docker-to-sealos artifact validation reported existing template rule failures
+- mlflow: docker-to-sealos artifact validation reported existing template rule failures
+- n8n: docker-to-sealos artifact validation reported existing template rule failures
+- nacos: docker-to-sealos artifact validation reported existing template rule failures
+- nexus: docker-to-sealos artifact validation reported existing template rule failures
+- nocodb: docker-to-sealos artifact validation reported existing template rule failures
+- nofx: docker-to-sealos artifact validation reported existing template rule failures
+- odysseus: docker-to-sealos artifact validation reported existing template rule failures
+- open-webui: docker-to-sealos artifact validation reported existing template rule failures
+- openclaw: docker-to-sealos artifact validation reported existing template rule failures
+- openlist: docker-to-sealos artifact validation reported existing template rule failures
+- outline: docker-to-sealos artifact validation reported existing template rule failures
+- overleaf: docker-to-sealos artifact validation reported existing template rule failures
+- pageplug: docker-to-sealos artifact validation reported existing template rule failures
+- pangolin: docker-to-sealos artifact validation reported existing template rule failures
+- pdf2zh: docker-to-sealos artifact validation reported existing template rule failures
+- penpot: docker-to-sealos artifact validation reported existing template rule failures
+- perplexica: docker-to-sealos artifact validation reported existing template rule failures
+- phpmyadmin: docker-to-sealos artifact validation reported existing template rule failures
+- planka: docker-to-sealos artifact validation reported existing template rule failures
+- pocket-id: docker-to-sealos artifact validation reported existing template rule failures
+- pocketbase: docker-to-sealos artifact validation reported existing template rule failures
+- posthog: docker-to-sealos artifact validation reported existing template rule failures
+- postiz: docker-to-sealos artifact validation reported existing template rule failures
+- presenton: docker-to-sealos artifact validation reported existing template rule failures
+- privatebin: docker-to-sealos artifact validation reported existing template rule failures
+- quay: docker-to-sealos artifact validation reported existing template rule failures
+- refly: docker-to-sealos artifact validation reported existing template rule failures
+- registry: docker-to-sealos artifact validation reported existing template rule failures
+- rocketchat: docker-to-sealos artifact validation reported existing template rule failures
+- rocketchat-micro: docker-to-sealos artifact validation reported existing template rule failures
+- rsshub: docker-to-sealos artifact validation reported existing template rule failures
+- rybbit: docker-to-sealos artifact validation reported existing template rule failures
+- s-pdf: docker-to-sealos artifact validation reported existing template rule failures
+- signoz: docker-to-sealos artifact validation reported existing template rule failures
+- skardi: docker-to-sealos artifact validation reported existing template rule failures
+- strapi: docker-to-sealos artifact validation reported existing template rule failures
+- sub2api: docker-to-sealos artifact validation reported existing template rule failures
+- supabase: docker-to-sealos artifact validation reported existing template rule failures
+- surveyking: docker-to-sealos artifact validation reported existing template rule failures
+- tailchat: docker-to-sealos artifact validation reported existing template rule failures
+- tianji: docker-to-sealos artifact validation reported existing template rule failures
+- tolgee: docker-to-sealos artifact validation reported existing template rule failures
+- tooljet: docker-to-sealos artifact validation reported existing template rule failures
+- tradingagents: docker-to-sealos artifact validation reported existing template rule failures
+- tududi: docker-to-sealos artifact validation reported existing template rule failures
+- twenty: docker-to-sealos artifact validation reported existing template rule failures
+- typo3: docker-to-sealos artifact validation reported existing template rule failures
+- umami: docker-to-sealos artifact validation reported existing template rule failures
+- uptime-kuma: docker-to-sealos artifact validation reported existing template rule failures
+- webos: docker-to-sealos artifact validation reported existing template rule failures
+- wewe-rss: docker-to-sealos artifact validation reported existing template rule failures
+- woocommerce: docker-to-sealos artifact validation reported existing template rule failures
+- wordpress: docker-to-sealos artifact validation reported existing template rule failures
+- wrenai: docker-to-sealos artifact validation reported existing template rule failures
+- yourls: docker-to-sealos artifact validation reported existing template rule failures
+- zitadel: docker-to-sealos artifact validation reported existing template rule failures
+- zot: docker-to-sealos artifact validation reported existing template rule failures

--- a/.sealos/update-reports/template-version-updates.json
+++ b/.sealos/update-reports/template-version-updates.json
@@ -1,0 +1,20243 @@
+{
+  "generated_at": "2026-07-08T11:01:47.652867+00:00",
+  "repo": "/Users/longnv/bin/repo/templates-version-refresh-20260708",
+  "record_count": 1143,
+  "candidate_count": 587,
+  "candidates": [
+    {
+      "template": "AllinSSL",
+      "image": "docker.io/allinssl/allinssl",
+      "repository": "docker.io/allinssl/allinssl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "AllinSSL",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/AllinSSL/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "docker.io/allinssl/allinssl",
+          "repository": "docker.io/allinssl/allinssl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "AllinSSL",
+      "image": "docker.io/allinssl/allinssl:latest",
+      "repository": "docker.io/allinssl/allinssl",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "AllinSSL",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/AllinSSL/index.yaml",
+          "line": 70,
+          "key": "image",
+          "image": "docker.io/allinssl/allinssl:latest",
+          "repository": "docker.io/allinssl/allinssl",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "OpenDeepWiki",
+      "image": "${{ inputs.wiki_image }}",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/OpenDeepWiki/index.yaml",
+          "line": 132,
+          "key": "originImageName",
+          "image": "${{ inputs.wiki_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/OpenDeepWiki/index.yaml",
+          "line": 159,
+          "key": "image",
+          "image": "${{ inputs.wiki_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "OpenDeepWiki",
+      "image": "${{ inputs.wiki_web_image }}",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/OpenDeepWiki/index.yaml",
+          "line": 302,
+          "key": "originImageName",
+          "image": "${{ inputs.wiki_web_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "OpenDeepWiki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/OpenDeepWiki/index.yaml",
+          "line": 327,
+          "key": "image",
+          "image": "${{ inputs.wiki_web_image }}",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "amruthpillai/reactive-resume:v4.1.2",
+      "repository": "amruthpillai/reactive-resume",
+      "current_tag": "v4.1.2",
+      "candidate_tag": "v5.2.2",
+      "candidate_image": "amruthpillai/reactive-resume:v5.2.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 351,
+          "key": "image",
+          "image": "amruthpillai/reactive-resume:v4.1.2",
+          "repository": "amruthpillai/reactive-resume",
+          "tag": "v4.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "bitnamilegacy/postgresql:latest",
+      "repository": "bitnamilegacy/postgresql",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 541,
+          "key": "image",
+          "image": "bitnamilegacy/postgresql:latest",
+          "repository": "bitnamilegacy/postgresql",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 563,
+          "key": "image",
+          "image": "bitnamilegacy/postgresql:latest",
+          "repository": "bitnamilegacy/postgresql",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "ghcr.io/browserless/chromium:v2.11.0",
+      "repository": "ghcr.io/browserless/chromium",
+      "current_tag": "v2.11.0",
+      "candidate_tag": "v2.54.2",
+      "candidate_image": "ghcr.io/browserless/chromium:v2.54.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "ghcr.io/browserless/chromium:v2.11.0",
+          "repository": "ghcr.io/browserless/chromium",
+          "tag": "v2.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 165,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Reactive-Resume",
+      "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+      "repository": "quay.io/minio/minio",
+      "current_tag": "RELEASE.2023-03-22T06-36-24Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Reactive-Resume",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Reactive-Resume/index.yaml",
+          "line": 198,
+          "key": "image",
+          "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+          "repository": "quay.io/minio/minio",
+          "tag": "RELEASE.2023-03-22T06-36-24Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Readeck",
+      "image": "codeberg.org/readeck/readeck:0.16.0",
+      "repository": "codeberg.org/readeck/readeck",
+      "current_tag": "0.16.0",
+      "candidate_tag": "0.22.3",
+      "candidate_image": "codeberg.org/readeck/readeck:0.22.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "Readeck",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "codeberg.org/readeck/readeck:0.16.0",
+          "repository": "codeberg.org/readeck/readeck",
+          "tag": "0.16.0",
+          "digest": null
+        },
+        {
+          "template": "Readeck",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Readeck/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "codeberg.org/readeck/readeck:0.16.0",
+          "repository": "codeberg.org/readeck/readeck",
+          "tag": "0.16.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "Ruiqi-Waf",
+      "image": "limbo2342/ruiqi-waf:sha-32b359f",
+      "repository": "limbo2342/ruiqi-waf",
+      "current_tag": "sha-32b359f",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "Ruiqi-Waf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/Ruiqi-Waf/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "limbo2342/ruiqi-waf:sha-32b359f",
+          "repository": "limbo2342/ruiqi-waf",
+          "tag": "sha-32b359f",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ace-step",
+      "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+      "repository": "ghcr.io/ace-step/ace-step-1.5",
+      "current_tag": "v0.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "ace-step",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ace-step/index.yaml",
+          "line": 91,
+          "key": "originImageName",
+          "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+          "repository": "ghcr.io/ace-step/ace-step-1.5",
+          "tag": "v0.1.0",
+          "digest": null
+        },
+        {
+          "template": "ace-step",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ace-step/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "ghcr.io/ace-step/ace-step-1.5:v0.1.0",
+          "repository": "ghcr.io/ace-step/ace-step-1.5",
+          "tag": "v0.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "affine",
+      "image": "ghcr.io/toeverything/affine:0.26.7",
+      "repository": "ghcr.io/toeverything/affine",
+      "current_tag": "0.26.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 357,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.7",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.7",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 419,
+          "key": "originImageName",
+          "image": "ghcr.io/toeverything/affine:0.26.7",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.7",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 490,
+          "key": "image",
+          "image": "ghcr.io/toeverything/affine:0.26.7",
+          "repository": "ghcr.io/toeverything/affine",
+          "tag": "0.26.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "affine",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 253,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 317,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "affine",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/affine/index.yaml",
+          "line": 444,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "agora",
+      "image": "agoracn/token:0.1.2023053011",
+      "repository": "agoracn/token",
+      "current_tag": "0.1.2023053011",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "agora",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/agora/index.yaml",
+          "line": 49,
+          "key": "originImageName",
+          "image": "agoracn/token:0.1.2023053011",
+          "repository": "agoracn/token",
+          "tag": "0.1.2023053011",
+          "digest": null
+        },
+        {
+          "template": "agora",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/agora/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "agoracn/token:0.1.2023053011",
+          "repository": "agoracn/token",
+          "tag": "0.1.2023053011",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/bootloader:2.1.0",
+      "repository": "airbyte/bootloader",
+      "current_tag": "2.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 953,
+          "key": "image",
+          "image": "airbyte/bootloader:2.1.0",
+          "repository": "airbyte/bootloader",
+          "tag": "2.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/cron:2.1.0",
+      "repository": "airbyte/cron",
+      "current_tag": "2.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2010,
+          "key": "originImageName",
+          "image": "airbyte/cron:2.1.0",
+          "repository": "airbyte/cron",
+          "tag": "2.1.0",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2066,
+          "key": "image",
+          "image": "airbyte/cron:2.1.0",
+          "repository": "airbyte/cron",
+          "tag": "2.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/server:2.1.0",
+      "repository": "airbyte/server",
+      "current_tag": "2.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1168,
+          "key": "originImageName",
+          "image": "airbyte/server:2.1.0",
+          "repository": "airbyte/server",
+          "tag": "2.1.0",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1232,
+          "key": "image",
+          "image": "airbyte/server:2.1.0",
+          "repository": "airbyte/server",
+          "tag": "2.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "airbyte/worker:2.1.0",
+      "repository": "airbyte/worker",
+      "current_tag": "2.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1601,
+          "key": "originImageName",
+          "image": "airbyte/worker:2.1.0",
+          "repository": "airbyte/worker",
+          "tag": "2.1.0",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1659,
+          "key": "image",
+          "image": "airbyte/worker:2.1.0",
+          "repository": "airbyte/worker",
+          "tag": "2.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "bitnamilegacy/kubectl:1.33.4",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": "1.33.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 162,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 780,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 894,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 924,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1076,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1191,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1624,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2031,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2263,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.33.4",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.33.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 607,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 811,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 1107,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "airbyte",
+      "image": "temporalio/auto-setup:1.29.7",
+      "repository": "temporalio/auto-setup",
+      "current_tag": "1.29.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2242,
+          "key": "originImageName",
+          "image": "temporalio/auto-setup:1.29.7",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.29.7",
+          "digest": null
+        },
+        {
+          "template": "airbyte",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/airbyte/index.yaml",
+          "line": 2298,
+          "key": "image",
+          "image": "temporalio/auto-setup:1.29.7",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.29.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "anki-sync-server",
+      "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+      "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+      "current_tag": "24.06.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "anki-sync-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anki-sync-server/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+          "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+          "tag": "24.06.3",
+          "digest": null
+        },
+        {
+          "template": "anki-sync-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anki-sync-server/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/anki-sync-server:24.06.3",
+          "repository": "ghcr.io/yangchuansheng/anki-sync-server",
+          "tag": "24.06.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "anything-llm",
+      "image": "mintplexlabs/anythingllm:1.14.0",
+      "repository": "mintplexlabs/anythingllm",
+      "current_tag": "1.14.0",
+      "candidate_tag": "1.15.0",
+      "candidate_image": "mintplexlabs/anythingllm:1.15.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "anything-llm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml",
+          "line": 75,
+          "key": "originImageName",
+          "image": "mintplexlabs/anythingllm:1.14.0",
+          "repository": "mintplexlabs/anythingllm",
+          "tag": "1.14.0",
+          "digest": null
+        },
+        {
+          "template": "anything-llm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/anything-llm/index.yaml",
+          "line": 100,
+          "key": "image",
+          "image": "mintplexlabs/anythingllm:1.14.0",
+          "repository": "mintplexlabs/anythingllm",
+          "tag": "1.14.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/backend-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1024,
+          "key": "originImageName",
+          "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/backend-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1107,
+          "key": "image",
+          "image": "apitable/backend-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/backend-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+      "repository": "apitable/databus-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1564,
+          "key": "originImageName",
+          "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+          "repository": "apitable/databus-server",
+          "tag": null,
+          "digest": "sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600"
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1645,
+          "key": "image",
+          "image": "apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600",
+          "repository": "apitable/databus-server",
+          "tag": null,
+          "digest": "sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600"
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+      "repository": "apitable/imageproxy-server",
+      "current_tag": "v0.13.4-alpha_build13",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1729,
+          "key": "originImageName",
+          "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+          "repository": "apitable/imageproxy-server",
+          "tag": "v0.13.4-alpha_build13",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1749,
+          "key": "image",
+          "image": "apitable/imageproxy-server:v0.13.4-alpha_build13",
+          "repository": "apitable/imageproxy-server",
+          "tag": "v0.13.4-alpha_build13",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+      "repository": "apitable/init-appdata",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 921,
+          "key": "originImageName",
+          "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+          "repository": "apitable/init-appdata",
+          "tag": null,
+          "digest": "sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b"
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 978,
+          "key": "image",
+          "image": "apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b",
+          "repository": "apitable/init-appdata",
+          "tag": null,
+          "digest": "sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b"
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/init-db:v1.13.0-beta.1_2016",
+      "repository": "apitable/init-db",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 819,
+          "key": "originImageName",
+          "image": "apitable/init-db:v1.13.0-beta.1_2016",
+          "repository": "apitable/init-db",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 875,
+          "key": "image",
+          "image": "apitable/init-db:v1.13.0-beta.1_2016",
+          "repository": "apitable/init-db",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/room-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/room-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1249,
+          "key": "originImageName",
+          "image": "apitable/room-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/room-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1332,
+          "key": "image",
+          "image": "apitable/room-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/room-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "apitable/web-server:v1.13.0-beta.1_2016",
+      "repository": "apitable/web-server",
+      "current_tag": "v1.13.0-beta.1_2016",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1486,
+          "key": "originImageName",
+          "image": "apitable/web-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/web-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1506,
+          "key": "image",
+          "image": "apitable/web-server:v1.13.0-beta.1_2016",
+          "repository": "apitable/web-server",
+          "tag": "v1.13.0-beta.1_2016",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "busybox:1.38.0",
+      "repository": "busybox",
+      "current_tag": "1.38.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1085,
+          "key": "image",
+          "image": "busybox:1.38.0",
+          "repository": "busybox",
+          "tag": "1.38.0",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1310,
+          "key": "image",
+          "image": "busybox:1.38.0",
+          "repository": "busybox",
+          "tag": "1.38.0",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1624,
+          "key": "image",
+          "image": "busybox:1.38.0",
+          "repository": "busybox",
+          "tag": "1.38.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "mysql:9.7.1",
+      "repository": "mysql",
+      "current_tag": "9.7.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 641,
+          "key": "originImageName",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 656,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 835,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1045,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1270,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1584,
+          "key": "image",
+          "image": "mysql:9.7.1",
+          "repository": "mysql",
+          "tag": "9.7.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "nginx:1.31.2-alpine",
+      "repository": "nginx",
+      "current_tag": "1.31.2-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1808,
+          "key": "originImageName",
+          "image": "nginx:1.31.2-alpine",
+          "repository": "nginx",
+          "tag": "1.31.2-alpine",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 1828,
+          "key": "image",
+          "image": "nginx:1.31.2-alpine",
+          "repository": "nginx",
+          "tag": "1.31.2-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "apitable",
+      "image": "rabbitmq:4.3.2-management",
+      "repository": "rabbitmq",
+      "current_tag": "4.3.2-management",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 709,
+          "key": "originImageName",
+          "image": "rabbitmq:4.3.2-management",
+          "repository": "rabbitmq",
+          "tag": "4.3.2-management",
+          "digest": null
+        },
+        {
+          "template": "apitable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/apitable/index.yaml",
+          "line": 732,
+          "key": "image",
+          "image": "rabbitmq:4.3.2-management",
+          "repository": "rabbitmq",
+          "tag": "4.3.2-management",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_cloud:0.15.22",
+      "repository": "appflowyinc/appflowy_cloud",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/appflowy_cloud:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 491,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_cloud:0.15.22",
+          "repository": "appflowyinc/appflowy_cloud",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 511,
+          "key": "image",
+          "image": "appflowyinc/appflowy_cloud:0.15.22",
+          "repository": "appflowyinc/appflowy_cloud",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_web:0.14.9",
+      "repository": "appflowyinc/appflowy_web",
+      "current_tag": "0.14.9",
+      "candidate_tag": "0.15.5",
+      "candidate_image": "appflowyinc/appflowy_web:0.15.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 820,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_web:0.14.9",
+          "repository": "appflowyinc/appflowy_web",
+          "tag": "0.14.9",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 840,
+          "key": "image",
+          "image": "appflowyinc/appflowy_web:0.14.9",
+          "repository": "appflowyinc/appflowy_web",
+          "tag": "0.14.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/appflowy_worker:0.15.22",
+      "repository": "appflowyinc/appflowy_worker",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/appflowy_worker:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 692,
+          "key": "originImageName",
+          "image": "appflowyinc/appflowy_worker:0.15.22",
+          "repository": "appflowyinc/appflowy_worker",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 712,
+          "key": "image",
+          "image": "appflowyinc/appflowy_worker:0.15.22",
+          "repository": "appflowyinc/appflowy_worker",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "appflowyinc/gotrue:0.15.22",
+      "repository": "appflowyinc/gotrue",
+      "current_tag": "0.15.22",
+      "candidate_tag": "0.16.5",
+      "candidate_image": "appflowyinc/gotrue:0.16.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 356,
+          "key": "originImageName",
+          "image": "appflowyinc/gotrue:0.15.22",
+          "repository": "appflowyinc/gotrue",
+          "tag": "0.15.22",
+          "digest": null
+        },
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 376,
+          "key": "image",
+          "image": "appflowyinc/gotrue:0.15.22",
+          "repository": "appflowyinc/gotrue",
+          "tag": "0.15.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appflowy",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "appflowy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appflowy/index.yaml",
+          "line": 205,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appsmith",
+      "image": "appsmith/appsmith-ce:v1.29",
+      "repository": "appsmith/appsmith-ce",
+      "current_tag": "v1.29",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "appsmith",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appsmith/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "appsmith/appsmith-ce:v1.29",
+          "repository": "appsmith/appsmith-ce",
+          "tag": "v1.29",
+          "digest": null
+        },
+        {
+          "template": "appsmith",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appsmith/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "appsmith/appsmith-ce:v1.29",
+          "repository": "appsmith/appsmith-ce",
+          "tag": "v1.29",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appwrite",
+      "image": "appwrite/appwrite:1.9.0",
+      "repository": "appwrite/appwrite",
+      "current_tag": "1.9.0",
+      "candidate_tag": "1.9.5",
+      "candidate_image": "appwrite/appwrite:1.9.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 285,
+          "key": "originImageName",
+          "image": "appwrite/appwrite:1.9.0",
+          "repository": "appwrite/appwrite",
+          "tag": "1.9.0",
+          "digest": null
+        },
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 356,
+          "key": "image",
+          "image": "appwrite/appwrite:1.9.0",
+          "repository": "appwrite/appwrite",
+          "tag": "1.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appwrite",
+      "image": "appwrite/console:7.8.26",
+      "repository": "appwrite/console",
+      "current_tag": "7.8.26",
+      "candidate_tag": "8.7.19",
+      "candidate_image": "appwrite/console:8.7.19",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 556,
+          "key": "originImageName",
+          "image": "appwrite/console:7.8.26",
+          "repository": "appwrite/console",
+          "tag": "7.8.26",
+          "digest": null
+        },
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 577,
+          "key": "image",
+          "image": "appwrite/console:7.8.26",
+          "repository": "appwrite/console",
+          "tag": "7.8.26",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "appwrite",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 311,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "appwrite",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/appwrite/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "artalk",
+      "image": "artalk/artalk-go:latest",
+      "repository": "artalk/artalk-go",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "artalk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/artalk/index.yaml",
+          "line": 43,
+          "key": "originImageName",
+          "image": "artalk/artalk-go:latest",
+          "repository": "artalk/artalk-go",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "artalk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/artalk/index.yaml",
+          "line": 66,
+          "key": "image",
+          "image": "artalk/artalk-go:latest",
+          "repository": "artalk/artalk-go",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/asktable/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest",
+      "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/asktable/index.yaml",
+          "line": 113,
+          "key": "image",
+          "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest",
+          "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "asktable",
+      "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest",
+      "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "asktable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/asktable/index.yaml",
+          "line": 209,
+          "key": "image",
+          "image": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest",
+          "repository": "registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "authentik",
+      "image": "ghcr.io/goauthentik/server:2025.12.3",
+      "repository": "ghcr.io/goauthentik/server",
+      "current_tag": "2025.12.3",
+      "candidate_tag": "2026.5.4",
+      "candidate_image": "ghcr.io/goauthentik/server:2026.5.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+          "line": 175,
+          "key": "originImageName",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+          "line": 195,
+          "key": "image",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+          "line": 290,
+          "key": "originImageName",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        },
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+          "line": 310,
+          "key": "image",
+          "image": "ghcr.io/goauthentik/server:2025.12.3",
+          "repository": "ghcr.io/goauthentik/server",
+          "tag": "2025.12.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "authentik",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "authentik",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/authentik/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "banana-slides",
+      "image": "anoinex/banana-slides-backend:latest",
+      "repository": "anoinex/banana-slides-backend",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/banana-slides/index.yaml",
+          "line": 112,
+          "key": "originImageName",
+          "image": "anoinex/banana-slides-backend:latest",
+          "repository": "anoinex/banana-slides-backend",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/banana-slides/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "anoinex/banana-slides-backend:latest",
+          "repository": "anoinex/banana-slides-backend",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "banana-slides",
+      "image": "anoinex/banana-slides-frontend:latest",
+      "repository": "anoinex/banana-slides-frontend",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/banana-slides/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "anoinex/banana-slides-frontend:latest",
+          "repository": "anoinex/banana-slides-frontend",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "banana-slides",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/banana-slides/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "anoinex/banana-slides-frontend:latest",
+          "repository": "anoinex/banana-slides-frontend",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "alpine/openssl:3.5.4",
+      "repository": "alpine/openssl",
+      "current_tag": "3.5.4",
+      "candidate_tag": "3.5.7",
+      "candidate_image": "alpine/openssl:3.5.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6468,
+          "key": "image",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "tag": "3.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+      "repository": "alpine/socat",
+      "current_tag": "1.8.0.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6692,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6723,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6755,
+          "key": "image",
+          "image": "alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8",
+          "repository": "alpine/socat",
+          "tag": "1.8.0.0",
+          "digest": "sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+      "repository": "billionmail/core",
+      "current_tag": "4.9.3",
+      "candidate_tag": "4.9.5",
+      "candidate_image": "billionmail/core:4.9.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6434,
+          "key": "originImageName",
+          "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "repository": "billionmail/core",
+          "tag": "4.9.3",
+          "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 7033,
+          "key": "image",
+          "image": "billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692",
+          "repository": "billionmail/core",
+          "tag": "4.9.3",
+          "digest": "sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab",
+      "repository": "billionmail/dovecot",
+      "current_tag": "1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6822,
+          "key": "image",
+          "image": "billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab",
+          "repository": "billionmail/dovecot",
+          "tag": "1.6",
+          "digest": "sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342",
+      "repository": "billionmail/postfix",
+      "current_tag": "1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6901,
+          "key": "image",
+          "image": "billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342",
+          "repository": "billionmail/postfix",
+          "tag": "1.6",
+          "digest": "sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058",
+      "repository": "billionmail/rspamd",
+      "current_tag": "1.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6775,
+          "key": "image",
+          "image": "billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058",
+          "repository": "billionmail/rspamd",
+          "tag": "1.2",
+          "digest": "sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058"
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6509,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "python:3.12.12-alpine",
+      "repository": "python",
+      "current_tag": "3.12.12-alpine",
+      "candidate_tag": "3.14.6-alpine",
+      "candidate_image": "python:3.14.6-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6672,
+          "key": "image",
+          "image": "python:3.12.12-alpine",
+          "repository": "python",
+          "tag": "3.12.12-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "billionmail",
+      "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+      "repository": "roundcube/roundcubemail",
+      "current_tag": "1.6.11-fpm-alpine",
+      "candidate_tag": "1.7.2-fpm-alpine",
+      "candidate_image": "roundcube/roundcubemail:1.7.2-fpm-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "billionmail",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/billionmail/index.yaml",
+          "line": 6974,
+          "key": "image",
+          "image": "roundcube/roundcubemail:1.6.11-fpm-alpine",
+          "repository": "roundcube/roundcubemail",
+          "tag": "1.6.11-fpm-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "blossom",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/blossom/index.yaml",
+          "line": 315,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "blossom",
+      "image": "jasminexzzz/blossom:1.16.0",
+      "repository": "jasminexzzz/blossom",
+      "current_tag": "1.16.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/blossom/index.yaml",
+          "line": 46,
+          "key": "originImageName",
+          "image": "jasminexzzz/blossom:1.16.0",
+          "repository": "jasminexzzz/blossom",
+          "tag": "1.16.0",
+          "digest": null
+        },
+        {
+          "template": "blossom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/blossom/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "jasminexzzz/blossom:1.16.0",
+          "repository": "jasminexzzz/blossom",
+          "tag": "1.16.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "btpanel",
+      "image": "btpanel/baota:nas",
+      "repository": "btpanel/baota",
+      "current_tag": "nas",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "btpanel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/btpanel/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "btpanel/baota:nas",
+          "repository": "btpanel/baota",
+          "tag": "nas",
+          "digest": null
+        },
+        {
+          "template": "btpanel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/btpanel/index.yaml",
+          "line": 56,
+          "key": "image",
+          "image": "btpanel/baota:nas",
+          "repository": "btpanel/baota",
+          "tag": "nas",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/apps:3.15.0",
+      "repository": "budibase/apps",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.27",
+      "candidate_image": "budibase/apps:3.39.27",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 429,
+          "key": "originImageName",
+          "image": "budibase/apps:3.15.0",
+          "repository": "budibase/apps",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "budibase/apps:3.15.0",
+          "repository": "budibase/apps",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+      "repository": "budibase/couchdb",
+      "current_tag": "v3.3.3-sqs-v2.1.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 254,
+          "key": "originImageName",
+          "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+          "repository": "budibase/couchdb",
+          "tag": "v3.3.3-sqs-v2.1.1",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "budibase/couchdb:v3.3.3-sqs-v2.1.1",
+          "repository": "budibase/couchdb",
+          "tag": "v3.3.3-sqs-v2.1.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/proxy:3.15.0",
+      "repository": "budibase/proxy",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.27",
+      "candidate_image": "budibase/proxy:3.39.27",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 821,
+          "key": "originImageName",
+          "image": "budibase/proxy:3.15.0",
+          "repository": "budibase/proxy",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 841,
+          "key": "image",
+          "image": "budibase/proxy:3.15.0",
+          "repository": "budibase/proxy",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "budibase/worker:3.15.0",
+      "repository": "budibase/worker",
+      "current_tag": "3.15.0",
+      "candidate_tag": "3.39.27",
+      "candidate_image": "budibase/worker:3.39.27",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 625,
+          "key": "originImageName",
+          "image": "budibase/worker:3.15.0",
+          "repository": "budibase/worker",
+          "tag": "3.15.0",
+          "digest": null
+        },
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 645,
+          "key": "image",
+          "image": "budibase/worker:3.15.0",
+          "repository": "budibase/worker",
+          "tag": "3.15.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "budibase",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "budibase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/budibase/index.yaml",
+          "line": 276,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+      "current_tag": "1.6.11",
+      "candidate_tag": "1.6.12",
+      "candidate_image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.12",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 607,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 680,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb-scheduler:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-scheduler",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb-ui",
+      "current_tag": "1.6.11",
+      "candidate_tag": "1.6.12",
+      "candidate_image": "docker.io/bunkerity/bunkerweb-ui:1.6.12",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 855,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-ui",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb-ui:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb-ui",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+      "repository": "docker.io/bunkerity/bunkerweb",
+      "current_tag": "1.6.11",
+      "candidate_tag": "1.6.12",
+      "candidate_image": "docker.io/bunkerity/bunkerweb:1.6.12",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 418,
+          "key": "originImageName",
+          "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb",
+          "tag": "1.6.11",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 511,
+          "key": "image",
+          "image": "docker.io/bunkerity/bunkerweb:1.6.11",
+          "repository": "docker.io/bunkerity/bunkerweb",
+          "tag": "1.6.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/library/busybox:1.36.1",
+      "repository": "docker.io/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "docker.io/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 487,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 633,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 656,
+          "key": "image",
+          "image": "docker.io/library/busybox:1.36.1",
+          "repository": "docker.io/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/library/postgres:16.4-alpine",
+      "repository": "docker.io/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 174,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 446,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 881,
+          "key": "image",
+          "image": "docker.io/library/postgres:16.4-alpine",
+          "repository": "docker.io/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bunkerweb",
+      "image": "docker.io/traefik/whoami:v1.11.0",
+      "repository": "docker.io/traefik/whoami",
+      "current_tag": "v1.11.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 349,
+          "key": "originImageName",
+          "image": "docker.io/traefik/whoami:v1.11.0",
+          "repository": "docker.io/traefik/whoami",
+          "tag": "v1.11.0",
+          "digest": null
+        },
+        {
+          "template": "bunkerweb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bunkerweb/index.yaml",
+          "line": 369,
+          "key": "image",
+          "image": "docker.io/traefik/whoami:v1.11.0",
+          "repository": "docker.io/traefik/whoami",
+          "tag": "v1.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "bytebase",
+      "image": "bytebase/bytebase:3.6.1",
+      "repository": "bytebase/bytebase",
+      "current_tag": "3.6.1",
+      "candidate_tag": "3.20.0",
+      "candidate_image": "bytebase/bytebase:3.20.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "bytebase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "bytebase/bytebase:3.6.1",
+          "repository": "bytebase/bytebase",
+          "tag": "3.6.1",
+          "digest": null
+        },
+        {
+          "template": "bytebase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/bytebase/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "bytebase/bytebase:3.6.1",
+          "repository": "bytebase/bytebase",
+          "tag": "3.6.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "calcom",
+      "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+      "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+      "current_tag": "v6.2.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/calcom/index.yaml",
+          "line": 217,
+          "key": "originImageName",
+          "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+          "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+          "tag": "v6.2.0",
+          "digest": null
+        },
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/calcom/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "calcom.docker.scarf.sh/calcom/cal.com:v6.2.0",
+          "repository": "calcom.docker.scarf.sh/calcom/cal.com",
+          "tag": "v6.2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "calcom",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "calcom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/calcom/index.yaml",
+          "line": 173,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+      "repository": "ghcr.io/capsoftware/cap-media-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cap/index.yaml",
+          "line": 342,
+          "key": "originImageName",
+          "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+          "repository": "ghcr.io/capsoftware/cap-media-server",
+          "tag": null,
+          "digest": "sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad"
+        },
+        {
+          "template": "cap",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cap/index.yaml",
+          "line": 362,
+          "key": "image",
+          "image": "ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad",
+          "repository": "ghcr.io/capsoftware/cap-media-server",
+          "tag": null,
+          "digest": "sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad"
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+      "repository": "ghcr.io/capsoftware/cap-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cap/index.yaml",
+          "line": 207,
+          "key": "originImageName",
+          "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+          "repository": "ghcr.io/capsoftware/cap-web",
+          "tag": null,
+          "digest": "sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57"
+        },
+        {
+          "template": "cap",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cap/index.yaml",
+          "line": 227,
+          "key": "image",
+          "image": "ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57",
+          "repository": "ghcr.io/capsoftware/cap-web",
+          "tag": null,
+          "digest": "sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57"
+        }
+      ]
+    },
+    {
+      "template": "cap",
+      "image": "mysql:8.0.46-debian",
+      "repository": "mysql",
+      "current_tag": "8.0.46-debian",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "cap",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cap/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "mysql:8.0.46-debian",
+          "repository": "mysql",
+          "tag": "8.0.46-debian",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "casbin/casdoor:v1.702.0",
+      "repository": "casbin/casdoor",
+      "current_tag": "v1.702.0",
+      "candidate_tag": "v2.190.0",
+      "candidate_image": "casbin/casdoor:v2.190.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+          "line": 425,
+          "key": "image",
+          "image": "casbin/casdoor:v1.702.0",
+          "repository": "casbin/casdoor",
+          "tag": "v1.702.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "casbin/casdoor:v2.32.0",
+      "repository": "casbin/casdoor",
+      "current_tag": "v2.32.0",
+      "candidate_tag": "v2.190.0",
+      "candidate_image": "casbin/casdoor:v2.190.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+          "line": 334,
+          "key": "originImageName",
+          "image": "casbin/casdoor:v2.32.0",
+          "repository": "casbin/casdoor",
+          "tag": "v2.32.0",
+          "digest": null
+        },
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+          "line": 355,
+          "key": "image",
+          "image": "casbin/casdoor:v2.32.0",
+          "repository": "casbin/casdoor",
+          "tag": "v2.32.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "mysql:8.0",
+      "repository": "mysql",
+      "current_tag": "8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "mysql:8.0",
+          "repository": "mysql",
+          "tag": "8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "casdoor",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "casdoor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/casdoor/index.yaml",
+          "line": 308,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "changedetection",
+      "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+      "repository": "ghcr.io/dgtlmoon/changedetection.io",
+      "current_tag": "0.50.43",
+      "candidate_tag": "0.55.7",
+      "candidate_image": "ghcr.io/dgtlmoon/changedetection.io:0.55.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "changedetection",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml",
+          "line": 43,
+          "key": "originImageName",
+          "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "repository": "ghcr.io/dgtlmoon/changedetection.io",
+          "tag": "0.50.43",
+          "digest": null
+        },
+        {
+          "template": "changedetection",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/changedetection/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "ghcr.io/dgtlmoon/changedetection.io:0.50.43",
+          "repository": "ghcr.io/dgtlmoon/changedetection.io",
+          "tag": "0.50.43",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatany",
+      "image": "licoy/chatany:v3.5.0",
+      "repository": "licoy/chatany",
+      "current_tag": "v3.5.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "chatany",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatany/index.yaml",
+          "line": 81,
+          "key": "originImageName",
+          "image": "licoy/chatany:v3.5.0",
+          "repository": "licoy/chatany",
+          "tag": "v3.5.0",
+          "digest": null
+        },
+        {
+          "template": "chatany",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatany/index.yaml",
+          "line": 106,
+          "key": "image",
+          "image": "licoy/chatany:v3.5.0",
+          "repository": "licoy/chatany",
+          "tag": "v3.5.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatbot-ui",
+      "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+      "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+      "current_tag": "main",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatbot-ui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatbot-ui/index.yaml",
+          "line": 41,
+          "key": "originImageName",
+          "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+          "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+          "tag": "main",
+          "digest": null
+        },
+        {
+          "template": "chatbot-ui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatbot-ui/index.yaml",
+          "line": 66,
+          "key": "image",
+          "image": "ghcr.io/mckaywrigley/chatbot-ui:main",
+          "repository": "ghcr.io/mckaywrigley/chatbot-ui",
+          "tag": "main",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-next-web",
+      "image": "yidadaa/chatgpt-next-web:v2.12.4",
+      "repository": "yidadaa/chatgpt-next-web",
+      "current_tag": "v2.12.4",
+      "candidate_tag": "v2.16.1",
+      "candidate_image": "yidadaa/chatgpt-next-web:v2.16.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatgpt-next-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml",
+          "line": 89,
+          "key": "originImageName",
+          "image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "repository": "yidadaa/chatgpt-next-web",
+          "tag": "v2.12.4",
+          "digest": null
+        },
+        {
+          "template": "chatgpt-next-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-next-web/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "yidadaa/chatgpt-next-web:v2.12.4",
+          "repository": "yidadaa/chatgpt-next-web",
+          "tag": "v2.12.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-on-wechat",
+      "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+      "repository": "zhayujie/chatgpt-on-wechat",
+      "current_tag": "1.6.8",
+      "candidate_tag": "2.1.3",
+      "candidate_image": "zhayujie/chatgpt-on-wechat:2.1.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatgpt-on-wechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml",
+          "line": 78,
+          "key": "originImageName",
+          "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "repository": "zhayujie/chatgpt-on-wechat",
+          "tag": "1.6.8",
+          "digest": null
+        },
+        {
+          "template": "chatgpt-on-wechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-on-wechat/index.yaml",
+          "line": 98,
+          "key": "image",
+          "image": "zhayujie/chatgpt-on-wechat:1.6.8",
+          "repository": "zhayujie/chatgpt-on-wechat",
+          "tag": "1.6.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatgpt-web",
+      "image": "chenzhaoyu94/chatgpt-web",
+      "repository": "chenzhaoyu94/chatgpt-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatgpt-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-web/index.yaml",
+          "line": 83,
+          "key": "originImageName",
+          "image": "chenzhaoyu94/chatgpt-web",
+          "repository": "chenzhaoyu94/chatgpt-web",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "chatgpt-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatgpt-web/index.yaml",
+          "line": 108,
+          "key": "image",
+          "image": "chenzhaoyu94/chatgpt-web",
+          "repository": "chenzhaoyu94/chatgpt-web",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatnio",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml",
+          "line": 290,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatnio",
+      "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+      "repository": "programzmh/chatnio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+          "repository": "programzmh/chatnio",
+          "tag": null,
+          "digest": "sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d"
+        },
+        {
+          "template": "chatnio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatnio/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d",
+          "repository": "programzmh/chatnio",
+          "tag": null,
+          "digest": "sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d"
+        }
+      ]
+    },
+    {
+      "template": "chatwoot",
+      "image": "chatwoot/chatwoot:v4.7.0",
+      "repository": "chatwoot/chatwoot",
+      "current_tag": "v4.7.0",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "chatwoot/chatwoot:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 171,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 383,
+          "key": "originImageName",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 404,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 507,
+          "key": "originImageName",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        },
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 528,
+          "key": "image",
+          "image": "chatwoot/chatwoot:v4.7.0",
+          "repository": "chatwoot/chatwoot",
+          "tag": "v4.7.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chatwoot",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chatwoot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chatwoot/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "chrome",
+      "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+      "repository": "lscr.io/linuxserver/chrome",
+      "current_tag": "148.0.7778.178-1-ls95",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "chrome",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chrome/index.yaml",
+          "line": 75,
+          "key": "originImageName",
+          "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+          "repository": "lscr.io/linuxserver/chrome",
+          "tag": "148.0.7778.178-1-ls95",
+          "digest": null
+        },
+        {
+          "template": "chrome",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/chrome/index.yaml",
+          "line": 104,
+          "key": "image",
+          "image": "lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95",
+          "repository": "lscr.io/linuxserver/chrome",
+          "tag": "148.0.7778.178-1-ls95",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cloudreve",
+      "image": "arey/mysql-client:latest",
+      "repository": "arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cloudreve/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "arey/mysql-client:latest",
+          "repository": "arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cloudreve",
+      "image": "cloudreve/cloudreve",
+      "repository": "cloudreve/cloudreve",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cloudreve/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "cloudreve/cloudreve",
+          "repository": "cloudreve/cloudreve",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "cloudreve",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cloudreve/index.yaml",
+          "line": 109,
+          "key": "image",
+          "image": "cloudreve/cloudreve",
+          "repository": "cloudreve/cloudreve",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cobalt",
+      "image": "ghcr.io/imputnet/cobalt:7.13.3",
+      "repository": "ghcr.io/imputnet/cobalt",
+      "current_tag": "7.13.3",
+      "candidate_tag": "11.7.1",
+      "candidate_image": "ghcr.io/imputnet/cobalt:11.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "cobalt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cobalt/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "repository": "ghcr.io/imputnet/cobalt",
+          "tag": "7.13.3",
+          "digest": null
+        },
+        {
+          "template": "cobalt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cobalt/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "ghcr.io/imputnet/cobalt:7.13.3",
+          "repository": "ghcr.io/imputnet/cobalt",
+          "tag": "7.13.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "code-server",
+      "image": "codercom/code-server:4.90.3-39",
+      "repository": "codercom/code-server",
+      "current_tag": "4.90.3-39",
+      "candidate_tag": "4.127.0-39",
+      "candidate_image": "codercom/code-server:4.127.0-39",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "code-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "codercom/code-server:4.90.3-39",
+          "repository": "codercom/code-server",
+          "tag": "4.90.3-39",
+          "digest": null
+        },
+        {
+          "template": "code-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/code-server/index.yaml",
+          "line": 72,
+          "key": "image",
+          "image": "codercom/code-server:4.90.3-39",
+          "repository": "codercom/code-server",
+          "tag": "4.90.3-39",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "alpine/curl:8.12.1",
+      "repository": "alpine/curl",
+      "current_tag": "8.12.1",
+      "candidate_tag": "8.21.0",
+      "candidate_image": "alpine/curl:8.21.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1042,
+          "key": "image",
+          "image": "alpine/curl:8.12.1",
+          "repository": "alpine/curl",
+          "tag": "8.12.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3",
+      "repository": "alpine/git",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 915,
+          "key": "image",
+          "image": "alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3",
+          "repository": "alpine/git",
+          "tag": null,
+          "digest": "sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3"
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "bitnamilegacy/elasticsearch:8.18.0",
+      "repository": "bitnamilegacy/elasticsearch",
+      "current_tag": "8.18.0",
+      "candidate_tag": "9.1.2",
+      "candidate_image": "bitnamilegacy/elasticsearch:9.1.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 633,
+          "key": "originImageName",
+          "image": "bitnamilegacy/elasticsearch:8.18.0",
+          "repository": "bitnamilegacy/elasticsearch",
+          "tag": "8.18.0",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 666,
+          "key": "image",
+          "image": "bitnamilegacy/elasticsearch:8.18.0",
+          "repository": "bitnamilegacy/elasticsearch",
+          "tag": "8.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+      "repository": "bitnamilegacy/etcd",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 518,
+          "key": "originImageName",
+          "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+          "repository": "bitnamilegacy/etcd",
+          "tag": null,
+          "digest": "sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0"
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 551,
+          "key": "image",
+          "image": "bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0",
+          "repository": "bitnamilegacy/etcd",
+          "tag": null,
+          "digest": "sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0"
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 540,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 655,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 908,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 982,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 989,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 996,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1148,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "cozedev/coze-studio-server:0.5.1",
+      "repository": "cozedev/coze-studio-server",
+      "current_tag": "0.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 888,
+          "key": "originImageName",
+          "image": "cozedev/coze-studio-server:0.5.1",
+          "repository": "cozedev/coze-studio-server",
+          "tag": "0.5.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1156,
+          "key": "image",
+          "image": "cozedev/coze-studio-server:0.5.1",
+          "repository": "cozedev/coze-studio-server",
+          "tag": "0.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "cozedev/coze-studio-web:0.5.1",
+      "repository": "cozedev/coze-studio-web",
+      "current_tag": "0.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1361,
+          "key": "originImageName",
+          "image": "cozedev/coze-studio-web:0.5.1",
+          "repository": "cozedev/coze-studio-web",
+          "tag": "0.5.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1379,
+          "key": "image",
+          "image": "cozedev/coze-studio-web:0.5.1",
+          "repository": "cozedev/coze-studio-web",
+          "tag": "0.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "milvusdb/milvus:v2.5.10",
+      "repository": "milvusdb/milvus",
+      "current_tag": "v2.5.10",
+      "candidate_tag": "v2.6.19",
+      "candidate_image": "milvusdb/milvus:v2.6.19",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 755,
+          "key": "originImageName",
+          "image": "milvusdb/milvus:v2.5.10",
+          "repository": "milvusdb/milvus",
+          "tag": "v2.5.10",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 775,
+          "key": "image",
+          "image": "milvusdb/milvus:v2.5.10",
+          "repository": "milvusdb/milvus",
+          "tag": "v2.5.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1",
+      "repository": "minio/mc",
+      "current_tag": "RELEASE.2025-05-21T01-59-54Z-cpuv1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 1003,
+          "key": "image",
+          "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1",
+          "repository": "minio/mc",
+          "tag": "RELEASE.2025-05-21T01-59-54Z-cpuv1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "mysql:8.0.36",
+      "repository": "mysql",
+      "current_tag": "8.0.36",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "mysql:8.0.36",
+          "repository": "mysql",
+          "tag": "8.0.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "coze-studio",
+      "image": "nsqio/nsq:v1.2.1",
+      "repository": "nsqio/nsq",
+      "current_tag": "v1.2.1",
+      "candidate_tag": "v1.3.0",
+      "candidate_image": "nsqio/nsq:v1.3.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 378,
+          "key": "originImageName",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 394,
+          "key": "image",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 447,
+          "key": "originImageName",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        },
+        {
+          "template": "coze-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/coze-studio/index.yaml",
+          "line": 463,
+          "key": "image",
+          "image": "nsqio/nsq:v1.2.1",
+          "repository": "nsqio/nsq",
+          "tag": "v1.2.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crawl4ai",
+      "image": "unclecode/crawl4ai:0.8.9",
+      "repository": "unclecode/crawl4ai",
+      "current_tag": "0.8.9",
+      "candidate_tag": "0.9.0",
+      "candidate_image": "unclecode/crawl4ai:0.9.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "crawl4ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "unclecode/crawl4ai:0.8.9",
+          "repository": "unclecode/crawl4ai",
+          "tag": "0.8.9",
+          "digest": null
+        },
+        {
+          "template": "crawl4ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crawl4ai/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "unclecode/crawl4ai:0.8.9",
+          "repository": "unclecode/crawl4ai",
+          "tag": "0.8.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+      "repository": "ghcr.io/yangchuansheng/crmeb",
+      "current_tag": "v5.4.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+          "line": 350,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        },
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+          "line": 373,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        },
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+          "line": 404,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/crmeb:v5.4.0",
+          "repository": "ghcr.io/yangchuansheng/crmeb",
+          "tag": "v5.4.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "crmeb",
+      "image": "nginx:alpine3.20",
+      "repository": "nginx",
+      "current_tag": "alpine3.20",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "crmeb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/crmeb/index.yaml",
+          "line": 381,
+          "key": "image",
+          "image": "nginx:alpine3.20",
+          "repository": "nginx",
+          "tag": "alpine3.20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "cronicle",
+      "image": "soulteary/cronicle:0.9.46",
+      "repository": "soulteary/cronicle",
+      "current_tag": "0.9.46",
+      "candidate_tag": "0.9.80",
+      "candidate_image": "soulteary/cronicle:0.9.80",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "cronicle",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "soulteary/cronicle:0.9.46",
+          "repository": "soulteary/cronicle",
+          "tag": "0.9.46",
+          "digest": null
+        },
+        {
+          "template": "cronicle",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/cronicle/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "soulteary/cronicle:0.9.46",
+          "repository": "soulteary/cronicle",
+          "tag": "0.9.46",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+          "line": 358,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dataease",
+      "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+      "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+      "current_tag": "v2.10.12",
+      "candidate_tag": "v2.10.25",
+      "candidate_image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+          "tag": "v2.10.12",
+          "digest": null
+        },
+        {
+          "template": "dataease",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dataease/index.yaml",
+          "line": 113,
+          "key": "image",
+          "image": "registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12",
+          "repository": "registry.cn-qingdao.aliyuncs.com/dataease/dataease",
+          "tag": "v2.10.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dbgate",
+      "image": "dbgate/dbgate:5.3.1-alpine",
+      "repository": "dbgate/dbgate",
+      "current_tag": "5.3.1-alpine",
+      "candidate_tag": "7.2.1-alpine",
+      "candidate_image": "dbgate/dbgate:7.2.1-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dbgate",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "dbgate/dbgate:5.3.1-alpine",
+          "repository": "dbgate/dbgate",
+          "tag": "5.3.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "dbgate",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dbgate/index.yaml",
+          "line": 78,
+          "key": "image",
+          "image": "dbgate/dbgate:5.3.1-alpine",
+          "repository": "dbgate/dbgate",
+          "tag": "5.3.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "deeplx",
+      "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+      "repository": "ghcr.io/owo-network/deeplx",
+      "current_tag": "v0.9.5",
+      "candidate_tag": "v1.2.2",
+      "candidate_image": "ghcr.io/owo-network/deeplx:v1.2.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "deeplx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "repository": "ghcr.io/owo-network/deeplx",
+          "tag": "v0.9.5",
+          "digest": null
+        },
+        {
+          "template": "deeplx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/deeplx/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/owo-network/deeplx:v0.9.5",
+          "repository": "ghcr.io/owo-network/deeplx",
+          "tag": "v0.9.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "derper",
+      "image": "bitnamilegacy/kubectl:1.28.9",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": "1.28.9",
+      "candidate_tag": "1.33.4",
+      "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "derper",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+          "line": 196,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.28.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "derper",
+      "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+      "repository": "ghcr.io/yangchuansheng/derper",
+      "current_tag": "v1.99.0-pre",
+      "candidate_tag": "v1.101.0-pre",
+      "candidate_image": "ghcr.io/yangchuansheng/derper:v1.101.0-pre",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "derper",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+          "line": 110,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "repository": "ghcr.io/yangchuansheng/derper",
+          "tag": "v1.99.0-pre",
+          "digest": null
+        },
+        {
+          "template": "derper",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/derper/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/derper:v1.99.0-pre",
+          "repository": "ghcr.io/yangchuansheng/derper",
+          "tag": "v1.99.0-pre",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 112,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-api:1.11.2",
+      "repository": "langgenius/dify-api",
+      "current_tag": "1.11.2",
+      "candidate_tag": "1.15.0",
+      "candidate_image": "langgenius/dify-api:1.15.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 131,
+          "key": "image",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 273,
+          "key": "image",
+          "image": "langgenius/dify-api:1.11.2",
+          "repository": "langgenius/dify-api",
+          "tag": "1.11.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+      "repository": "langgenius/dify-plugin-daemon",
+      "current_tag": "0.5.2-local",
+      "candidate_tag": "0.6.3-local",
+      "candidate_image": "langgenius/dify-plugin-daemon:0.6.3-local",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 681,
+          "key": "originImageName",
+          "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "repository": "langgenius/dify-plugin-daemon",
+          "tag": "0.5.2-local",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 740,
+          "key": "image",
+          "image": "langgenius/dify-plugin-daemon:0.5.2-local",
+          "repository": "langgenius/dify-plugin-daemon",
+          "tag": "0.5.2-local",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-sandbox:0.2.12",
+      "repository": "langgenius/dify-sandbox",
+      "current_tag": "0.2.12",
+      "candidate_tag": "0.2.15",
+      "candidate_image": "langgenius/dify-sandbox:0.2.15",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 601,
+          "key": "originImageName",
+          "image": "langgenius/dify-sandbox:0.2.12",
+          "repository": "langgenius/dify-sandbox",
+          "tag": "0.2.12",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 624,
+          "key": "image",
+          "image": "langgenius/dify-sandbox:0.2.12",
+          "repository": "langgenius/dify-sandbox",
+          "tag": "0.2.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "langgenius/dify-web:1.11.2",
+      "repository": "langgenius/dify-web",
+      "current_tag": "1.11.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 414,
+          "key": "originImageName",
+          "image": "langgenius/dify-web:1.11.2",
+          "repository": "langgenius/dify-web",
+          "tag": "1.11.2",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 470,
+          "key": "image",
+          "image": "langgenius/dify-web:1.11.2",
+          "repository": "langgenius/dify-web",
+          "tag": "1.11.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 434,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 704,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 965,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dify",
+      "image": "semitechnologies/weaviate:1.27.0",
+      "repository": "semitechnologies/weaviate",
+      "current_tag": "1.27.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 1120,
+          "key": "originImageName",
+          "image": "semitechnologies/weaviate:1.27.0",
+          "repository": "semitechnologies/weaviate",
+          "tag": "1.27.0",
+          "digest": null
+        },
+        {
+          "template": "dify",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dify/index.yaml",
+          "line": 1141,
+          "key": "image",
+          "image": "semitechnologies/weaviate:1.27.0",
+          "repository": "semitechnologies/weaviate",
+          "tag": "1.27.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "directus/directus:11.17.4",
+      "repository": "directus/directus",
+      "current_tag": "11.17.4",
+      "candidate_tag": "12.1.1",
+      "candidate_image": "directus/directus:12.1.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 332,
+          "key": "originImageName",
+          "image": "directus/directus:11.17.4",
+          "repository": "directus/directus",
+          "tag": "11.17.4",
+          "digest": null
+        },
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "directus/directus:11.17.4",
+          "repository": "directus/directus",
+          "tag": "11.17.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 357,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 380,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "directus",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "directus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/directus/index.yaml",
+          "line": 421,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docker-stacks",
+      "image": "jupyter/scipy-notebook:2023-10-20",
+      "repository": "jupyter/scipy-notebook",
+      "current_tag": "2023-10-20",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "docker-stacks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docker-stacks/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "jupyter/scipy-notebook:2023-10-20",
+          "repository": "jupyter/scipy-notebook",
+          "tag": "2023-10-20",
+          "digest": null
+        },
+        {
+          "template": "docker-stacks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docker-stacks/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "jupyter/scipy-notebook:2023-10-20",
+          "repository": "jupyter/scipy-notebook",
+          "tag": "2023-10-20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docuseal",
+      "image": "docuseal/docuseal:3.0.1",
+      "repository": "docuseal/docuseal",
+      "current_tag": "3.0.1",
+      "candidate_tag": "3.1.3",
+      "candidate_image": "docuseal/docuseal:3.1.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml",
+          "line": 184,
+          "key": "originImageName",
+          "image": "docuseal/docuseal:3.0.1",
+          "repository": "docuseal/docuseal",
+          "tag": "3.0.1",
+          "digest": null
+        },
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml",
+          "line": 207,
+          "key": "image",
+          "image": "docuseal/docuseal:3.0.1",
+          "repository": "docuseal/docuseal",
+          "tag": "3.0.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "docuseal",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "docuseal",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/docuseal/index.yaml",
+          "line": 139,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "dolibarr",
+      "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+      "repository": "dolibarr/dolibarr",
+      "current_tag": "23.0.3-php8.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dolibarr/index.yaml",
+          "line": 213,
+          "key": "originImageName",
+          "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+          "repository": "dolibarr/dolibarr",
+          "tag": "23.0.3-php8.2",
+          "digest": "sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865"
+        },
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dolibarr/index.yaml",
+          "line": 234,
+          "key": "image",
+          "image": "dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865",
+          "repository": "dolibarr/dolibarr",
+          "tag": "23.0.3-php8.2",
+          "digest": "sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865"
+        }
+      ]
+    },
+    {
+      "template": "dolibarr",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "dolibarr",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/dolibarr/index.yaml",
+          "line": 161,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "drawdb",
+      "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+      "repository": "ghcr.io/drawdb-io/drawdb",
+      "current_tag": "v1.5.0",
+      "candidate_tag": "v1.8.1",
+      "candidate_image": "ghcr.io/drawdb-io/drawdb:v1.8.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "drawdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml",
+          "line": 60,
+          "key": "originImageName",
+          "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "repository": "ghcr.io/drawdb-io/drawdb",
+          "tag": "v1.5.0",
+          "digest": null
+        },
+        {
+          "template": "drawdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drawdb/index.yaml",
+          "line": 81,
+          "key": "image",
+          "image": "ghcr.io/drawdb-io/drawdb:v1.5.0",
+          "repository": "ghcr.io/drawdb-io/drawdb",
+          "tag": "v1.5.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "drizzle-studio",
+      "image": "ghcr.io/drizzle-team/gateway:latest",
+      "repository": "ghcr.io/drizzle-team/gateway",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "drizzle-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drizzle-studio/index.yaml",
+          "line": 42,
+          "key": "originImageName",
+          "image": "ghcr.io/drizzle-team/gateway:latest",
+          "repository": "ghcr.io/drizzle-team/gateway",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "drizzle-studio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/drizzle-studio/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "ghcr.io/drizzle-team/gateway:latest",
+          "repository": "ghcr.io/drizzle-team/gateway",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "eaglercraft-server",
+      "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1@sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810",
+      "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+      "current_tag": "1.12.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "eaglercraft-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/eaglercraft-server/index.yaml",
+          "line": 49,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1@sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810",
+          "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+          "tag": "1.12.1",
+          "digest": "sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810"
+        },
+        {
+          "template": "eaglercraft-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/eaglercraft-server/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1@sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810",
+          "repository": "ghcr.io/yangchuansheng/eaglerx1.8server",
+          "tag": "1.12.1",
+          "digest": "sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810"
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+      "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+      "current_tag": "0.12.2",
+      "candidate_tag": "0.15.0",
+      "candidate_image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.15.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+          "line": 380,
+          "key": "originImageName",
+          "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+          "tag": "0.12.2",
+          "digest": null
+        },
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+          "line": 400,
+          "key": "image",
+          "image": "ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake-frontend",
+          "tag": "0.12.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+      "repository": "ghcr.io/raphaelmansuy/edgequake",
+      "current_tag": "0.12.2",
+      "candidate_tag": "0.15.0",
+      "candidate_image": "ghcr.io/raphaelmansuy/edgequake:0.15.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+          "line": 282,
+          "key": "originImageName",
+          "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake",
+          "tag": "0.12.2",
+          "digest": null
+        },
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+          "line": 302,
+          "key": "image",
+          "image": "ghcr.io/raphaelmansuy/edgequake:0.12.2",
+          "repository": "ghcr.io/raphaelmansuy/edgequake",
+          "tag": "0.12.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "edgequake",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "edgequake",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/edgequake/index.yaml",
+          "line": 163,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "elasticsearch",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "elasticsearch",
+      "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+      "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+      "current_tag": "9.4.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+          "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+          "tag": "9.4.1",
+          "digest": null
+        },
+        {
+          "template": "elasticsearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/elasticsearch/index.yaml",
+          "line": 84,
+          "key": "image",
+          "image": "docker.elastic.co/elasticsearch/elasticsearch:9.4.1",
+          "repository": "docker.elastic.co/elasticsearch/elasticsearch",
+          "tag": "9.4.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "emqx",
+      "image": "emqx/emqx:5.8.9",
+      "repository": "emqx/emqx",
+      "current_tag": "5.8.9",
+      "candidate_tag": "6.2.2",
+      "candidate_image": "emqx/emqx:6.2.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "emqx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "emqx/emqx:5.8.9",
+          "repository": "emqx/emqx",
+          "tag": "5.8.9",
+          "digest": null
+        },
+        {
+          "template": "emqx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/emqx/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "emqx/emqx:5.8.9",
+          "repository": "emqx/emqx",
+          "tag": "5.8.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/enshrouded/index.yaml",
+          "line": 90,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/enshrouded/index.yaml",
+          "line": 102,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/enshrouded/index.yaml",
+          "line": 211,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "enshrouded",
+      "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+      "current_tag": "v0.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/enshrouded/index.yaml",
+          "line": 68,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+          "tag": "v0.2",
+          "digest": null
+        },
+        {
+          "template": "enshrouded",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/enshrouded/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded",
+          "tag": "v0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "frappe/erpnext:v16.21.1",
+      "repository": "frappe/erpnext",
+      "current_tag": "v16.21.1",
+      "candidate_tag": "v16.26.2",
+      "candidate_image": "frappe/erpnext:v16.26.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 374,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 530,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 666,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 731,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 786,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 882,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 962,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1027,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1118,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1214,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1275,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1371,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1432,
+          "key": "originImageName",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1497,
+          "key": "image",
+          "image": "frappe/erpnext:v16.21.1",
+          "repository": "frappe/erpnext",
+          "tag": "v16.21.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "mariadb:11.4.7",
+      "repository": "mariadb",
+      "current_tag": "11.4.7",
+      "candidate_tag": "12.3.2",
+      "candidate_image": "mariadb:12.3.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "mariadb:11.4.7",
+          "repository": "mariadb",
+          "tag": "11.4.7",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 89,
+          "key": "image",
+          "image": "mariadb:11.4.7",
+          "repository": "mariadb",
+          "tag": "11.4.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 319,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 475,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 687,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 710,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 807,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 861,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 983,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1006,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1139,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1193,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1296,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1350,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1453,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1476,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "erpnext",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 342,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 498,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 830,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1162,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "erpnext",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/erpnext/index.yaml",
+          "line": 1319,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 208,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+      "repository": "ghcr.io/ever-co/gauzy-api-demo",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 186,
+          "key": "originImageName",
+          "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+          "repository": "ghcr.io/ever-co/gauzy-api-demo",
+          "tag": null,
+          "digest": "sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4"
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 271,
+          "key": "image",
+          "image": "ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4",
+          "repository": "ghcr.io/ever-co/gauzy-api-demo",
+          "tag": null,
+          "digest": "sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4"
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+      "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 516,
+          "key": "originImageName",
+          "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+          "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+          "tag": null,
+          "digest": "sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493"
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 537,
+          "key": "image",
+          "image": "ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493",
+          "repository": "ghcr.io/ever-co/gauzy-webapp-demo",
+          "tag": null,
+          "digest": "sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493"
+        }
+      ]
+    },
+    {
+      "template": "ever-gauzy",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 149,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "ever-gauzy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ever-gauzy/index.yaml",
+          "line": 228,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "evoapicloud/evolution-api:v2.3.7",
+      "repository": "evoapicloud/evolution-api",
+      "current_tag": "v2.3.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 315,
+          "key": "originImageName",
+          "image": "evoapicloud/evolution-api:v2.3.7",
+          "repository": "evoapicloud/evolution-api",
+          "tag": "v2.3.7",
+          "digest": null
+        },
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 424,
+          "key": "image",
+          "image": "evoapicloud/evolution-api:v2.3.7",
+          "repository": "evoapicloud/evolution-api",
+          "tag": "v2.3.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 340,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 152,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 361,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "evolution-api",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "evolution-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/evolution-api/index.yaml",
+          "line": 393,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "excalidraw",
+      "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+      "repository": "excalidraw/excalidraw",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "excalidraw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/excalidraw/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+          "repository": "excalidraw/excalidraw",
+          "tag": null,
+          "digest": "sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f"
+        },
+        {
+          "template": "excalidraw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/excalidraw/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f",
+          "repository": "excalidraw/excalidraw",
+          "tag": null,
+          "digest": "sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f"
+        }
+      ]
+    },
+    {
+      "template": "fast-poster",
+      "image": "fastposter/fastposter:latest",
+      "repository": "fastposter/fastposter",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fast-poster",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fast-poster/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "fastposter/fastposter:latest",
+          "repository": "fastposter/fastposter",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "fast-poster",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fast-poster/index.yaml",
+          "line": 52,
+          "key": "image",
+          "image": "fastposter/fastposter:latest",
+          "repository": "fastposter/fastposter",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 369,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1013,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1033,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1126,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1146,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v1.0.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 852,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 872,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 562,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 582,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.5",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1238,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt/index.yaml",
+          "line": 1258,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 1176,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 678,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 704,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 774,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 800,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v1.0.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 417,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 443,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 136,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-milvus",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.5",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 580,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-milvus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-milvus/index.yaml",
+          "line": 606,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1161,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1181,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.14.23",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1274,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1294,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+      "current_tag": "v0.6.2",
+      "candidate_tag": "v1.0.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1000,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1020,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin",
+          "tag": "v0.6.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 855,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 875,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+      "current_tag": "v4.14.22",
+      "candidate_tag": "v4.15.1",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 563,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 583,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt",
+          "tag": "v4.14.22",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "fastgpt-pro",
+      "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+      "current_tag": "v0.5.8",
+      "candidate_tag": "v0.6.5",
+      "candidate_image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1386,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        },
+        {
+          "template": "fastgpt-pro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fastgpt-pro/index.yaml",
+          "line": 1406,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/labring/aiproxy",
+          "tag": "v0.5.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-api-server:5.0.5",
+      "repository": "featbit/featbit-api-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-api-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1118,
+          "key": "originImageName",
+          "image": "featbit/featbit-api-server:5.0.5",
+          "repository": "featbit/featbit-api-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1179,
+          "key": "image",
+          "image": "featbit/featbit-api-server:5.0.5",
+          "repository": "featbit/featbit-api-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-data-analytics-server:5.0.5",
+      "repository": "featbit/featbit-data-analytics-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-data-analytics-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1247,
+          "key": "originImageName",
+          "image": "featbit/featbit-data-analytics-server:5.0.5",
+          "repository": "featbit/featbit-data-analytics-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1308,
+          "key": "image",
+          "image": "featbit/featbit-data-analytics-server:5.0.5",
+          "repository": "featbit/featbit-data-analytics-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-evaluation-server:5.0.5",
+      "repository": "featbit/featbit-evaluation-server",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-evaluation-server:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1370,
+          "key": "originImageName",
+          "image": "featbit/featbit-evaluation-server:5.0.5",
+          "repository": "featbit/featbit-evaluation-server",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1431,
+          "key": "image",
+          "image": "featbit/featbit-evaluation-server:5.0.5",
+          "repository": "featbit/featbit-evaluation-server",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "featbit/featbit-ui:5.0.5",
+      "repository": "featbit/featbit-ui",
+      "current_tag": "5.0.5",
+      "candidate_tag": "5.4.2",
+      "candidate_image": "featbit/featbit-ui:5.4.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1497,
+          "key": "originImageName",
+          "image": "featbit/featbit-ui:5.0.5",
+          "repository": "featbit/featbit-ui",
+          "tag": "5.0.5",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1519,
+          "key": "image",
+          "image": "featbit/featbit-ui:5.0.5",
+          "repository": "featbit/featbit-ui",
+          "tag": "5.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "featbit-standard",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 240,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1140,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1269,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "featbit-standard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/featbit-standard/index.yaml",
+          "line": 1392,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "filecodebox",
+      "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+      "repository": "lanol/filecodebox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "filecodebox",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/filecodebox/index.yaml",
+          "line": 126,
+          "key": "originImageName",
+          "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+          "repository": "lanol/filecodebox",
+          "tag": null,
+          "digest": "sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2"
+        },
+        {
+          "template": "filecodebox",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/filecodebox/index.yaml",
+          "line": 147,
+          "key": "image",
+          "image": "lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2",
+          "repository": "lanol/filecodebox",
+          "tag": null,
+          "digest": "sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2"
+        }
+      ]
+    },
+    {
+      "template": "fireboom",
+      "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+      "repository": "fireboomapi/fireboom_server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "fireboom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fireboom/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+          "repository": "fireboomapi/fireboom_server",
+          "tag": null,
+          "digest": "sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f"
+        },
+        {
+          "template": "fireboom",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/fireboom/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f",
+          "repository": "fireboomapi/fireboom_server",
+          "tag": null,
+          "digest": "sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f"
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 258,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 702,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "ghcr.io/firecrawl/firecrawl@sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c",
+      "repository": "ghcr.io/firecrawl/firecrawl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 450,
+          "key": "originImageName",
+          "image": "ghcr.io/firecrawl/firecrawl@sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c",
+          "repository": "ghcr.io/firecrawl/firecrawl",
+          "tag": null,
+          "digest": "sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c"
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 728,
+          "key": "image",
+          "image": "ghcr.io/firecrawl/firecrawl@sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c",
+          "repository": "ghcr.io/firecrawl/firecrawl",
+          "tag": null,
+          "digest": "sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c"
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "ghcr.io/firecrawl/playwright-service@sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e",
+      "repository": "ghcr.io/firecrawl/playwright-service",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 366,
+          "key": "originImageName",
+          "image": "ghcr.io/firecrawl/playwright-service@sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e",
+          "repository": "ghcr.io/firecrawl/playwright-service",
+          "tag": null,
+          "digest": "sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e"
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 389,
+          "key": "image",
+          "image": "ghcr.io/firecrawl/playwright-service@sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e",
+          "repository": "ghcr.io/firecrawl/playwright-service",
+          "tag": null,
+          "digest": "sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e"
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 474,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "rabbitmq:3.13.7-management",
+      "repository": "rabbitmq",
+      "current_tag": "3.13.7-management",
+      "candidate_tag": "4.3.2-management",
+      "candidate_image": "rabbitmq:4.3.2-management",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 230,
+          "key": "originImageName",
+          "image": "rabbitmq:3.13.7-management",
+          "repository": "rabbitmq",
+          "tag": "3.13.7-management",
+          "digest": null
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 287,
+          "key": "image",
+          "image": "rabbitmq:3.13.7-management",
+          "repository": "rabbitmq",
+          "tag": "3.13.7-management",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "firecrawl",
+      "image": "redis:7.2.7-alpine",
+      "repository": "redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 145,
+          "key": "originImageName",
+          "image": "redis:7.2.7-alpine",
+          "repository": "redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 169,
+          "key": "image",
+          "image": "redis:7.2.7-alpine",
+          "repository": "redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "firecrawl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firecrawl/index.yaml",
+          "line": 675,
+          "key": "image",
+          "image": "redis:7.2.7-alpine",
+          "repository": "redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "firefox",
+      "image": "jlesage/firefox:latest",
+      "repository": "jlesage/firefox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "firefox",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firefox/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "jlesage/firefox:latest",
+          "repository": "jlesage/firefox",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "firefox",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/firefox/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "jlesage/firefox:latest",
+          "repository": "jlesage/firefox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flarum",
+      "image": "crazymax/flarum:1.8.10",
+      "repository": "crazymax/flarum",
+      "current_tag": "1.8.10",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml",
+          "line": 129,
+          "key": "originImageName",
+          "image": "crazymax/flarum:1.8.10",
+          "repository": "crazymax/flarum",
+          "tag": "1.8.10",
+          "digest": null
+        },
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml",
+          "line": 202,
+          "key": "image",
+          "image": "crazymax/flarum:1.8.10",
+          "repository": "crazymax/flarum",
+          "tag": "1.8.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flarum",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "flarum",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flarum/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flowise",
+      "image": "flowiseai/flowise:3.0.5",
+      "repository": "flowiseai/flowise",
+      "current_tag": "3.0.5",
+      "candidate_tag": "3.1.3",
+      "candidate_image": "flowiseai/flowise:3.1.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+          "line": 195,
+          "key": "originImageName",
+          "image": "flowiseai/flowise:3.0.5",
+          "repository": "flowiseai/flowise",
+          "tag": "3.0.5",
+          "digest": null
+        },
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "flowiseai/flowise:3.0.5",
+          "repository": "flowiseai/flowise",
+          "tag": "3.0.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "flowise",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        },
+        {
+          "template": "flowise",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/flowise/index.yaml",
+          "line": 217,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "formbricks",
+      "image": "ghcr.io/formbricks/formbricks:4.9.7",
+      "repository": "ghcr.io/formbricks/formbricks",
+      "current_tag": "4.9.7",
+      "candidate_tag": "5.1.4",
+      "candidate_image": "ghcr.io/formbricks/formbricks:5.1.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+          "line": 344,
+          "key": "originImageName",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        },
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        },
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+          "line": 426,
+          "key": "image",
+          "image": "ghcr.io/formbricks/formbricks:4.9.7",
+          "repository": "ghcr.io/formbricks/formbricks",
+          "tag": "4.9.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "formbricks",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "formbricks",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/formbricks/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "frp",
+      "image": "bitnamilegacy/kubectl:1.28.9",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": "1.28.9",
+      "candidate_tag": "1.33.4",
+      "candidate_image": "bitnamilegacy/kubectl:1.33.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "frp",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml",
+          "line": 299,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl:1.28.9",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": "1.28.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "frp",
+      "image": "snowdreamtech/frps:0.59",
+      "repository": "snowdreamtech/frps",
+      "current_tag": "0.59",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "frp",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml",
+          "line": 79,
+          "key": "originImageName",
+          "image": "snowdreamtech/frps:0.59",
+          "repository": "snowdreamtech/frps",
+          "tag": "0.59",
+          "digest": null
+        },
+        {
+          "template": "frp",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/frp/index.yaml",
+          "line": 104,
+          "key": "image",
+          "image": "snowdreamtech/frps:0.59",
+          "repository": "snowdreamtech/frps",
+          "tag": "0.59",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+      "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+      "current_tag": "0.8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 232,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 300,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 320,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-backend",
+          "tag": "0.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+      "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+      "current_tag": "0.8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 429,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+          "tag": "0.8.0",
+          "digest": null
+        },
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 449,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0",
+          "repository": "ghcr.io/yangchuansheng/full-stack-fastapi-frontend",
+          "tag": "0.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "full-stack-fastapi",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "full-stack-fastapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/full-stack-fastapi/index.yaml",
+          "line": 183,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "ghost:6.44.1-alpine",
+      "repository": "ghost",
+      "current_tag": "6.44.1-alpine",
+      "candidate_tag": "6.51.0-alpine",
+      "candidate_image": "ghost:6.51.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+          "line": 250,
+          "key": "originImageName",
+          "image": "ghost:6.44.1-alpine",
+          "repository": "ghost",
+          "tag": "6.44.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+          "line": 339,
+          "key": "image",
+          "image": "ghost:6.44.1-alpine",
+          "repository": "ghost",
+          "tag": "6.44.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+      "repository": "public.ecr.aws/docker/library/mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+          "line": 300,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ghost",
+      "image": "public.ecr.aws/docker/library/node:22-alpine",
+      "repository": "public.ecr.aws/docker/library/node",
+      "current_tag": "22-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ghost",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ghost/index.yaml",
+          "line": 277,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/node:22-alpine",
+          "repository": "public.ecr.aws/docker/library/node",
+          "tag": "22-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "gitea",
+      "image": "gitea/gitea:1.22.0-rootless",
+      "repository": "gitea/gitea",
+      "current_tag": "1.22.0-rootless",
+      "candidate_tag": "1.26.4-rootless",
+      "candidate_image": "gitea/gitea:1.26.4-rootless",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "gitea",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "gitea/gitea:1.22.0-rootless",
+          "repository": "gitea/gitea",
+          "tag": "1.22.0-rootless",
+          "digest": null
+        },
+        {
+          "template": "gitea",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gitea/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "gitea/gitea:1.22.0-rootless",
+          "repository": "gitea/gitea",
+          "tag": "1.22.0-rootless",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glance",
+      "image": "glanceapp/glance",
+      "repository": "glanceapp/glance",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "glance",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glance/index.yaml",
+          "line": 146,
+          "key": "originImageName",
+          "image": "glanceapp/glance",
+          "repository": "glanceapp/glance",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glance",
+      "image": "glanceapp/glance:latest",
+      "repository": "glanceapp/glance",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "glance",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glance/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "glanceapp/glance:latest",
+          "repository": "glanceapp/glance",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glitchtip",
+      "image": "glitchtip/glitchtip:v4.1.5",
+      "repository": "glitchtip/glitchtip",
+      "current_tag": "v4.1.5",
+      "candidate_tag": "v6.0.3",
+      "candidate_image": "glitchtip/glitchtip:v6.0.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+          "line": 61,
+          "key": "originImageName",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+          "line": 86,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+          "line": 175,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        },
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "glitchtip/glitchtip:v4.1.5",
+          "repository": "glitchtip/glitchtip",
+          "tag": "v4.1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "glitchtip",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "glitchtip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/glitchtip/index.yaml",
+          "line": 623,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "gpt-academic",
+      "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+      "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+      "current_tag": "master",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "gpt-academic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gpt-academic/index.yaml",
+          "line": 63,
+          "key": "originImageName",
+          "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+          "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+          "tag": "master",
+          "digest": null
+        },
+        {
+          "template": "gpt-academic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/gpt-academic/index.yaml",
+          "line": 88,
+          "key": "image",
+          "image": "ghcr.io/binary-husky/gpt_academic_nolocal:master",
+          "repository": "ghcr.io/binary-husky/gpt_academic_nolocal",
+          "tag": "master",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana",
+      "image": "grafana/grafana:13.0.2",
+      "repository": "grafana/grafana",
+      "current_tag": "13.0.2",
+      "candidate_tag": "13.1.0",
+      "candidate_image": "grafana/grafana:13.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana/index.yaml",
+          "line": 193,
+          "key": "originImageName",
+          "image": "grafana/grafana:13.0.2",
+          "repository": "grafana/grafana",
+          "tag": "13.0.2",
+          "digest": null
+        },
+        {
+          "template": "grafana",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana/index.yaml",
+          "line": 217,
+          "key": "image",
+          "image": "grafana/grafana:13.0.2",
+          "repository": "grafana/grafana",
+          "tag": "13.0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "grafana",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana/index.yaml",
+          "line": 142,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 242,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 372,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "grafana/grafana:12.3.0",
+      "repository": "grafana/grafana",
+      "current_tag": "12.3.0",
+      "candidate_tag": "13.1.0",
+      "candidate_image": "grafana/grafana:13.1.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 351,
+          "key": "originImageName",
+          "image": "grafana/grafana:12.3.0",
+          "repository": "grafana/grafana",
+          "tag": "12.3.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 384,
+          "key": "image",
+          "image": "grafana/grafana:12.3.0",
+          "repository": "grafana/grafana",
+          "tag": "12.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "otel/opentelemetry-collector:0.99.0",
+      "repository": "otel/opentelemetry-collector",
+      "current_tag": "0.99.0",
+      "candidate_tag": "0.156.0",
+      "candidate_image": "otel/opentelemetry-collector:0.156.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 70,
+          "key": "originImageName",
+          "image": "otel/opentelemetry-collector:0.99.0",
+          "repository": "otel/opentelemetry-collector",
+          "tag": "0.99.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "otel/opentelemetry-collector:0.99.0",
+          "repository": "otel/opentelemetry-collector",
+          "tag": "0.99.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "grafana-otel",
+      "image": "prom/prometheus:v3.8.0",
+      "repository": "prom/prometheus",
+      "current_tag": "v3.8.0",
+      "candidate_tag": "v3.13.0",
+      "candidate_image": "prom/prometheus:v3.13.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 221,
+          "key": "originImageName",
+          "image": "prom/prometheus:v3.8.0",
+          "repository": "prom/prometheus",
+          "tag": "v3.8.0",
+          "digest": null
+        },
+        {
+          "template": "grafana-otel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/grafana-otel/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "prom/prometheus:v3.8.0",
+          "repository": "prom/prometheus",
+          "tag": "v3.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "halo",
+      "image": "halohub/halo:2.18.0",
+      "repository": "halohub/halo",
+      "current_tag": "2.18.0",
+      "candidate_tag": "2.25.4",
+      "candidate_image": "halohub/halo:2.25.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "halo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "halohub/halo:2.18.0",
+          "repository": "halohub/halo",
+          "tag": "2.18.0",
+          "digest": null
+        },
+        {
+          "template": "halo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "halohub/halo:2.18.0",
+          "repository": "halohub/halo",
+          "tag": "2.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "halo",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "halo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/halo/index.yaml",
+          "line": 271,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "happy-server",
+      "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+      "repository": "ghcr.io/yangchuansheng/happy-server",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/happy-server/index.yaml",
+          "line": 704,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+          "repository": "ghcr.io/yangchuansheng/happy-server",
+          "tag": null,
+          "digest": "sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe"
+        },
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/happy-server/index.yaml",
+          "line": 724,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe",
+          "repository": "ghcr.io/yangchuansheng/happy-server",
+          "tag": null,
+          "digest": "sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe"
+        }
+      ]
+    },
+    {
+      "template": "happy-server",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "happy-server",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/happy-server/index.yaml",
+          "line": 523,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-core:v2.14.4",
+      "repository": "goharbor/harbor-core",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/harbor-core:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 606,
+          "key": "originImageName",
+          "image": "goharbor/harbor-core:v2.14.4",
+          "repository": "goharbor/harbor-core",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 628,
+          "key": "image",
+          "image": "goharbor/harbor-core:v2.14.4",
+          "repository": "goharbor/harbor-core",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-jobservice:v2.14.4",
+      "repository": "goharbor/harbor-jobservice",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/harbor-jobservice:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 739,
+          "key": "originImageName",
+          "image": "goharbor/harbor-jobservice:v2.14.4",
+          "repository": "goharbor/harbor-jobservice",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 762,
+          "key": "image",
+          "image": "goharbor/harbor-jobservice:v2.14.4",
+          "repository": "goharbor/harbor-jobservice",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-portal:v2.14.4",
+      "repository": "goharbor/harbor-portal",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/harbor-portal:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 840,
+          "key": "originImageName",
+          "image": "goharbor/harbor-portal:v2.14.4",
+          "repository": "goharbor/harbor-portal",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 862,
+          "key": "image",
+          "image": "goharbor/harbor-portal:v2.14.4",
+          "repository": "goharbor/harbor-portal",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/harbor-registryctl:v2.14.4",
+      "repository": "goharbor/harbor-registryctl",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/harbor-registryctl:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 1041,
+          "key": "originImageName",
+          "image": "goharbor/harbor-registryctl:v2.14.4",
+          "repository": "goharbor/harbor-registryctl",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 1063,
+          "key": "image",
+          "image": "goharbor/harbor-registryctl:v2.14.4",
+          "repository": "goharbor/harbor-registryctl",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/registry-photon:v2.14.4",
+      "repository": "goharbor/registry-photon",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/registry-photon:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 903,
+          "key": "originImageName",
+          "image": "goharbor/registry-photon:v2.14.4",
+          "repository": "goharbor/registry-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 926,
+          "key": "image",
+          "image": "goharbor/registry-photon:v2.14.4",
+          "repository": "goharbor/registry-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "goharbor/trivy-adapter-photon:v2.14.4",
+      "repository": "goharbor/trivy-adapter-photon",
+      "current_tag": "v2.14.4",
+      "candidate_tag": "v2.15.2",
+      "candidate_image": "goharbor/trivy-adapter-photon:v2.15.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 1121,
+          "key": "originImageName",
+          "image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "repository": "goharbor/trivy-adapter-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        },
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 1146,
+          "key": "image",
+          "image": "goharbor/trivy-adapter-photon:v2.14.4",
+          "repository": "goharbor/trivy-adapter-photon",
+          "tag": "v2.14.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "harbor",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "harbor",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/harbor/index.yaml",
+          "line": 163,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "hasura",
+      "image": "hasura/graphql-data-connector:v2.48.11",
+      "repository": "hasura/graphql-data-connector",
+      "current_tag": "v2.48.11",
+      "candidate_tag": "v2.49.4",
+      "candidate_image": "hasura/graphql-data-connector:v2.49.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+          "line": 215,
+          "key": "originImageName",
+          "image": "hasura/graphql-data-connector:v2.48.11",
+          "repository": "hasura/graphql-data-connector",
+          "tag": "v2.48.11",
+          "digest": null
+        },
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+          "line": 235,
+          "key": "image",
+          "image": "hasura/graphql-data-connector:v2.48.11",
+          "repository": "hasura/graphql-data-connector",
+          "tag": "v2.48.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "hasura",
+      "image": "hasura/graphql-engine:v2.48.11",
+      "repository": "hasura/graphql-engine",
+      "current_tag": "v2.48.11",
+      "candidate_tag": "v2.49.4",
+      "candidate_image": "hasura/graphql-engine:v2.49.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+          "line": 121,
+          "key": "originImageName",
+          "image": "hasura/graphql-engine:v2.48.11",
+          "repository": "hasura/graphql-engine",
+          "tag": "v2.48.11",
+          "digest": null
+        },
+        {
+          "template": "hasura",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/hasura/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "hasura/graphql-engine:v2.48.11",
+          "repository": "hasura/graphql-engine",
+          "tag": "v2.48.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 945,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "ghcr.io/tale/headplane:0.6.3",
+      "repository": "ghcr.io/tale/headplane",
+      "current_tag": "0.6.3",
+      "candidate_tag": "0.7.0",
+      "candidate_image": "ghcr.io/tale/headplane:0.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 1042,
+          "key": "image",
+          "image": "ghcr.io/tale/headplane:0.6.3",
+          "repository": "ghcr.io/tale/headplane",
+          "tag": "0.6.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "headscale/headscale:0.29.0-beta.1-debug",
+      "repository": "headscale/headscale",
+      "current_tag": "0.29.0-beta.1-debug",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 879,
+          "key": "originImageName",
+          "image": "headscale/headscale:0.29.0-beta.1-debug",
+          "repository": "headscale/headscale",
+          "tag": "0.29.0-beta.1-debug",
+          "digest": null
+        },
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 998,
+          "key": "image",
+          "image": "headscale/headscale:0.29.0-beta.1-debug",
+          "repository": "headscale/headscale",
+          "tag": "0.29.0-beta.1-debug",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "headscale",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 140,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "headscale",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/headscale/index.yaml",
+          "line": 906,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "heyform",
+      "image": "heyform/community-edition:v3.0.0-rc.7",
+      "repository": "heyform/community-edition",
+      "current_tag": "v3.0.0-rc.7",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "heyform",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/heyform/index.yaml",
+          "line": 271,
+          "key": "originImageName",
+          "image": "heyform/community-edition:v3.0.0-rc.7",
+          "repository": "heyform/community-edition",
+          "tag": "v3.0.0-rc.7",
+          "digest": null
+        },
+        {
+          "template": "heyform",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/heyform/index.yaml",
+          "line": 293,
+          "key": "image",
+          "image": "heyform/community-edition:v3.0.0-rc.7",
+          "repository": "heyform/community-edition",
+          "tag": "v3.0.0-rc.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "illa-builder",
+      "image": "illasoft/illa-builder:v4.8.2",
+      "repository": "illasoft/illa-builder",
+      "current_tag": "v4.8.2",
+      "candidate_tag": "v4.8.5",
+      "candidate_image": "illasoft/illa-builder:v4.8.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "illa-builder",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "illasoft/illa-builder:v4.8.2",
+          "repository": "illasoft/illa-builder",
+          "tag": "v4.8.2",
+          "digest": null
+        },
+        {
+          "template": "illa-builder",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/illa-builder/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "illasoft/illa-builder:v4.8.2",
+          "repository": "illasoft/illa-builder",
+          "tag": "v4.8.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+      "repository": "ghcr.io/immich-app/immich-machine-learning",
+      "current_tag": "v2.7.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 506,
+          "key": "originImageName",
+          "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-machine-learning",
+          "tag": "v2.7.5",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 529,
+          "key": "image",
+          "image": "ghcr.io/immich-app/immich-machine-learning:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-machine-learning",
+          "tag": "v2.7.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+      "repository": "ghcr.io/immich-app/immich-server",
+      "current_tag": "v2.7.5",
+      "candidate_tag": "v3.0.1",
+      "candidate_image": "ghcr.io/immich-app/immich-server:v3.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 319,
+          "key": "originImageName",
+          "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-server",
+          "tag": "v2.7.5",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 388,
+          "key": "image",
+          "image": "ghcr.io/immich-app/immich-server:v2.7.5",
+          "repository": "ghcr.io/immich-app/immich-server",
+          "tag": "v2.7.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "immich",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 255,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "immich",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/immich/index.yaml",
+          "line": 342,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "influxdb",
+      "image": "docker.io/library/influxdb:2.9.1",
+      "repository": "docker.io/library/influxdb",
+      "current_tag": "2.9.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "influxdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/influxdb/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "docker.io/library/influxdb:2.9.1",
+          "repository": "docker.io/library/influxdb",
+          "tag": "2.9.1",
+          "digest": null
+        },
+        {
+          "template": "influxdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/influxdb/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "docker.io/library/influxdb:2.9.1",
+          "repository": "docker.io/library/influxdb",
+          "tag": "2.9.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "inpaint-web",
+      "image": "yangchuansheng/inpaint-web",
+      "repository": "yangchuansheng/inpaint-web",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "inpaint-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/inpaint-web/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "yangchuansheng/inpaint-web",
+          "repository": "yangchuansheng/inpaint-web",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "inpaint-web",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/inpaint-web/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "yangchuansheng/inpaint-web",
+          "repository": "yangchuansheng/inpaint-web",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "apecloud/kubeblocks-tools:0.9.3",
+      "repository": "apecloud/kubeblocks-tools",
+      "current_tag": "0.9.3",
+      "candidate_tag": "1.0.2",
+      "candidate_image": "apecloud/kubeblocks-tools:1.0.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "apecloud/kubeblocks-tools:0.9.3",
+          "repository": "apecloud/kubeblocks-tools",
+          "tag": "0.9.3",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 352,
+          "key": "image",
+          "image": "apecloud/kubeblocks-tools:0.9.3",
+          "repository": "apecloud/kubeblocks-tools",
+          "tag": "0.9.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+      "repository": "ghcr.io/insforge/deno-runtime",
+      "current_tag": "2.0.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 767,
+          "key": "originImageName",
+          "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+          "repository": "ghcr.io/insforge/deno-runtime",
+          "tag": "2.0.6",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 787,
+          "key": "image",
+          "image": "ghcr.io/insforge/deno-runtime:2.0.6",
+          "repository": "ghcr.io/insforge/deno-runtime",
+          "tag": "2.0.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+      "repository": "ghcr.io/insforge/insforge-oss",
+      "current_tag": "v2.1.8",
+      "candidate_tag": "v2.2.6",
+      "candidate_image": "ghcr.io/insforge/insforge-oss:v2.2.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 420,
+          "key": "originImageName",
+          "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "repository": "ghcr.io/insforge/insforge-oss",
+          "tag": "v2.1.8",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 500,
+          "key": "image",
+          "image": "ghcr.io/insforge/insforge-oss:v2.1.8",
+          "repository": "ghcr.io/insforge/insforge-oss",
+          "tag": "v2.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 441,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "insforge",
+      "image": "postgrest/postgrest:v12.2.12",
+      "repository": "postgrest/postgrest",
+      "current_tag": "v12.2.12",
+      "candidate_tag": "v13.0.8",
+      "candidate_image": "postgrest/postgrest:v13.0.8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 675,
+          "key": "originImageName",
+          "image": "postgrest/postgrest:v12.2.12",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.2.12",
+          "digest": null
+        },
+        {
+          "template": "insforge",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/insforge/index.yaml",
+          "line": 695,
+          "key": "image",
+          "image": "postgrest/postgrest:v12.2.12",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.2.12",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "it-tools",
+      "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+      "repository": "ghcr.io/corentinth/it-tools",
+      "current_tag": "2024.5.13-a0bc346",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "it-tools",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/it-tools/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+          "repository": "ghcr.io/corentinth/it-tools",
+          "tag": "2024.5.13-a0bc346",
+          "digest": null
+        },
+        {
+          "template": "it-tools",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/it-tools/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "ghcr.io/corentinth/it-tools:2024.5.13-a0bc346",
+          "repository": "ghcr.io/corentinth/it-tools",
+          "tag": "2024.5.13-a0bc346",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "jellyfin",
+      "image": "jellyfin/jellyfin:10.10.7",
+      "repository": "jellyfin/jellyfin",
+      "current_tag": "10.10.7",
+      "candidate_tag": "10.11.11",
+      "candidate_image": "jellyfin/jellyfin:10.11.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "jellyfin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jellyfin/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "jellyfin/jellyfin:10.10.7",
+          "repository": "jellyfin/jellyfin",
+          "tag": "10.10.7",
+          "digest": null
+        },
+        {
+          "template": "jellyfin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jellyfin/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "jellyfin/jellyfin:10.10.7",
+          "repository": "jellyfin/jellyfin",
+          "tag": "10.10.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "joplin",
+      "image": "joplin/server:3.7.1",
+      "repository": "joplin/server",
+      "current_tag": "3.7.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "joplin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/joplin/index.yaml",
+          "line": 183,
+          "key": "originImageName",
+          "image": "joplin/server:3.7.1",
+          "repository": "joplin/server",
+          "tag": "3.7.1",
+          "digest": null
+        },
+        {
+          "template": "joplin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/joplin/index.yaml",
+          "line": 244,
+          "key": "image",
+          "image": "joplin/server:3.7.1",
+          "repository": "joplin/server",
+          "tag": "3.7.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "joplin",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "joplin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/joplin/index.yaml",
+          "line": 133,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "joplin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/joplin/index.yaml",
+          "line": 204,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "jsoncrack",
+      "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+      "repository": "shokohsc/jsoncrack",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "jsoncrack",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jsoncrack/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+          "repository": "shokohsc/jsoncrack",
+          "tag": null,
+          "digest": "sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef"
+        },
+        {
+          "template": "jsoncrack",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/jsoncrack/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef",
+          "repository": "shokohsc/jsoncrack",
+          "tag": null,
+          "digest": "sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef"
+        }
+      ]
+    },
+    {
+      "template": "kanboard",
+      "image": "kanboard/kanboard:v1.2.50",
+      "repository": "kanboard/kanboard",
+      "current_tag": "v1.2.50",
+      "candidate_tag": "v1.2.52",
+      "candidate_image": "kanboard/kanboard:v1.2.52",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kanboard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml",
+          "line": 121,
+          "key": "originImageName",
+          "image": "kanboard/kanboard:v1.2.50",
+          "repository": "kanboard/kanboard",
+          "tag": "v1.2.50",
+          "digest": null
+        },
+        {
+          "template": "kanboard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kanboard/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "kanboard/kanboard:v1.2.50",
+          "repository": "kanboard/kanboard",
+          "tag": "v1.2.50",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "ghcr.io/usekaneo/api:1.1.8",
+      "repository": "ghcr.io/usekaneo/api",
+      "current_tag": "1.1.8",
+      "candidate_tag": "2.9.0",
+      "candidate_image": "ghcr.io/usekaneo/api:2.9.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+          "line": 170,
+          "key": "originImageName",
+          "image": "ghcr.io/usekaneo/api:1.1.8",
+          "repository": "ghcr.io/usekaneo/api",
+          "tag": "1.1.8",
+          "digest": null
+        },
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+          "line": 190,
+          "key": "image",
+          "image": "ghcr.io/usekaneo/api:1.1.8",
+          "repository": "ghcr.io/usekaneo/api",
+          "tag": "1.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "ghcr.io/usekaneo/web:1.1.8",
+      "repository": "ghcr.io/usekaneo/web",
+      "current_tag": "1.1.8",
+      "candidate_tag": "2.9.0",
+      "candidate_image": "ghcr.io/usekaneo/web:2.9.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "ghcr.io/usekaneo/web:1.1.8",
+          "repository": "ghcr.io/usekaneo/web",
+          "tag": "1.1.8",
+          "digest": null
+        },
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "ghcr.io/usekaneo/web:1.1.8",
+          "repository": "ghcr.io/usekaneo/web",
+          "tag": "1.1.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kaneo",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kaneo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kaneo/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keycloak",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml",
+          "line": 152,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keycloak",
+      "image": "quay.io/keycloak/keycloak:26.3.2",
+      "repository": "quay.io/keycloak/keycloak",
+      "current_tag": "26.3.2",
+      "candidate_tag": "26.6.4",
+      "candidate_image": "quay.io/keycloak/keycloak:26.6.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml",
+          "line": 177,
+          "key": "originImageName",
+          "image": "quay.io/keycloak/keycloak:26.3.2",
+          "repository": "quay.io/keycloak/keycloak",
+          "tag": "26.3.2",
+          "digest": null
+        },
+        {
+          "template": "keycloak",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keycloak/index.yaml",
+          "line": 198,
+          "key": "image",
+          "image": "quay.io/keycloak/keycloak:26.3.2",
+          "repository": "quay.io/keycloak/keycloak",
+          "tag": "26.3.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keystone",
+      "image": "node:22.22.1-alpine",
+      "repository": "node",
+      "current_tag": "22.22.1-alpine",
+      "candidate_tag": "26.4.0-alpine",
+      "candidate_image": "node:26.4.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+          "line": 479,
+          "key": "originImageName",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+          "line": 544,
+          "key": "image",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        },
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+          "line": 620,
+          "key": "image",
+          "image": "node:22.22.1-alpine",
+          "repository": "node",
+          "tag": "22.22.1-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "keystone",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "keystone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/keystone/index.yaml",
+          "line": 149,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kitten-tts",
+      "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+      "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+      "current_tag": "cpu-v1.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kitten-tts/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        },
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kitten-tts/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        },
+        {
+          "template": "kitten-tts",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kitten-tts/index.yaml",
+          "line": 76,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2",
+          "repository": "ghcr.io/yangchuansheng/kitten-tts-server",
+          "tag": "cpu-v1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kodcloud",
+      "image": "kodcloud/kodbox:latest",
+      "repository": "kodcloud/kodbox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kodcloud",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kodcloud/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "kodcloud/kodbox:latest",
+          "repository": "kodcloud/kodbox",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "kodcloud",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kodcloud/index.yaml",
+          "line": 67,
+          "key": "image",
+          "image": "kodcloud/kodbox:latest",
+          "repository": "kodcloud/kodbox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuboard",
+      "image": "eipwork/kuboard:v3",
+      "repository": "eipwork/kuboard",
+      "current_tag": "v3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kuboard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuboard/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "eipwork/kuboard:v3",
+          "repository": "eipwork/kuboard",
+          "tag": "v3",
+          "digest": null
+        },
+        {
+          "template": "kuboard",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuboard/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "eipwork/kuboard:v3",
+          "repository": "eipwork/kuboard",
+          "tag": "v3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuvasz",
+      "image": "kuvaszmonitoring/kuvasz:3.11.0",
+      "repository": "kuvaszmonitoring/kuvasz",
+      "current_tag": "3.11.0",
+      "candidate_tag": "4.0.1",
+      "candidate_image": "kuvaszmonitoring/kuvasz:4.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+          "line": 201,
+          "key": "originImageName",
+          "image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "repository": "kuvaszmonitoring/kuvasz",
+          "tag": "3.11.0",
+          "digest": null
+        },
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+          "line": 277,
+          "key": "image",
+          "image": "kuvaszmonitoring/kuvasz:3.11.0",
+          "repository": "kuvaszmonitoring/kuvasz",
+          "tag": "3.11.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "kuvasz",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "kuvasz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/kuvasz/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/laf-server:sha-ef30cd9",
+      "repository": "docker.io/lafyun/laf-server",
+      "current_tag": "sha-ef30cd9",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 209,
+          "key": "image",
+          "image": "docker.io/lafyun/laf-server:sha-ef30cd9",
+          "repository": "docker.io/lafyun/laf-server",
+          "tag": "sha-ef30cd9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/laf-web:sha-e9d012d",
+      "repository": "docker.io/lafyun/laf-web",
+      "current_tag": "sha-e9d012d",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 328,
+          "key": "image",
+          "image": "docker.io/lafyun/laf-web:sha-e9d012d",
+          "repository": "docker.io/lafyun/laf-web",
+          "tag": "sha-e9d012d",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/runtime-node-init:sha-67b3cd6",
+      "repository": "docker.io/lafyun/runtime-node-init",
+      "current_tag": "sha-67b3cd6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1418,
+          "key": "image",
+          "image": "docker.io/lafyun/runtime-node-init:sha-67b3cd6",
+          "repository": "docker.io/lafyun/runtime-node-init",
+          "tag": "sha-67b3cd6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/lafyun/runtime-node:sha-67b3cd6",
+      "repository": "docker.io/lafyun/runtime-node",
+      "current_tag": "sha-67b3cd6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1396,
+          "key": "image",
+          "image": "docker.io/lafyun/runtime-node:sha-67b3cd6",
+          "repository": "docker.io/lafyun/runtime-node",
+          "tag": "sha-67b3cd6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "docker.io/library/nginx:latest",
+      "repository": "docker.io/library/nginx",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1441,
+          "key": "image",
+          "image": "docker.io/library/nginx:latest",
+          "repository": "docker.io/library/nginx",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+      "repository": "quay.io/minio/mc",
+      "current_tag": "RELEASE.2022-11-07T23-47-39Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1094,
+          "key": "image",
+          "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+          "repository": "quay.io/minio/mc",
+          "tag": "RELEASE.2022-11-07T23-47-39Z",
+          "digest": null
+        },
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1148,
+          "key": "image",
+          "image": "quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z",
+          "repository": "quay.io/minio/mc",
+          "tag": "RELEASE.2022-11-07T23-47-39Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 975,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+      "repository": "quay.io/minio/minio",
+      "current_tag": "RELEASE.2023-03-22T06-36-24Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 1008,
+          "key": "image",
+          "image": "quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z",
+          "repository": "quay.io/minio/minio",
+          "tag": "RELEASE.2023-03-22T06-36-24Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "laf",
+      "image": "quay.io/prometheus/prometheus:v2.45.0",
+      "repository": "quay.io/prometheus/prometheus",
+      "current_tag": "v2.45.0",
+      "candidate_tag": "v3.13.0",
+      "candidate_image": "quay.io/prometheus/prometheus:v3.13.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "laf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/laf/index.yaml",
+          "line": 519,
+          "key": "image",
+          "image": "quay.io/prometheus/prometheus:v2.45.0",
+          "repository": "quay.io/prometheus/prometheus",
+          "tag": "v2.45.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langflow",
+      "image": "langflowai/langflow:1.9.5",
+      "repository": "langflowai/langflow",
+      "current_tag": "1.9.5",
+      "candidate_tag": "1.10.2",
+      "candidate_image": "langflowai/langflow:1.10.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langflow/index.yaml",
+          "line": 219,
+          "key": "originImageName",
+          "image": "langflowai/langflow:1.9.5",
+          "repository": "langflowai/langflow",
+          "tag": "1.9.5",
+          "digest": null
+        },
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langflow/index.yaml",
+          "line": 247,
+          "key": "image",
+          "image": "langflowai/langflow:1.9.5",
+          "repository": "langflowai/langflow",
+          "tag": "1.9.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langflow",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langflow/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "clickhouse/clickhouse-server:25.4.2",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.4.2",
+      "candidate_tag": "26.6.1",
+      "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 385,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 409,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+      "repository": "docker.io/langfuse/langfuse-worker",
+      "current_tag": "3.180.0",
+      "candidate_tag": "3.207.0",
+      "candidate_image": "docker.io/langfuse/langfuse-worker:3.207.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 528,
+          "key": "originImageName",
+          "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "repository": "docker.io/langfuse/langfuse-worker",
+          "tag": "3.180.0",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 622,
+          "key": "image",
+          "image": "docker.io/langfuse/langfuse-worker:3.180.0",
+          "repository": "docker.io/langfuse/langfuse-worker",
+          "tag": "3.180.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "docker.io/langfuse/langfuse:3.180.0",
+      "repository": "docker.io/langfuse/langfuse",
+      "current_tag": "3.180.0",
+      "candidate_tag": "3.207.0",
+      "candidate_image": "docker.io/langfuse/langfuse:3.207.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 786,
+          "key": "originImageName",
+          "image": "docker.io/langfuse/langfuse:3.180.0",
+          "repository": "docker.io/langfuse/langfuse",
+          "tag": "3.180.0",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 839,
+          "key": "image",
+          "image": "docker.io/langfuse/langfuse:3.180.0",
+          "repository": "docker.io/langfuse/langfuse",
+          "tag": "3.180.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+      "repository": "minio/minio",
+      "current_tag": "RELEASE.2025-09-07T16-13-09Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 1042,
+          "key": "originImageName",
+          "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+          "repository": "minio/minio",
+          "tag": "RELEASE.2025-09-07T16-13-09Z",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 1065,
+          "key": "image",
+          "image": "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+          "repository": "minio/minio",
+          "tag": "RELEASE.2025-09-07T16-13-09Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 184,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 550,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "langfuse",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 591,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "langfuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/langfuse/index.yaml",
+          "line": 808,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "librechat",
+      "image": "getmeili/meilisearch:v1.5",
+      "repository": "getmeili/meilisearch",
+      "current_tag": "v1.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+          "line": 260,
+          "key": "originImageName",
+          "image": "getmeili/meilisearch:v1.5",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.5",
+          "digest": null
+        },
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+          "line": 283,
+          "key": "image",
+          "image": "getmeili/meilisearch:v1.5",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "librechat",
+      "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+      "repository": "ghcr.io/danny-avila/librechat",
+      "current_tag": "v0.7.3",
+      "candidate_tag": "v0.8.7",
+      "candidate_image": "ghcr.io/danny-avila/librechat:v0.8.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "repository": "ghcr.io/danny-avila/librechat",
+          "tag": "v0.7.3",
+          "digest": null
+        },
+        {
+          "template": "librechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/librechat/index.yaml",
+          "line": 75,
+          "key": "image",
+          "image": "ghcr.io/danny-avila/librechat:v0.7.3",
+          "repository": "ghcr.io/danny-avila/librechat",
+          "tag": "v0.7.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+          "line": 99,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "docker.io/arey/mysql-client:latest",
+      "repository": "docker.io/arey/mysql-client",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+          "line": 712,
+          "key": "image",
+          "image": "docker.io/arey/mysql-client:latest",
+          "repository": "docker.io/arey/mysql-client",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "docker.io/labring4docker/php-custom:7.2-fpm",
+      "repository": "docker.io/labring4docker/php-custom",
+      "current_tag": "7.2-fpm",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "docker.io/labring4docker/php-custom:7.2-fpm",
+          "repository": "docker.io/labring4docker/php-custom",
+          "tag": "7.2-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "labring4docker/php-custom:7.2-fpm",
+      "repository": "labring4docker/php-custom",
+      "current_tag": "7.2-fpm",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+          "line": 78,
+          "key": "originImageName",
+          "image": "labring4docker/php-custom:7.2-fpm",
+          "repository": "labring4docker/php-custom",
+          "tag": "7.2-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "liebianbao",
+      "image": "nginx:1.25.2",
+      "repository": "nginx",
+      "current_tag": "1.25.2",
+      "candidate_tag": "1.31.2",
+      "candidate_image": "nginx:1.31.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "liebianbao",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/liebianbao/index.yaml",
+          "line": 253,
+          "key": "image",
+          "image": "nginx:1.25.2",
+          "repository": "nginx",
+          "tag": "1.25.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+          "line": 252,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "listmonk/listmonk:v6.1.0",
+      "repository": "listmonk/listmonk",
+      "current_tag": "v6.1.0",
+      "candidate_tag": "v6.2.0",
+      "candidate_image": "listmonk/listmonk:v6.2.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+          "line": 224,
+          "key": "originImageName",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        },
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+          "line": 274,
+          "key": "image",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        },
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+          "line": 343,
+          "key": "image",
+          "image": "listmonk/listmonk:v6.1.0",
+          "repository": "listmonk/listmonk",
+          "tag": "v6.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "listmonk",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "listmonk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/listmonk/index.yaml",
+          "line": 151,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "litellm",
+      "image": "litellm/litellm-database:v1.88.1",
+      "repository": "litellm/litellm-database",
+      "current_tag": "v1.88.1",
+      "candidate_tag": "v1.91.0",
+      "candidate_image": "litellm/litellm-database:v1.91.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "litellm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+          "line": 255,
+          "key": "originImageName",
+          "image": "litellm/litellm-database:v1.88.1",
+          "repository": "litellm/litellm-database",
+          "tag": "v1.88.1",
+          "digest": null
+        },
+        {
+          "template": "litellm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+          "line": 322,
+          "key": "image",
+          "image": "litellm/litellm-database:v1.88.1",
+          "repository": "litellm/litellm-database",
+          "tag": "v1.88.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "litellm",
+      "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z",
+      "repository": "minio/mc",
+      "current_tag": "RELEASE.2025-05-21T01-59-54Z",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "litellm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+          "line": 280,
+          "key": "image",
+          "image": "minio/mc:RELEASE.2025-05-21T01-59-54Z",
+          "repository": "minio/mc",
+          "tag": "RELEASE.2025-05-21T01-59-54Z",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "litellm",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "litellm",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/litellm/index.yaml",
+          "line": 199,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llama2-chinese",
+      "image": "luanshaotong/text-generation-webui-cpu:dev",
+      "repository": "luanshaotong/text-generation-webui-cpu",
+      "current_tag": "dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llama2-chinese",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llama2-chinese/index.yaml",
+          "line": 64,
+          "key": "originImageName",
+          "image": "luanshaotong/text-generation-webui-cpu:dev",
+          "repository": "luanshaotong/text-generation-webui-cpu",
+          "tag": "dev",
+          "digest": null
+        },
+        {
+          "template": "llama2-chinese",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llama2-chinese/index.yaml",
+          "line": 89,
+          "key": "image",
+          "image": "luanshaotong/text-generation-webui-cpu:dev",
+          "repository": "luanshaotong/text-generation-webui-cpu",
+          "tag": "dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llama3-8b-chinese",
+      "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+      "current_tag": "q4_k_m",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llama3-8b-chinese",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llama3-8b-chinese/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+          "tag": "q4_k_m",
+          "digest": null
+        },
+        {
+          "template": "llama3-8b-chinese",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llama3-8b-chinese/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese",
+          "tag": "q4_k_m",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-api",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-api:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 357,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-api",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 442,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-api:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-api",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-docs",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-docs:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 1195,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-docs",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 1217,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-docs:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-docs",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-gateway",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-gateway:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 590,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-gateway",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 716,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-gateway:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-gateway",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-ui",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-ui:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 1066,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-ui",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 1087,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-ui:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-ui",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+      "repository": "ghcr.io/theopenco/llmgateway-worker",
+      "current_tag": "v1.3.0",
+      "candidate_tag": "v1.7.0",
+      "candidate_image": "ghcr.io/theopenco/llmgateway-worker:v1.7.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 874,
+          "key": "originImageName",
+          "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-worker",
+          "tag": "v1.3.0",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 1001,
+          "key": "image",
+          "image": "ghcr.io/theopenco/llmgateway-worker:v1.3.0",
+          "repository": "ghcr.io/theopenco/llmgateway-worker",
+          "tag": "v1.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 378,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 611,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 652,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 896,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 937,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "llmgateway",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 419,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 693,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "llmgateway",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/llmgateway/index.yaml",
+          "line": 978,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat",
+      "image": "lobehub/lobe-chat:1.143.3",
+      "repository": "lobehub/lobe-chat",
+      "current_tag": "1.143.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "lobe-chat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat/index.yaml",
+          "line": 61,
+          "key": "originImageName",
+          "image": "lobehub/lobe-chat:1.143.3",
+          "repository": "lobehub/lobe-chat",
+          "tag": "1.143.3",
+          "digest": null
+        },
+        {
+          "template": "lobe-chat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat/index.yaml",
+          "line": 87,
+          "key": "image",
+          "image": "lobehub/lobe-chat:1.143.3",
+          "repository": "lobehub/lobe-chat",
+          "tag": "1.143.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat-db",
+      "image": "lobehub/lobe-chat-database:1.143.2",
+      "repository": "lobehub/lobe-chat-database",
+      "current_tag": "1.143.2",
+      "candidate_tag": "1.143.3",
+      "candidate_image": "lobehub/lobe-chat-database:1.143.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "lobehub/lobe-chat-database:1.143.2",
+          "repository": "lobehub/lobe-chat-database",
+          "tag": "1.143.2",
+          "digest": null
+        },
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "lobehub/lobe-chat-database:1.143.2",
+          "repository": "lobehub/lobe-chat-database",
+          "tag": "1.143.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "lobe-chat-db",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "lobe-chat-db",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/lobe-chat-db/index.yaml",
+          "line": 172,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "logto",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "logto",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+          "line": 127,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "logto",
+      "image": "svhd/logto:1.40.1",
+      "repository": "svhd/logto",
+      "current_tag": "1.40.1",
+      "candidate_tag": "1.41.0",
+      "candidate_image": "svhd/logto:1.41.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "logto",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+          "line": 179,
+          "key": "originImageName",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        },
+        {
+          "template": "logto",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+          "line": 204,
+          "key": "image",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        },
+        {
+          "template": "logto",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/logto/index.yaml",
+          "line": 253,
+          "key": "image",
+          "image": "svhd/logto:1.40.1",
+          "repository": "svhd/logto",
+          "tag": "1.40.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "loki",
+      "image": "busybox:1.37.0",
+      "repository": "busybox",
+      "current_tag": "1.37.0",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "loki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/loki/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "busybox:1.37.0",
+          "repository": "busybox",
+          "tag": "1.37.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "loki",
+      "image": "docker.io/grafana/loki:3.7.2",
+      "repository": "docker.io/grafana/loki",
+      "current_tag": "3.7.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "loki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/loki/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "docker.io/grafana/loki:3.7.2",
+          "repository": "docker.io/grafana/loki",
+          "tag": "3.7.2",
+          "digest": null
+        },
+        {
+          "template": "loki",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/loki/index.yaml",
+          "line": 77,
+          "key": "image",
+          "image": "docker.io/grafana/loki:3.7.2",
+          "repository": "docker.io/grafana/loki",
+          "tag": "3.7.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mage-ai",
+      "image": "mageai/mageai:0.9.79",
+      "repository": "mageai/mageai",
+      "current_tag": "0.9.79",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mage-ai/index.yaml",
+          "line": 211,
+          "key": "originImageName",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        },
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mage-ai/index.yaml",
+          "line": 233,
+          "key": "image",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        },
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mage-ai/index.yaml",
+          "line": 283,
+          "key": "image",
+          "image": "mageai/mageai:0.9.79",
+          "repository": "mageai/mageai",
+          "tag": "0.9.79",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mage-ai",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mage-ai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mage-ai/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+      "repository": "ghcr.io/mastodon/mastodon-streaming",
+      "current_tag": "v4.5.11",
+      "candidate_tag": "v4.6.3",
+      "candidate_image": "ghcr.io/mastodon/mastodon-streaming:v4.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 937,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon-streaming",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 1004,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon-streaming:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon-streaming",
+          "tag": "v4.5.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+      "repository": "ghcr.io/mastodon/mastodon",
+      "current_tag": "v4.5.11",
+      "candidate_tag": "v4.6.3",
+      "candidate_image": "ghcr.io/mastodon/mastodon:v4.6.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 455,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 572,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 639,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 753,
+          "key": "originImageName",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 817,
+          "key": "image",
+          "image": "ghcr.io/mastodon/mastodon:v4.5.11",
+          "repository": "ghcr.io/mastodon/mastodon",
+          "tag": "v4.5.11",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 598,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 776,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 963,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mastodon",
+      "image": "public.ecr.aws/docker/library/redis:7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mastodon",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mastodon/index.yaml",
+          "line": 434,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matomo",
+      "image": "matomo:5.10.0-apache",
+      "repository": "matomo",
+      "current_tag": "5.10.0-apache",
+      "candidate_tag": "5.11.2-apache",
+      "candidate_image": "matomo:5.11.2-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+          "line": 179,
+          "key": "originImageName",
+          "image": "matomo:5.10.0-apache",
+          "repository": "matomo",
+          "tag": "5.10.0-apache",
+          "digest": null
+        },
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+          "line": 201,
+          "key": "image",
+          "image": "matomo:5.10.0-apache",
+          "repository": "matomo",
+          "tag": "5.10.0-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matomo",
+      "image": "mysql:8.0.44",
+      "repository": "mysql",
+      "current_tag": "8.0.44",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "matomo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matomo/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "tag": "8.0.44",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "${{ defaults.app_name }}-api",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matrixgorilla/index.yaml",
+          "line": 79,
+          "key": "originImageName",
+          "image": "${{ defaults.app_name }}-api",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "${{ defaults.app_name }}-web",
+      "repository": null,
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "templated or unparseable image requires manual release check",
+      "evidence": "local parse",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matrixgorilla/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "${{ defaults.app_name }}-web",
+          "repository": null,
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest",
+      "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matrixgorilla/index.yaml",
+          "line": 101,
+          "key": "image",
+          "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest",
+          "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "matrixgorilla",
+      "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest",
+      "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "matrixgorilla",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/matrixgorilla/index.yaml",
+          "line": 58,
+          "key": "image",
+          "image": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest",
+          "repository": "registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 473,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 597,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "mautic/mautic:7.1.2-apache",
+      "repository": "mautic/mautic",
+      "current_tag": "7.1.2-apache",
+      "candidate_tag": "7.1.3-apache",
+      "candidate_image": "mautic/mautic:7.1.3-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 242,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 266,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 343,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 440,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 492,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 564,
+          "key": "originImageName",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        },
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 616,
+          "key": "image",
+          "image": "mautic/mautic:7.1.2-apache",
+          "repository": "mautic/mautic",
+          "tag": "7.1.2-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mautic",
+      "image": "mysql:8.4.2",
+      "repository": "mysql",
+      "current_tag": "8.4.2",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mautic",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mautic/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "mysql:8.4.2",
+          "repository": "mysql",
+          "tag": "8.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mazanoke",
+      "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+      "repository": "ghcr.io/civilblur/mazanoke",
+      "current_tag": "v1.1.6",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mazanoke",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mazanoke/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+          "repository": "ghcr.io/civilblur/mazanoke",
+          "tag": "v1.1.6",
+          "digest": null
+        },
+        {
+          "template": "mazanoke",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mazanoke/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "ghcr.io/civilblur/mazanoke:v1.1.6",
+          "repository": "ghcr.io/civilblur/mazanoke",
+          "tag": "v1.1.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "meilisearch",
+      "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+      "repository": "eyeix/meilisearch-ui",
+      "current_tag": "v0.15.1-lite",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+          "repository": "eyeix/meilisearch-ui",
+          "tag": "v0.15.1-lite",
+          "digest": null
+        },
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "eyeix/meilisearch-ui:v0.15.1-lite",
+          "repository": "eyeix/meilisearch-ui",
+          "tag": "v0.15.1-lite",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "meilisearch",
+      "image": "getmeili/meilisearch:v1.45.1",
+      "repository": "getmeili/meilisearch",
+      "current_tag": "v1.45.1",
+      "candidate_tag": "v1.49.0",
+      "candidate_image": "getmeili/meilisearch:v1.49.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+          "line": 44,
+          "key": "originImageName",
+          "image": "getmeili/meilisearch:v1.45.1",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.45.1",
+          "digest": null
+        },
+        {
+          "template": "meilisearch",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/meilisearch/index.yaml",
+          "line": 68,
+          "key": "image",
+          "image": "getmeili/meilisearch:v1.45.1",
+          "repository": "getmeili/meilisearch",
+          "tag": "v1.45.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "memos",
+      "image": "ghcr.io/usememos/memos:latest",
+      "repository": "ghcr.io/usememos/memos",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "memos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/memos/index.yaml",
+          "line": 39,
+          "key": "originImageName",
+          "image": "ghcr.io/usememos/memos:latest",
+          "repository": "ghcr.io/usememos/memos",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "memos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/memos/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "ghcr.io/usememos/memos:latest",
+          "repository": "ghcr.io/usememos/memos",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "metabase",
+      "image": "metabase/metabase:v0.61.3",
+      "repository": "metabase/metabase",
+      "current_tag": "v0.61.3",
+      "candidate_tag": "v0.62.3",
+      "candidate_image": "metabase/metabase:v0.62.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml",
+          "line": 171,
+          "key": "originImageName",
+          "image": "metabase/metabase:v0.61.3",
+          "repository": "metabase/metabase",
+          "tag": "v0.61.3",
+          "digest": null
+        },
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml",
+          "line": 194,
+          "key": "image",
+          "image": "metabase/metabase:v0.61.3",
+          "repository": "metabase/metabase",
+          "tag": "v0.61.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "metabase",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "metabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/metabase/index.yaml",
+          "line": 128,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "midjourney-ui",
+      "image": "erictik/midjourney-ui:1.1.47",
+      "repository": "erictik/midjourney-ui",
+      "current_tag": "1.1.47",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "midjourney-ui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/midjourney-ui/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "erictik/midjourney-ui:1.1.47",
+          "repository": "erictik/midjourney-ui",
+          "tag": "1.1.47",
+          "digest": null
+        },
+        {
+          "template": "midjourney-ui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/midjourney-ui/index.yaml",
+          "line": 82,
+          "key": "image",
+          "image": "erictik/midjourney-ui:1.1.47",
+          "repository": "erictik/midjourney-ui",
+          "tag": "1.1.47",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindoc",
+      "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+      "current_tag": "v2.2-beta.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindoc/index.yaml",
+          "line": 274,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+          "tag": "v2.2-beta.1",
+          "digest": null
+        },
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindoc/index.yaml",
+          "line": 299,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc",
+          "tag": "v2.2-beta.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindoc",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "mindoc",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindoc/index.yaml",
+          "line": 133,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindsdb",
+      "image": "mindsdb/mindsdb:v26.1.0",
+      "repository": "mindsdb/mindsdb",
+      "current_tag": "v26.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindsdb/index.yaml",
+          "line": 253,
+          "key": "originImageName",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindsdb/index.yaml",
+          "line": 323,
+          "key": "image",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindsdb/index.yaml",
+          "line": 365,
+          "key": "image",
+          "image": "mindsdb/mindsdb:v26.1.0",
+          "repository": "mindsdb/mindsdb",
+          "tag": "v26.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mindsdb",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindsdb/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "mindsdb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mindsdb/index.yaml",
+          "line": 276,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minecraft",
+      "image": "alpine:3.22.4",
+      "repository": "alpine",
+      "current_tag": "3.22.4",
+      "candidate_tag": "3.24.1",
+      "candidate_image": "alpine:3.24.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "alpine:3.22.4",
+          "repository": "alpine",
+          "tag": "3.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minecraft",
+      "image": "itzg/minecraft-server:2026.5.3-java25",
+      "repository": "itzg/minecraft-server",
+      "current_tag": "2026.5.3-java25",
+      "candidate_tag": "2026.7.0-java8",
+      "candidate_image": "itzg/minecraft-server:2026.7.0-java8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "itzg/minecraft-server:2026.5.3-java25",
+          "repository": "itzg/minecraft-server",
+          "tag": "2026.5.3-java25",
+          "digest": null
+        },
+        {
+          "template": "minecraft",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minecraft/index.yaml",
+          "line": 91,
+          "key": "image",
+          "image": "itzg/minecraft-server:2026.5.3-java25",
+          "repository": "itzg/minecraft-server",
+          "tag": "2026.5.3-java25",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "minio",
+      "image": "quay.io/minio/minio",
+      "repository": "quay.io/minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "minio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minio/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "minio",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/minio/index.yaml",
+          "line": 80,
+          "key": "image",
+          "image": "quay.io/minio/minio",
+          "repository": "quay.io/minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mlflow",
+      "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+      "repository": "ghcr.io/mlflow/mlflow",
+      "current_tag": "v3.12.0",
+      "candidate_tag": "v3.14.0",
+      "candidate_image": "ghcr.io/mlflow/mlflow:v3.14.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+          "line": 201,
+          "key": "originImageName",
+          "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "repository": "ghcr.io/mlflow/mlflow",
+          "tag": "v3.12.0",
+          "digest": null
+        },
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+          "line": 270,
+          "key": "image",
+          "image": "ghcr.io/mlflow/mlflow:v3.12.0",
+          "repository": "ghcr.io/mlflow/mlflow",
+          "tag": "v3.12.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mlflow",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+          "line": 151,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        },
+        {
+          "template": "mlflow",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mlflow/index.yaml",
+          "line": 222,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "moneyprinterturbo",
+      "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+      "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+      "current_tag": "20240510083200",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "moneyprinterturbo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/moneyprinterturbo/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+          "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+          "tag": "20240510083200",
+          "digest": null
+        },
+        {
+          "template": "moneyprinterturbo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/moneyprinterturbo/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200",
+          "repository": "ghcr.io/yangchuansheng/moneyprinterturbo",
+          "tag": "20240510083200",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "mongo-express",
+      "image": "mongo-express:1.0.2-20-alpine3.19",
+      "repository": "mongo-express",
+      "current_tag": "1.0.2-20-alpine3.19",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "mongo-express",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mongo-express/index.yaml",
+          "line": 127,
+          "key": "originImageName",
+          "image": "mongo-express:1.0.2-20-alpine3.19",
+          "repository": "mongo-express",
+          "tag": "1.0.2-20-alpine3.19",
+          "digest": null
+        },
+        {
+          "template": "mongo-express",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/mongo-express/index.yaml",
+          "line": 147,
+          "key": "image",
+          "image": "mongo-express:1.0.2-20-alpine3.19",
+          "repository": "mongo-express",
+          "tag": "1.0.2-20-alpine3.19",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 362,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 605,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "n8nio/n8n:2.22.4",
+      "repository": "n8nio/n8n",
+      "current_tag": "2.22.4",
+      "candidate_tag": "2.30.1",
+      "candidate_image": "n8nio/n8n:2.30.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 337,
+          "key": "originImageName",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 583,
+          "key": "originImageName",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 624,
+          "key": "image",
+          "image": "n8nio/n8n:2.22.4",
+          "repository": "n8nio/n8n",
+          "tag": "2.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "n8nio/runners:2.22.4",
+      "repository": "n8nio/runners",
+      "current_tag": "2.22.4",
+      "candidate_tag": "2.30.1",
+      "candidate_image": "n8nio/runners:2.30.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 522,
+          "key": "originImageName",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 544,
+          "key": "image",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 711,
+          "key": "originImageName",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        },
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 733,
+          "key": "image",
+          "image": "n8nio/runners:2.22.4",
+          "repository": "n8nio/runners",
+          "tag": "2.22.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "n8n",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "n8n",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/n8n/index.yaml",
+          "line": 296,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nacos",
+      "image": "mysql:8.0.44",
+      "repository": "mysql",
+      "current_tag": "8.0.44",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+          "line": 347,
+          "key": "image",
+          "image": "mysql:8.0.44",
+          "repository": "mysql",
+          "tag": "8.0.44",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nacos",
+      "image": "nacos/nacos-server:v3.2.2",
+      "repository": "nacos/nacos-server",
+      "current_tag": "v3.2.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+          "line": 410,
+          "key": "originImageName",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+          "line": 432,
+          "key": "image",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+          "line": 545,
+          "key": "originImageName",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        },
+        {
+          "template": "nacos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nacos/index.yaml",
+          "line": 567,
+          "key": "image",
+          "image": "nacos/nacos-server:v3.2.2",
+          "repository": "nacos/nacos-server",
+          "tag": "v3.2.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 261,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "heroiclabs/nakama:3.39.0",
+      "repository": "heroiclabs/nakama",
+      "current_tag": "3.39.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 237,
+          "key": "originImageName",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 327,
+          "key": "image",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 370,
+          "key": "image",
+          "image": "heroiclabs/nakama:3.39.0",
+          "repository": "heroiclabs/nakama",
+          "tag": "3.39.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nakama",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 187,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "nakama",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nakama/index.yaml",
+          "line": 278,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/dashboard:v2.38.1",
+      "repository": "netbirdio/dashboard",
+      "current_tag": "v2.38.1",
+      "candidate_tag": "v2.90.3",
+      "candidate_image": "netbirdio/dashboard:v2.90.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 150,
+          "key": "originImageName",
+          "image": "netbirdio/dashboard:v2.38.1",
+          "repository": "netbirdio/dashboard",
+          "tag": "v2.38.1",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 170,
+          "key": "image",
+          "image": "netbirdio/dashboard:v2.38.1",
+          "repository": "netbirdio/dashboard",
+          "tag": "v2.38.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/management:0.71.4",
+      "repository": "netbirdio/management",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.74.2",
+      "candidate_image": "netbirdio/management:0.74.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 217,
+          "key": "originImageName",
+          "image": "netbirdio/management:0.71.4",
+          "repository": "netbirdio/management",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 238,
+          "key": "image",
+          "image": "netbirdio/management:0.71.4",
+          "repository": "netbirdio/management",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/relay:0.71.4",
+      "repository": "netbirdio/relay",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.74.2",
+      "candidate_image": "netbirdio/relay:0.74.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 356,
+          "key": "originImageName",
+          "image": "netbirdio/relay:0.71.4",
+          "repository": "netbirdio/relay",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 376,
+          "key": "image",
+          "image": "netbirdio/relay:0.71.4",
+          "repository": "netbirdio/relay",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "netbird",
+      "image": "netbirdio/signal:0.71.4",
+      "repository": "netbirdio/signal",
+      "current_tag": "0.71.4",
+      "candidate_tag": "0.74.2",
+      "candidate_image": "netbirdio/signal:0.74.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 295,
+          "key": "originImageName",
+          "image": "netbirdio/signal:0.71.4",
+          "repository": "netbirdio/signal",
+          "tag": "0.71.4",
+          "digest": null
+        },
+        {
+          "template": "netbird",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/netbird/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "netbirdio/signal:0.71.4",
+          "repository": "netbirdio/signal",
+          "tag": "0.71.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "new-api",
+      "image": "calciumion/new-api:v0.13.2",
+      "repository": "calciumion/new-api",
+      "current_tag": "v0.13.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/new-api/index.yaml",
+          "line": 304,
+          "key": "originImageName",
+          "image": "calciumion/new-api:v0.13.2",
+          "repository": "calciumion/new-api",
+          "tag": "v0.13.2",
+          "digest": null
+        },
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/new-api/index.yaml",
+          "line": 326,
+          "key": "image",
+          "image": "calciumion/new-api:v0.13.2",
+          "repository": "calciumion/new-api",
+          "tag": "v0.13.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "new-api",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "new-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/new-api/index.yaml",
+          "line": 252,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nexus",
+      "image": "alpine:3.22.2",
+      "repository": "alpine",
+      "current_tag": "3.22.2",
+      "candidate_tag": "3.24.1",
+      "candidate_image": "alpine:3.24.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "alpine:3.22.2",
+          "repository": "alpine",
+          "tag": "3.22.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nexus",
+      "image": "sonatype/nexus3:3.92.3",
+      "repository": "sonatype/nexus3",
+      "current_tag": "3.92.3",
+      "candidate_tag": "3.93.2",
+      "candidate_image": "sonatype/nexus3:3.93.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "sonatype/nexus3:3.92.3",
+          "repository": "sonatype/nexus3",
+          "tag": "3.92.3",
+          "digest": null
+        },
+        {
+          "template": "nexus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nexus/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "sonatype/nexus3:3.92.3",
+          "repository": "sonatype/nexus3",
+          "tag": "3.92.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nocodb",
+      "image": "nocodb/nocodb:2026.05.2",
+      "repository": "nocodb/nocodb",
+      "current_tag": "2026.05.2",
+      "candidate_tag": "2026.06.2",
+      "candidate_image": "nocodb/nocodb:2026.06.2",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nocodb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml",
+          "line": 132,
+          "key": "originImageName",
+          "image": "nocodb/nocodb:2026.05.2",
+          "repository": "nocodb/nocodb",
+          "tag": "2026.05.2",
+          "digest": null
+        },
+        {
+          "template": "nocodb",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nocodb/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "nocodb/nocodb:2026.05.2",
+          "repository": "nocodb/nocodb",
+          "tag": "2026.05.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "node-red",
+      "image": "nodered/node-red:4.1.10",
+      "repository": "nodered/node-red",
+      "current_tag": "4.1.10",
+      "candidate_tag": "5.0.1",
+      "candidate_image": "nodered/node-red:5.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "node-red",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/node-red/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "nodered/node-red:4.1.10",
+          "repository": "nodered/node-red",
+          "tag": "4.1.10",
+          "digest": null
+        },
+        {
+          "template": "node-red",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/node-red/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "nodered/node-red:4.1.10",
+          "repository": "nodered/node-red",
+          "tag": "4.1.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "alpine/openssl:3.5.4",
+      "repository": "alpine/openssl",
+      "current_tag": "3.5.4",
+      "candidate_tag": "3.5.7",
+      "candidate_image": "alpine/openssl:3.5.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 210,
+          "key": "image",
+          "image": "alpine/openssl:3.5.4",
+          "repository": "alpine/openssl",
+          "tag": "3.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+      "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 189,
+          "key": "originImageName",
+          "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+          "tag": null,
+          "digest": "sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7"
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 273,
+          "key": "image",
+          "image": "ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-backend",
+          "tag": null,
+          "digest": "sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7"
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+      "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 427,
+          "key": "originImageName",
+          "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+          "tag": null,
+          "digest": "sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887"
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 448,
+          "key": "image",
+          "image": "ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887",
+          "repository": "ghcr.io/nofxaios/nofx/nofx-frontend",
+          "tag": null,
+          "digest": "sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887"
+        }
+      ]
+    },
+    {
+      "template": "nofx",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 136,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "nofx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nofx/index.yaml",
+          "line": 231,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "notifuse",
+      "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+      "repository": "notifuse/notifuse",
+      "current_tag": "v32.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/notifuse/index.yaml",
+          "line": 175,
+          "key": "originImageName",
+          "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+          "repository": "notifuse/notifuse",
+          "tag": "v32.1",
+          "digest": "sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb"
+        },
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/notifuse/index.yaml",
+          "line": 250,
+          "key": "image",
+          "image": "notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb",
+          "repository": "notifuse/notifuse",
+          "tag": "v32.1",
+          "digest": "sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb"
+        }
+      ]
+    },
+    {
+      "template": "notifuse",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/notifuse/index.yaml",
+          "line": 138,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "notifuse",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/notifuse/index.yaml",
+          "line": 196,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "nsfw",
+      "image": "ethandai4869/nsfw-auth",
+      "repository": "ethandai4869/nsfw-auth",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "nsfw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nsfw/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ethandai4869/nsfw-auth",
+          "repository": "ethandai4869/nsfw-auth",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "nsfw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/nsfw/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ethandai4869/nsfw-auth",
+          "repository": "ethandai4869/nsfw-auth",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "odoo",
+      "image": "odoo:18.0-20260609",
+      "repository": "odoo",
+      "current_tag": "18.0-20260609",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "odoo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odoo/index.yaml",
+          "line": 212,
+          "key": "originImageName",
+          "image": "odoo:18.0-20260609",
+          "repository": "odoo",
+          "tag": "18.0-20260609",
+          "digest": null
+        },
+        {
+          "template": "odoo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odoo/index.yaml",
+          "line": 238,
+          "key": "image",
+          "image": "odoo:18.0-20260609",
+          "repository": "odoo",
+          "tag": "18.0-20260609",
+          "digest": null
+        },
+        {
+          "template": "odoo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odoo/index.yaml",
+          "line": 301,
+          "key": "image",
+          "image": "odoo:18.0-20260609",
+          "repository": "odoo",
+          "tag": "18.0-20260609",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "odoo",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "odoo",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odoo/index.yaml",
+          "line": 138,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "odysseus",
+      "image": "chromadb/chroma:1.0.15",
+      "repository": "chromadb/chroma",
+      "current_tag": "1.0.15",
+      "candidate_tag": "1.5.9",
+      "candidate_image": "chromadb/chroma:1.5.9",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 73,
+          "key": "originImageName",
+          "image": "chromadb/chroma:1.0.15",
+          "repository": "chromadb/chroma",
+          "tag": "1.0.15",
+          "digest": null
+        },
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 94,
+          "key": "image",
+          "image": "chromadb/chroma:1.0.15",
+          "repository": "chromadb/chroma",
+          "tag": "1.0.15",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "odysseus",
+      "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+      "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+      "current_tag": "1.0.0",
+      "candidate_tag": "1.0.1",
+      "candidate_image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 272,
+          "key": "originImageName",
+          "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+          "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+          "tag": "1.0.0",
+          "digest": null
+        },
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 294,
+          "key": "image",
+          "image": "ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0",
+          "repository": "ghcr.io/pewdiepie-archdaemon/odysseus",
+          "tag": "1.0.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "odysseus",
+      "image": "searxng/searxng:2026.5.31-7159b8aed",
+      "repository": "searxng/searxng",
+      "current_tag": "2026.5.31-7159b8aed",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 169,
+          "key": "originImageName",
+          "image": "searxng/searxng:2026.5.31-7159b8aed",
+          "repository": "searxng/searxng",
+          "tag": "2026.5.31-7159b8aed",
+          "digest": null
+        },
+        {
+          "template": "odysseus",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/odysseus/index.yaml",
+          "line": 190,
+          "key": "image",
+          "image": "searxng/searxng:2026.5.31-7159b8aed",
+          "repository": "searxng/searxng",
+          "tag": "2026.5.31-7159b8aed",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "one-api",
+      "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+      "repository": "ghcr.io/songquanpeng/one-api",
+      "current_tag": "v0.6.10",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "one-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/one-api/index.yaml",
+          "line": 51,
+          "key": "originImageName",
+          "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+          "repository": "ghcr.io/songquanpeng/one-api",
+          "tag": "v0.6.10",
+          "digest": null
+        },
+        {
+          "template": "one-api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/one-api/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "ghcr.io/songquanpeng/one-api:v0.6.10",
+          "repository": "ghcr.io/songquanpeng/one-api",
+          "tag": "v0.6.10",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "open-design",
+      "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+      "repository": "docker.io/vanjayak/open-design",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-design/index.yaml",
+          "line": 101,
+          "key": "originImageName",
+          "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+          "repository": "docker.io/vanjayak/open-design",
+          "tag": null,
+          "digest": "sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13"
+        },
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-design/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13",
+          "repository": "docker.io/vanjayak/open-design",
+          "tag": null,
+          "digest": "sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13"
+        }
+      ]
+    },
+    {
+      "template": "open-design",
+      "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+      "repository": "nginxinc/nginx-unprivileged",
+      "current_tag": "1.25-alpine-slim",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-design/index.yaml",
+          "line": 222,
+          "key": "originImageName",
+          "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+          "repository": "nginxinc/nginx-unprivileged",
+          "tag": "1.25-alpine-slim",
+          "digest": null
+        },
+        {
+          "template": "open-design",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-design/index.yaml",
+          "line": 248,
+          "key": "image",
+          "image": "nginxinc/nginx-unprivileged:1.25-alpine-slim",
+          "repository": "nginxinc/nginx-unprivileged",
+          "tag": "1.25-alpine-slim",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "open-webui",
+      "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+      "repository": "ghcr.io/open-webui/open-webui",
+      "current_tag": "v0.5.4",
+      "candidate_tag": "v0.10.2",
+      "candidate_image": "ghcr.io/open-webui/open-webui:v0.10.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+          "line": 36,
+          "key": "originImageName",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        },
+        {
+          "template": "open-webui",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/open-webui/index.yaml",
+          "line": 74,
+          "key": "image",
+          "image": "ghcr.io/open-webui/open-webui:v0.5.4",
+          "repository": "ghcr.io/open-webui/open-webui",
+          "tag": "v0.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openagents",
+      "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+      "repository": "ghcr.io/openagents-org/openagents",
+      "current_tag": "sha-48764c0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openagents/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+          "repository": "ghcr.io/openagents-org/openagents",
+          "tag": "sha-48764c0",
+          "digest": null
+        },
+        {
+          "template": "openagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openagents/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "ghcr.io/openagents-org/openagents:sha-48764c0",
+          "repository": "ghcr.io/openagents-org/openagents",
+          "tag": "sha-48764c0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openai-proxy",
+      "image": "unickcheng/openai-proxy",
+      "repository": "unickcheng/openai-proxy",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openai-proxy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openai-proxy/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "unickcheng/openai-proxy",
+          "repository": "unickcheng/openai-proxy",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "openai-proxy",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openai-proxy/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "unickcheng/openai-proxy",
+          "repository": "unickcheng/openai-proxy",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "opencart",
+      "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+      "repository": "ghcr.io/yangchuansheng/opencart",
+      "current_tag": "4.1.0.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "opencart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/opencart/index.yaml",
+          "line": 139,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+          "repository": "ghcr.io/yangchuansheng/opencart",
+          "tag": "4.1.0.3",
+          "digest": "sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94"
+        },
+        {
+          "template": "opencart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/opencart/index.yaml",
+          "line": 160,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94",
+          "repository": "ghcr.io/yangchuansheng/opencart",
+          "tag": "4.1.0.3",
+          "digest": "sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94"
+        }
+      ]
+    },
+    {
+      "template": "openclaw",
+      "image": "busybox:1.36",
+      "repository": "busybox",
+      "current_tag": "1.36",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+          "line": 85,
+          "key": "image",
+          "image": "busybox:1.36",
+          "repository": "busybox",
+          "tag": "1.36",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openclaw",
+      "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+      "repository": "ghcr.io/openclaw/openclaw",
+      "current_tag": "2026.3.8",
+      "candidate_tag": "2026.6.11",
+      "candidate_image": "ghcr.io/openclaw/openclaw:2026.6.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        },
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+          "line": 102,
+          "key": "image",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        },
+        {
+          "template": "openclaw",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openclaw/index.yaml",
+          "line": 160,
+          "key": "image",
+          "image": "ghcr.io/openclaw/openclaw:2026.3.8",
+          "repository": "ghcr.io/openclaw/openclaw",
+          "tag": "2026.3.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openhands",
+      "image": "ghcr.io/openhands/openhands:1.8.0",
+      "repository": "ghcr.io/openhands/openhands",
+      "current_tag": "1.8.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "openhands",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openhands/index.yaml",
+          "line": 51,
+          "key": "originImageName",
+          "image": "ghcr.io/openhands/openhands:1.8.0",
+          "repository": "ghcr.io/openhands/openhands",
+          "tag": "1.8.0",
+          "digest": null
+        },
+        {
+          "template": "openhands",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openhands/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "ghcr.io/openhands/openhands:1.8.0",
+          "repository": "ghcr.io/openhands/openhands",
+          "tag": "1.8.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openlist",
+      "image": "openlistteam/openlist:v4.0.9-aria2",
+      "repository": "openlistteam/openlist",
+      "current_tag": "v4.0.9-aria2",
+      "candidate_tag": "v4.2.3-aria2",
+      "candidate_image": "openlistteam/openlist:v4.2.3-aria2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openlist",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml",
+          "line": 49,
+          "key": "originImageName",
+          "image": "openlistteam/openlist:v4.0.9-aria2",
+          "repository": "openlistteam/openlist",
+          "tag": "v4.0.9-aria2",
+          "digest": null
+        },
+        {
+          "template": "openlist",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openlist/index.yaml",
+          "line": 72,
+          "key": "image",
+          "image": "openlistteam/openlist:v4.0.9-aria2",
+          "repository": "openlistteam/openlist",
+          "tag": "v4.0.9-aria2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "openobserve",
+      "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+      "repository": "public.ecr.aws/zinclabs/openobserve",
+      "current_tag": "v0.90.3",
+      "candidate_tag": "v0.91.1",
+      "candidate_image": "public.ecr.aws/zinclabs/openobserve:v0.91.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "openobserve",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openobserve/index.yaml",
+          "line": 68,
+          "key": "originImageName",
+          "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "repository": "public.ecr.aws/zinclabs/openobserve",
+          "tag": "v0.90.3",
+          "digest": null
+        },
+        {
+          "template": "openobserve",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/openobserve/index.yaml",
+          "line": 97,
+          "key": "image",
+          "image": "public.ecr.aws/zinclabs/openobserve:v0.90.3",
+          "repository": "public.ecr.aws/zinclabs/openobserve",
+          "tag": "v0.90.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "outline",
+      "image": "outlinewiki/outline:1.8.0-1",
+      "repository": "outlinewiki/outline",
+      "current_tag": "1.8.0-1",
+      "candidate_tag": "1.8.2-0",
+      "candidate_image": "outlinewiki/outline:1.8.2-0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "outline",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml",
+          "line": 427,
+          "key": "originImageName",
+          "image": "outlinewiki/outline:1.8.0-1",
+          "repository": "outlinewiki/outline",
+          "tag": "1.8.0-1",
+          "digest": null
+        },
+        {
+          "template": "outline",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml",
+          "line": 448,
+          "key": "image",
+          "image": "outlinewiki/outline:1.8.0-1",
+          "repository": "outlinewiki/outline",
+          "tag": "1.8.0-1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "outline",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "outline",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/outline/index.yaml",
+          "line": 384,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "overleaf",
+      "image": "sharelatex/sharelatex:6.1.2",
+      "repository": "sharelatex/sharelatex",
+      "current_tag": "6.1.2",
+      "candidate_tag": "6.2.1",
+      "candidate_image": "sharelatex/sharelatex:6.2.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "overleaf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml",
+          "line": 260,
+          "key": "originImageName",
+          "image": "sharelatex/sharelatex:6.1.2",
+          "repository": "sharelatex/sharelatex",
+          "tag": "6.1.2",
+          "digest": null
+        },
+        {
+          "template": "overleaf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/overleaf/index.yaml",
+          "line": 284,
+          "key": "image",
+          "image": "sharelatex/sharelatex:6.1.2",
+          "repository": "sharelatex/sharelatex",
+          "tag": "6.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pageplug",
+      "image": "cloudtogouser/pageplug-ce:v1.9.35",
+      "repository": "cloudtogouser/pageplug-ce",
+      "current_tag": "v1.9.35",
+      "candidate_tag": "v1.9.37",
+      "candidate_image": "cloudtogouser/pageplug-ce:v1.9.37",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pageplug",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "repository": "cloudtogouser/pageplug-ce",
+          "tag": "v1.9.35",
+          "digest": null
+        },
+        {
+          "template": "pageplug",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pageplug/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "cloudtogouser/pageplug-ce:v1.9.35",
+          "repository": "cloudtogouser/pageplug-ce",
+          "tag": "v1.9.35",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palacms",
+      "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+      "repository": "ghcr.io/palacms/palacms",
+      "current_tag": "v3.0.0-beta.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "2026/07/08 18:56:21 No matching credentials were found for \"ghcr.io\"\nError: reading tags for ghcr.io/palacms/palacms: GET https://ghcr.io/token?scope=repository%3Apalacms%2Fpalacms%3Apull&service=ghcr.io: DENIED: requested access to the resource is denied",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "palacms",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palacms/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+          "repository": "ghcr.io/palacms/palacms",
+          "tag": "v3.0.0-beta.1",
+          "digest": null
+        },
+        {
+          "template": "palacms",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palacms/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/palacms/palacms:v3.0.0-beta.1",
+          "repository": "ghcr.io/palacms/palacms",
+          "tag": "v3.0.0-beta.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld/index.yaml",
+          "line": 85,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "hurlenko/filebrowser",
+      "repository": "hurlenko/filebrowser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld/index.yaml",
+          "line": 158,
+          "key": "image",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld",
+      "image": "thijsvanloef/palworld-server-docker",
+      "repository": "thijsvanloef/palworld-server-docker",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld/index.yaml",
+          "line": 62,
+          "key": "originImageName",
+          "image": "thijsvanloef/palworld-server-docker",
+          "repository": "thijsvanloef/palworld-server-docker",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "palworld",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld/index.yaml",
+          "line": 103,
+          "key": "image",
+          "image": "thijsvanloef/palworld-server-docker",
+          "repository": "thijsvanloef/palworld-server-docker",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-autobackup",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-autobackup",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-autobackup/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-export",
+      "image": "bitnamilegacy/kubectl",
+      "repository": "bitnamilegacy/kubectl",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-export/index.yaml",
+          "line": 64,
+          "key": "image",
+          "image": "bitnamilegacy/kubectl",
+          "repository": "bitnamilegacy/kubectl",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-export",
+      "image": "hurlenko/filebrowser",
+      "repository": "hurlenko/filebrowser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-export/index.yaml",
+          "line": 42,
+          "key": "originImageName",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "palworld-export",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-export/index.yaml",
+          "line": 76,
+          "key": "image",
+          "image": "hurlenko/filebrowser",
+          "repository": "hurlenko/filebrowser",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "palworld-management",
+      "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+      "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+      "current_tag": "2024-02-18",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "palworld-management",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-management/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+          "tag": "2024-02-18",
+          "digest": null
+        },
+        {
+          "template": "palworld-management",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/palworld-management/index.yaml",
+          "line": 90,
+          "key": "image",
+          "image": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18",
+          "repository": "registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool",
+          "tag": "2024-02-18",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pangolin",
+      "image": "docker.io/fosrl/pangolin:1.15.2",
+      "repository": "docker.io/fosrl/pangolin",
+      "current_tag": "1.15.2",
+      "candidate_tag": "1.19.4",
+      "candidate_image": "docker.io/fosrl/pangolin:1.19.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pangolin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml",
+          "line": 102,
+          "key": "originImageName",
+          "image": "docker.io/fosrl/pangolin:1.15.2",
+          "repository": "docker.io/fosrl/pangolin",
+          "tag": "1.15.2",
+          "digest": null
+        },
+        {
+          "template": "pangolin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pangolin/index.yaml",
+          "line": 122,
+          "key": "image",
+          "image": "docker.io/fosrl/pangolin:1.15.2",
+          "repository": "docker.io/fosrl/pangolin",
+          "tag": "1.15.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+      "repository": "ghcr.io/paperclipai/paperclip",
+      "current_tag": "sha-b8725c5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 231,
+          "key": "originImageName",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 319,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 470,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 692,
+          "key": "image",
+          "image": "ghcr.io/paperclipai/paperclip:sha-b8725c5",
+          "repository": "ghcr.io/paperclipai/paperclip",
+          "tag": "sha-b8725c5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+      "repository": "public.ecr.aws/docker/library/busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "public.ecr.aws/docker/library/busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/busybox:1.36.1",
+          "repository": "public.ecr.aws/docker/library/busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperclip",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 178,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "paperclip",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperclip/index.yaml",
+          "line": 278,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperless-ngx",
+      "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+      "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperless-ngx/index.yaml",
+          "line": 318,
+          "key": "originImageName",
+          "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+          "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperless-ngx/index.yaml",
+          "line": 339,
+          "key": "image",
+          "image": "ghcr.io/paperless-ngx/paperless-ngx:latest",
+          "repository": "ghcr.io/paperless-ngx/paperless-ngx",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "paperless-ngx",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "paperless-ngx",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/paperless-ngx/index.yaml",
+          "line": 294,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "payload",
+      "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+      "repository": "ghcr.io/yangchuansheng/payload",
+      "current_tag": "3.82.1-a7dd17c9be0c",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "payload",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/payload/index.yaml",
+          "line": 178,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+          "repository": "ghcr.io/yangchuansheng/payload",
+          "tag": "3.82.1-a7dd17c9be0c",
+          "digest": null
+        },
+        {
+          "template": "payload",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/payload/index.yaml",
+          "line": 200,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c",
+          "repository": "ghcr.io/yangchuansheng/payload",
+          "tag": "3.82.1-a7dd17c9be0c",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "payload",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "payload",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/payload/index.yaml",
+          "line": 134,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pdf2zh",
+      "image": "byaidu/pdf2zh:1.9.6",
+      "repository": "byaidu/pdf2zh",
+      "current_tag": "1.9.6",
+      "candidate_tag": "1.9.11",
+      "candidate_image": "byaidu/pdf2zh:1.9.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pdf2zh",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "byaidu/pdf2zh:1.9.6",
+          "repository": "byaidu/pdf2zh",
+          "tag": "1.9.6",
+          "digest": null
+        },
+        {
+          "template": "pdf2zh",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pdf2zh/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "byaidu/pdf2zh:1.9.6",
+          "repository": "byaidu/pdf2zh",
+          "tag": "1.9.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/backend:2.1.2",
+      "repository": "penpotapp/backend",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.2",
+      "candidate_image": "penpotapp/backend:2.16.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 281,
+          "key": "originImageName",
+          "image": "penpotapp/backend:2.1.2",
+          "repository": "penpotapp/backend",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 307,
+          "key": "image",
+          "image": "penpotapp/backend:2.1.2",
+          "repository": "penpotapp/backend",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/exporter:2.1.2",
+      "repository": "penpotapp/exporter",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.2",
+      "candidate_image": "penpotapp/exporter:2.16.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 422,
+          "key": "originImageName",
+          "image": "penpotapp/exporter:2.1.2",
+          "repository": "penpotapp/exporter",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 447,
+          "key": "image",
+          "image": "penpotapp/exporter:2.1.2",
+          "repository": "penpotapp/exporter",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "penpotapp/frontend:2.1.2",
+      "repository": "penpotapp/frontend",
+      "current_tag": "2.1.2",
+      "candidate_tag": "2.16.2",
+      "candidate_image": "penpotapp/frontend:2.16.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 496,
+          "key": "originImageName",
+          "image": "penpotapp/frontend:2.1.2",
+          "repository": "penpotapp/frontend",
+          "tag": "2.1.2",
+          "digest": null
+        },
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 523,
+          "key": "image",
+          "image": "penpotapp/frontend:2.1.2",
+          "repository": "penpotapp/frontend",
+          "tag": "2.1.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "penpot",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "penpot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/penpot/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "perplexica",
+      "image": "itzcrazykns1337/perplexica:v1.10.2",
+      "repository": "itzcrazykns1337/perplexica",
+      "current_tag": "v1.10.2",
+      "candidate_tag": "v1.12.0",
+      "candidate_image": "itzcrazykns1337/perplexica:v1.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+          "line": 261,
+          "key": "originImageName",
+          "image": "itzcrazykns1337/perplexica:v1.10.2",
+          "repository": "itzcrazykns1337/perplexica",
+          "tag": "v1.10.2",
+          "digest": null
+        },
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+          "line": 284,
+          "key": "image",
+          "image": "itzcrazykns1337/perplexica:v1.10.2",
+          "repository": "itzcrazykns1337/perplexica",
+          "tag": "v1.10.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "perplexica",
+      "image": "searxng/searxng:2025.2.20-28d1240fc",
+      "repository": "searxng/searxng",
+      "current_tag": "2025.2.20-28d1240fc",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "searxng/searxng:2025.2.20-28d1240fc",
+          "repository": "searxng/searxng",
+          "tag": "2025.2.20-28d1240fc",
+          "digest": null
+        },
+        {
+          "template": "perplexica",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/perplexica/index.yaml",
+          "line": 158,
+          "key": "image",
+          "image": "searxng/searxng:2025.2.20-28d1240fc",
+          "repository": "searxng/searxng",
+          "tag": "2025.2.20-28d1240fc",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pgadmin4",
+      "image": "dpage/pgadmin4:8.9",
+      "repository": "dpage/pgadmin4",
+      "current_tag": "8.9",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "pgadmin4",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pgadmin4/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "dpage/pgadmin4:8.9",
+          "repository": "dpage/pgadmin4",
+          "tag": "8.9",
+          "digest": null
+        },
+        {
+          "template": "pgadmin4",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pgadmin4/index.yaml",
+          "line": 65,
+          "key": "image",
+          "image": "dpage/pgadmin4:8.9",
+          "repository": "dpage/pgadmin4",
+          "tag": "8.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "photoprism",
+      "image": "photoprism/photoprism:240711",
+      "repository": "photoprism/photoprism",
+      "current_tag": "240711",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "photoprism",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/photoprism/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "photoprism/photoprism:240711",
+          "repository": "photoprism/photoprism",
+          "tag": "240711",
+          "digest": null
+        },
+        {
+          "template": "photoprism",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/photoprism/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "photoprism/photoprism:240711",
+          "repository": "photoprism/photoprism",
+          "tag": "240711",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "phpmyadmin",
+      "image": "phpmyadmin:5.2.1",
+      "repository": "phpmyadmin",
+      "current_tag": "5.2.1",
+      "candidate_tag": "5.2.3",
+      "candidate_image": "phpmyadmin:5.2.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "phpmyadmin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "phpmyadmin:5.2.1",
+          "repository": "phpmyadmin",
+          "tag": "5.2.1",
+          "digest": null
+        },
+        {
+          "template": "phpmyadmin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/phpmyadmin/index.yaml",
+          "line": 55,
+          "key": "image",
+          "image": "phpmyadmin:5.2.1",
+          "repository": "phpmyadmin",
+          "tag": "5.2.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-admin:v0.22-dev",
+      "repository": "makeplane/plane-admin",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 433,
+          "key": "originImageName",
+          "image": "makeplane/plane-admin:v0.22-dev",
+          "repository": "makeplane/plane-admin",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 458,
+          "key": "image",
+          "image": "makeplane/plane-admin:v0.22-dev",
+          "repository": "makeplane/plane-admin",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-backend:v0.22-dev",
+      "repository": "makeplane/plane-backend",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 511,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 536,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 678,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 703,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 820,
+          "key": "originImageName",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 845,
+          "key": "image",
+          "image": "makeplane/plane-backend:v0.22-dev",
+          "repository": "makeplane/plane-backend",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-frontend:v0.22-dev",
+      "repository": "makeplane/plane-frontend",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 1037,
+          "key": "originImageName",
+          "image": "makeplane/plane-frontend:v0.22-dev",
+          "repository": "makeplane/plane-frontend",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 1062,
+          "key": "image",
+          "image": "makeplane/plane-frontend:v0.22-dev",
+          "repository": "makeplane/plane-frontend",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "makeplane/plane-space:v0.22-dev",
+      "repository": "makeplane/plane-space",
+      "current_tag": "v0.22-dev",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 962,
+          "key": "originImageName",
+          "image": "makeplane/plane-space:v0.22-dev",
+          "repository": "makeplane/plane-space",
+          "tag": "v0.22-dev",
+          "digest": null
+        },
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 987,
+          "key": "image",
+          "image": "makeplane/plane-space:v0.22-dev",
+          "repository": "makeplane/plane-space",
+          "tag": "v0.22-dev",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plane",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "plane",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plane/index.yaml",
+          "line": 145,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml",
+          "line": 219,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "ghcr.io/plankanban/planka:2.1.1",
+      "repository": "ghcr.io/plankanban/planka",
+      "current_tag": "2.1.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml",
+          "line": 198,
+          "key": "originImageName",
+          "image": "ghcr.io/plankanban/planka:2.1.1",
+          "repository": "ghcr.io/plankanban/planka",
+          "tag": "2.1.1",
+          "digest": null
+        },
+        {
+          "template": "planka",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml",
+          "line": 249,
+          "key": "image",
+          "image": "ghcr.io/plankanban/planka:2.1.1",
+          "repository": "ghcr.io/plankanban/planka",
+          "tag": "2.1.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "planka",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "planka",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/planka/index.yaml",
+          "line": 153,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plausible",
+      "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "23.3.7.5-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plausible/index.yaml",
+          "line": 187,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "23.3.7.5-alpine",
+          "digest": null
+        },
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plausible/index.yaml",
+          "line": 208,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:23.3.7.5-alpine",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "23.3.7.5-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "plausible",
+      "image": "plausible/analytics:v2.0",
+      "repository": "plausible/analytics",
+      "current_tag": "v2.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plausible/index.yaml",
+          "line": 282,
+          "key": "originImageName",
+          "image": "plausible/analytics:v2.0",
+          "repository": "plausible/analytics",
+          "tag": "v2.0",
+          "digest": null
+        },
+        {
+          "template": "plausible",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/plausible/index.yaml",
+          "line": 307,
+          "key": "image",
+          "image": "plausible/analytics:v2.0",
+          "repository": "plausible/analytics",
+          "tag": "v2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocket-id",
+      "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+      "repository": "ghcr.io/pocket-id/pocket-id",
+      "current_tag": "v2.2.0",
+      "candidate_tag": "v2.9.0",
+      "candidate_image": "ghcr.io/pocket-id/pocket-id:v2.9.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pocket-id",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml",
+          "line": 40,
+          "key": "originImageName",
+          "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "repository": "ghcr.io/pocket-id/pocket-id",
+          "tag": "v2.2.0",
+          "digest": null
+        },
+        {
+          "template": "pocket-id",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocket-id/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "ghcr.io/pocket-id/pocket-id:v2.2.0",
+          "repository": "ghcr.io/pocket-id/pocket-id",
+          "tag": "v2.2.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocketbase",
+      "image": "adrianmusante/pocketbase:0.29.3",
+      "repository": "adrianmusante/pocketbase",
+      "current_tag": "0.29.3",
+      "candidate_tag": "0.39.5",
+      "candidate_image": "adrianmusante/pocketbase:0.39.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml",
+          "line": 58,
+          "key": "originImageName",
+          "image": "adrianmusante/pocketbase:0.29.3",
+          "repository": "adrianmusante/pocketbase",
+          "tag": "0.29.3",
+          "digest": null
+        },
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml",
+          "line": 87,
+          "key": "image",
+          "image": "adrianmusante/pocketbase:0.29.3",
+          "repository": "adrianmusante/pocketbase",
+          "tag": "0.29.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pocketbase",
+      "image": "busybox:latest",
+      "repository": "busybox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "pocketbase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pocketbase/index.yaml",
+          "line": 79,
+          "key": "image",
+          "image": "busybox:latest",
+          "repository": "busybox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "clickhouse/clickhouse-server:25.8.12.129",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.8.12.129",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1559,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.8.12.129",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.8.12.129",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1579,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.8.12.129",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.8.12.129",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+      "repository": "docker.redpanda.com/redpandadata/redpanda",
+      "current_tag": "v25.1.9",
+      "candidate_tag": "v26.1.12",
+      "candidate_image": "docker.redpanda.com/redpandadata/redpanda:v26.1.12",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 339,
+          "key": "originImageName",
+          "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "repository": "docker.redpanda.com/redpandadata/redpanda",
+          "tag": "v25.1.9",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 360,
+          "key": "image",
+          "image": "docker.redpanda.com/redpandadata/redpanda:v25.1.9",
+          "repository": "docker.redpanda.com/redpandadata/redpanda",
+          "tag": "v25.1.9",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+      "repository": "ghcr.io/posthog/posthog-node",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 968,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1005,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1068,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a",
+          "repository": "ghcr.io/posthog/posthog-node",
+          "tag": null,
+          "digest": "sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+      "repository": "ghcr.io/posthog/posthog/capture",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1302,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1322,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1359,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1379,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b",
+          "repository": "ghcr.io/posthog/posthog/capture",
+          "tag": null,
+          "digest": "sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+      "repository": "ghcr.io/posthog/posthog/feature-flags",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 988,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1414,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 1434,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65",
+          "repository": "ghcr.io/posthog/posthog/feature-flags",
+          "tag": null,
+          "digest": "sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65"
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+      "repository": "ghcr.io/posthog/posthog",
+      "current_tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 600,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 620,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 784,
+          "key": "originImageName",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 804,
+          "key": "image",
+          "image": "ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "repository": "ghcr.io/posthog/posthog",
+          "tag": "86d6812c7de75c6c869b935e17baf45bf295bfd5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 146,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "posthog",
+      "image": "zookeeper:3.9.3",
+      "repository": "zookeeper",
+      "current_tag": "3.9.3",
+      "candidate_tag": "3.9.5",
+      "candidate_image": "zookeeper:3.9.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 481,
+          "key": "originImageName",
+          "image": "zookeeper:3.9.3",
+          "repository": "zookeeper",
+          "tag": "3.9.3",
+          "digest": null
+        },
+        {
+          "template": "posthog",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/posthog/index.yaml",
+          "line": 502,
+          "key": "image",
+          "image": "zookeeper:3.9.3",
+          "repository": "zookeeper",
+          "tag": "3.9.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "busybox:1.36.1",
+      "repository": "busybox",
+      "current_tag": "1.36.1",
+      "candidate_tag": "1.38.0",
+      "candidate_image": "busybox:1.38.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 326,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 531,
+          "key": "image",
+          "image": "busybox:1.36.1",
+          "repository": "busybox",
+          "tag": "1.36.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "elasticsearch:7.17.27",
+      "repository": "elasticsearch",
+      "current_tag": "7.17.27",
+      "candidate_tag": "9.4.3",
+      "candidate_image": "elasticsearch:9.4.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 305,
+          "key": "originImageName",
+          "image": "elasticsearch:7.17.27",
+          "repository": "elasticsearch",
+          "tag": "7.17.27",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 341,
+          "key": "image",
+          "image": "elasticsearch:7.17.27",
+          "repository": "elasticsearch",
+          "tag": "7.17.27",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+      "repository": "ghcr.io/gitroomhq/postiz-app",
+      "current_tag": "v2.21.8",
+      "candidate_tag": "v2.21.10",
+      "candidate_image": "ghcr.io/gitroomhq/postiz-app:v2.21.10",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 510,
+          "key": "originImageName",
+          "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "repository": "ghcr.io/gitroomhq/postiz-app",
+          "tag": "v2.21.8",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 583,
+          "key": "image",
+          "image": "ghcr.io/gitroomhq/postiz-app:v2.21.8",
+          "repository": "ghcr.io/gitroomhq/postiz-app",
+          "tag": "v2.21.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "postiz",
+      "image": "temporalio/auto-setup:1.28.1",
+      "repository": "temporalio/auto-setup",
+      "current_tag": "1.28.1",
+      "candidate_tag": "1.29.7",
+      "candidate_image": "temporalio/auto-setup:1.29.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 400,
+          "key": "originImageName",
+          "image": "temporalio/auto-setup:1.28.1",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.28.1",
+          "digest": null
+        },
+        {
+          "template": "postiz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/postiz/index.yaml",
+          "line": 420,
+          "key": "image",
+          "image": "temporalio/auto-setup:1.28.1",
+          "repository": "temporalio/auto-setup",
+          "tag": "1.28.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "presenton",
+      "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+      "repository": "ghcr.io/presenton/presenton",
+      "current_tag": "v0.8.2-beta",
+      "candidate_tag": "v0.8.9-beta",
+      "candidate_image": "ghcr.io/presenton/presenton:v0.8.9-beta",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "presenton",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "repository": "ghcr.io/presenton/presenton",
+          "tag": "v0.8.2-beta",
+          "digest": null
+        },
+        {
+          "template": "presenton",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/presenton/index.yaml",
+          "line": 59,
+          "key": "image",
+          "image": "ghcr.io/presenton/presenton:v0.8.2-beta",
+          "repository": "ghcr.io/presenton/presenton",
+          "tag": "v0.8.2-beta",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "prestashop",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "prestashop",
+      "image": "prestashop/prestashop:9.1.3-apache",
+      "repository": "prestashop/prestashop",
+      "current_tag": "9.1.3-apache",
+      "candidate_tag": "9.1.4-apache",
+      "candidate_image": "prestashop/prestashop:9.1.4-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+          "line": 216,
+          "key": "originImageName",
+          "image": "prestashop/prestashop:9.1.3-apache",
+          "repository": "prestashop/prestashop",
+          "tag": "9.1.3-apache",
+          "digest": null
+        },
+        {
+          "template": "prestashop",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/prestashop/index.yaml",
+          "line": 237,
+          "key": "image",
+          "image": "prestashop/prestashop:9.1.3-apache",
+          "repository": "prestashop/prestashop",
+          "tag": "9.1.3-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml",
+          "line": 272,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "frooodle/privatebin:0.26.1-fat",
+      "repository": "frooodle/privatebin",
+      "current_tag": "0.26.1-fat",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/frooodle/privatebin: GET https://index.docker.io/v2/frooodle/privatebin/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:frooodle/privatebin Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml",
+          "line": 249,
+          "key": "originImageName",
+          "image": "frooodle/privatebin:0.26.1-fat",
+          "repository": "frooodle/privatebin",
+          "tag": "0.26.1-fat",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "privatebin",
+      "image": "ghcr.io/privatebin/fs:1.7.4",
+      "repository": "ghcr.io/privatebin/fs",
+      "current_tag": "1.7.4",
+      "candidate_tag": "2.0.4",
+      "candidate_image": "ghcr.io/privatebin/fs:2.0.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "privatebin",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/privatebin/index.yaml",
+          "line": 280,
+          "key": "image",
+          "image": "ghcr.io/privatebin/fs:1.7.4",
+          "repository": "ghcr.io/privatebin/fs",
+          "tag": "1.7.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+      "repository": "ghcr.io/pterodactyl/panel",
+      "current_tag": "v1.12.4",
+      "candidate_tag": "v1.14.1",
+      "candidate_image": "ghcr.io/pterodactyl/panel:v1.14.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 399,
+          "key": "image",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 545,
+          "key": "originImageName",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 677,
+          "key": "image",
+          "image": "ghcr.io/pterodactyl/panel:v1.12.4",
+          "repository": "ghcr.io/pterodactyl/panel",
+          "tag": "v1.12.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+      "repository": "public.ecr.aws/docker/library/mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "public.ecr.aws/docker/library/mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 183,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 568,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 636,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/mysql:8.0.30",
+          "repository": "public.ecr.aws/docker/library/mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "pterodactyl",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 368,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "pterodactyl",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/pterodactyl/index.yaml",
+          "line": 606,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "qinglong",
+      "image": "whyour/qinglong:latest",
+      "repository": "whyour/qinglong",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "qinglong",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/qinglong/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "whyour/qinglong:latest",
+          "repository": "whyour/qinglong",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "qinglong",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/qinglong/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "whyour/qinglong:latest",
+          "repository": "whyour/qinglong",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "python:3.12.8-alpine3.20",
+      "repository": "python",
+      "current_tag": "3.12.8-alpine3.20",
+      "candidate_tag": "3.14.6-alpine3.24",
+      "candidate_image": "python:3.14.6-alpine3.24",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+          "line": 541,
+          "key": "image",
+          "image": "python:3.12.8-alpine3.20",
+          "repository": "python",
+          "tag": "3.12.8-alpine3.20",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "quay",
+      "image": "quay.io/projectquay/quay:v3.9.8",
+      "repository": "quay.io/projectquay/quay",
+      "current_tag": "v3.9.8",
+      "candidate_tag": "v3.17.3",
+      "candidate_image": "quay.io/projectquay/quay:v3.17.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "quay",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+          "line": 301,
+          "key": "originImageName",
+          "image": "quay.io/projectquay/quay:v3.9.8",
+          "repository": "quay.io/projectquay/quay",
+          "tag": "v3.9.8",
+          "digest": null
+        },
+        {
+          "template": "quay",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/quay/index.yaml",
+          "line": 332,
+          "key": "image",
+          "image": "quay.io/projectquay/quay:v3.9.8",
+          "repository": "quay.io/projectquay/quay",
+          "tag": "v3.9.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rclone",
+      "image": "rclone/rclone:1.74.3",
+      "repository": "rclone/rclone",
+      "current_tag": "1.74.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "rclone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rclone/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "rclone/rclone:1.74.3",
+          "repository": "rclone/rclone",
+          "tag": "1.74.3",
+          "digest": null
+        },
+        {
+          "template": "rclone",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rclone/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "rclone/rclone:1.74.3",
+          "repository": "rclone/rclone",
+          "tag": "1.74.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "redisinsight",
+      "image": "redislabs/redisinsight:2.52",
+      "repository": "redislabs/redisinsight",
+      "current_tag": "2.52",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "redisinsight",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/redisinsight/index.yaml",
+          "line": 34,
+          "key": "originImageName",
+          "image": "redislabs/redisinsight:2.52",
+          "repository": "redislabs/redisinsight",
+          "tag": "2.52",
+          "digest": null
+        },
+        {
+          "template": "redisinsight",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/redisinsight/index.yaml",
+          "line": 54,
+          "key": "image",
+          "image": "redislabs/redisinsight:2.52",
+          "repository": "redislabs/redisinsight",
+          "tag": "2.52",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "mautic/mautic:5.2.3-fpm",
+      "repository": "mautic/mautic",
+      "current_tag": "5.2.3-fpm",
+      "candidate_tag": "7.1.3-fpm",
+      "candidate_image": "mautic/mautic:7.1.3-fpm",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 409,
+          "key": "image",
+          "image": "mautic/mautic:5.2.3-fpm",
+          "repository": "mautic/mautic",
+          "tag": "5.2.3-fpm",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/elasticsearch:7.10.2",
+      "repository": "reflyai/elasticsearch",
+      "current_tag": "7.10.2",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 386,
+          "key": "originImageName",
+          "image": "reflyai/elasticsearch:7.10.2",
+          "repository": "reflyai/elasticsearch",
+          "tag": "7.10.2",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 417,
+          "key": "image",
+          "image": "reflyai/elasticsearch:7.10.2",
+          "repository": "reflyai/elasticsearch",
+          "tag": "7.10.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/qdrant:v1.13.1",
+      "repository": "reflyai/qdrant",
+      "current_tag": "v1.13.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 305,
+          "key": "originImageName",
+          "image": "reflyai/qdrant:v1.13.1",
+          "repository": "reflyai/qdrant",
+          "tag": "v1.13.1",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 328,
+          "key": "image",
+          "image": "reflyai/qdrant:v1.13.1",
+          "repository": "reflyai/qdrant",
+          "tag": "v1.13.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+      "repository": "reflyai/refly-api",
+      "current_tag": "8d870210470801f62a4d2adb3423c947afddf400",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 479,
+          "key": "originImageName",
+          "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-api",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 504,
+          "key": "image",
+          "image": "reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-api",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+      "repository": "reflyai/refly-web",
+      "current_tag": "8d870210470801f62a4d2adb3423c947afddf400",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 824,
+          "key": "originImageName",
+          "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-web",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        },
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 849,
+          "key": "image",
+          "image": "reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400",
+          "repository": "reflyai/refly-web",
+          "tag": "8d870210470801f62a4d2adb3423c947afddf400",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "refly",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "refly",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/refly/index.yaml",
+          "line": 165,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "registry",
+      "image": "joxit/docker-registry-ui:2.5.6-debian",
+      "repository": "joxit/docker-registry-ui",
+      "current_tag": "2.5.6-debian",
+      "candidate_tag": "2.6.0-debian",
+      "candidate_image": "joxit/docker-registry-ui:2.6.0-debian",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "registry",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+          "line": 206,
+          "key": "originImageName",
+          "image": "joxit/docker-registry-ui:2.5.6-debian",
+          "repository": "joxit/docker-registry-ui",
+          "tag": "2.5.6-debian",
+          "digest": null
+        },
+        {
+          "template": "registry",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+          "line": 230,
+          "key": "image",
+          "image": "joxit/docker-registry-ui:2.5.6-debian",
+          "repository": "joxit/docker-registry-ui",
+          "tag": "2.5.6-debian",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "registry",
+      "image": "registry:2.8.3",
+      "repository": "registry",
+      "current_tag": "2.8.3",
+      "candidate_tag": "3.1.1",
+      "candidate_image": "registry:3.1.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "registry",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+          "line": 35,
+          "key": "originImageName",
+          "image": "registry:2.8.3",
+          "repository": "registry",
+          "tag": "2.8.3",
+          "digest": null
+        },
+        {
+          "template": "registry",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/registry/index.yaml",
+          "line": 57,
+          "key": "image",
+          "image": "registry:2.8.3",
+          "repository": "registry",
+          "tag": "2.8.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat",
+      "image": "mongo:6.0",
+      "repository": "mongo",
+      "current_tag": "6.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml",
+          "line": 132,
+          "key": "image",
+          "image": "mongo:6.0",
+          "repository": "mongo",
+          "tag": "6.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat",
+      "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+      "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "registry.rocket.chat/rocketchat/rocket.chat:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml",
+          "line": 183,
+          "key": "originImageName",
+          "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "registry.rocket.chat/rocketchat/rocket.chat:7.9.0",
+          "repository": "registry.rocket.chat/rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "mongo:6.0",
+      "repository": "mongo",
+      "current_tag": "6.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 130,
+          "key": "image",
+          "image": "mongo:6.0",
+          "repository": "mongo",
+          "tag": "6.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "nats:2.4-alpine",
+      "repository": "nats",
+      "current_tag": "2.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 332,
+          "key": "originImageName",
+          "image": "nats:2.4-alpine",
+          "repository": "nats",
+          "tag": "2.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 367,
+          "key": "image",
+          "image": "nats:2.4-alpine",
+          "repository": "nats",
+          "tag": "2.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "natsio/nats-server-config-reloader:0.6.3",
+      "repository": "natsio/nats-server-config-reloader",
+      "current_tag": "0.6.3",
+      "candidate_tag": "0.23.0",
+      "candidate_image": "natsio/nats-server-config-reloader:0.23.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 438,
+          "key": "image",
+          "image": "natsio/nats-server-config-reloader:0.6.3",
+          "repository": "natsio/nats-server-config-reloader",
+          "tag": "0.6.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/account-service:7.9.0",
+      "repository": "rocketchat/account-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "rocketchat/account-service:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 517,
+          "key": "originImageName",
+          "image": "rocketchat/account-service:7.9.0",
+          "repository": "rocketchat/account-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 542,
+          "key": "image",
+          "image": "rocketchat/account-service:7.9.0",
+          "repository": "rocketchat/account-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/authorization-service:7.9.0",
+      "repository": "rocketchat/authorization-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "rocketchat/authorization-service:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 606,
+          "key": "originImageName",
+          "image": "rocketchat/authorization-service:7.9.0",
+          "repository": "rocketchat/authorization-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 631,
+          "key": "image",
+          "image": "rocketchat/authorization-service:7.9.0",
+          "repository": "rocketchat/authorization-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/ddp-streamer-service:7.9.0",
+      "repository": "rocketchat/ddp-streamer-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "rocketchat/ddp-streamer-service:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 695,
+          "key": "originImageName",
+          "image": "rocketchat/ddp-streamer-service:7.9.0",
+          "repository": "rocketchat/ddp-streamer-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 720,
+          "key": "image",
+          "image": "rocketchat/ddp-streamer-service:7.9.0",
+          "repository": "rocketchat/ddp-streamer-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/presence-service:7.9.0",
+      "repository": "rocketchat/presence-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "rocketchat/presence-service:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 793,
+          "key": "originImageName",
+          "image": "rocketchat/presence-service:7.9.0",
+          "repository": "rocketchat/presence-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 818,
+          "key": "image",
+          "image": "rocketchat/presence-service:7.9.0",
+          "repository": "rocketchat/presence-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/rocket.chat:7.9.0",
+      "repository": "rocketchat/rocket.chat",
+      "current_tag": "7.9.0",
+      "candidate_tag": "8.6.0",
+      "candidate_image": "rocketchat/rocket.chat:8.6.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 224,
+          "key": "originImageName",
+          "image": "rocketchat/rocket.chat:7.9.0",
+          "repository": "rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 249,
+          "key": "image",
+          "image": "rocketchat/rocket.chat:7.9.0",
+          "repository": "rocketchat/rocket.chat",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rocketchat-micro",
+      "image": "rocketchat/stream-hub-service:7.9.0",
+      "repository": "rocketchat/stream-hub-service",
+      "current_tag": "7.9.0",
+      "candidate_tag": "7.13.9",
+      "candidate_image": "rocketchat/stream-hub-service:7.13.9",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 882,
+          "key": "originImageName",
+          "image": "rocketchat/stream-hub-service:7.9.0",
+          "repository": "rocketchat/stream-hub-service",
+          "tag": "7.9.0",
+          "digest": null
+        },
+        {
+          "template": "rocketchat-micro",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rocketchat-micro/index.yaml",
+          "line": 907,
+          "key": "image",
+          "image": "rocketchat/stream-hub-service:7.9.0",
+          "repository": "rocketchat/stream-hub-service",
+          "tag": "7.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rsshub",
+      "image": "browserless/chrome:1.61.1-chrome-stable",
+      "repository": "browserless/chrome",
+      "current_tag": "1.61.1-chrome-stable",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "browserless/chrome:1.61.1-chrome-stable",
+          "repository": "browserless/chrome",
+          "tag": "1.61.1-chrome-stable",
+          "digest": null
+        },
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+          "line": 157,
+          "key": "image",
+          "image": "browserless/chrome:1.61.1-chrome-stable",
+          "repository": "browserless/chrome",
+          "tag": "1.61.1-chrome-stable",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rsshub",
+      "image": "diygod/rsshub:2024-07-06",
+      "repository": "diygod/rsshub",
+      "current_tag": "2024-07-06",
+      "candidate_tag": "2026-07-08",
+      "candidate_image": "diygod/rsshub:2026-07-08",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+          "line": 46,
+          "key": "originImageName",
+          "image": "diygod/rsshub:2024-07-06",
+          "repository": "diygod/rsshub",
+          "tag": "2024-07-06",
+          "digest": null
+        },
+        {
+          "template": "rsshub",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rsshub/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "diygod/rsshub:2024-07-06",
+          "repository": "diygod/rsshub",
+          "tag": "2024-07-06",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustdesk",
+      "image": "rustdesk/rustdesk-server-s6:1.1.15",
+      "repository": "rustdesk/rustdesk-server-s6",
+      "current_tag": "1.1.15",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "rustdesk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rustdesk/index.yaml",
+          "line": 45,
+          "key": "originImageName",
+          "image": "rustdesk/rustdesk-server-s6:1.1.15",
+          "repository": "rustdesk/rustdesk-server-s6",
+          "tag": "1.1.15",
+          "digest": null
+        },
+        {
+          "template": "rustdesk",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rustdesk/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "rustdesk/rustdesk-server-s6:1.1.15",
+          "repository": "rustdesk/rustdesk-server-s6",
+          "tag": "1.1.15",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustfs",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rustfs/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rustfs",
+      "image": "rustfs/rustfs:latest",
+      "repository": "rustfs/rustfs",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rustfs/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "rustfs/rustfs:latest",
+          "repository": "rustfs/rustfs",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "rustfs",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rustfs/index.yaml",
+          "line": 114,
+          "key": "image",
+          "image": "rustfs/rustfs:latest",
+          "repository": "rustfs/rustfs",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "clickhouse/clickhouse-server:25.4.2",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.4.2",
+      "candidate_tag": "26.6.1",
+      "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 258,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 419,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.4.2",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.4.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+      "repository": "ghcr.io/rybbit-io/rybbit-backend",
+      "current_tag": "sha-aa404ba",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 392,
+          "key": "originImageName",
+          "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-backend",
+          "tag": "sha-aa404ba",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 464,
+          "key": "image",
+          "image": "ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-backend",
+          "tag": "sha-aa404ba",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+      "repository": "ghcr.io/rybbit-io/rybbit-client",
+      "current_tag": "sha-aa404ba",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 605,
+          "key": "originImageName",
+          "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-client",
+          "tag": "sha-aa404ba",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 632,
+          "key": "image",
+          "image": "ghcr.io/rybbit-io/rybbit-client:sha-aa404ba",
+          "repository": "ghcr.io/rybbit-io/rybbit-client",
+          "tag": "sha-aa404ba",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "rybbit",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 135,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "rybbit",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/rybbit/index.yaml",
+          "line": 432,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "alpine",
+      "repository": "alpine",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+          "line": 251,
+          "key": "image",
+          "image": "alpine",
+          "repository": "alpine",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+      "repository": "ghcr.io/stirling-tools/stirling-pdf",
+      "current_tag": "1.2.0-fat",
+      "candidate_tag": "2.14.1-fat",
+      "candidate_image": "ghcr.io/stirling-tools/stirling-pdf:2.14.1-fat",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+          "line": 228,
+          "key": "originImageName",
+          "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "repository": "ghcr.io/stirling-tools/stirling-pdf",
+          "tag": "1.2.0-fat",
+          "digest": null
+        },
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat",
+          "repository": "ghcr.io/stirling-tools/stirling-pdf",
+          "tag": "1.2.0-fat",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "s-pdf",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "s-pdf",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/s-pdf/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "samarium",
+      "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+      "repository": "ghcr.io/yangchuansheng/samarium",
+      "current_tag": "0.0.0-9514fcadb867",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/samarium/index.yaml",
+          "line": 142,
+          "key": "originImageName",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        },
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/samarium/index.yaml",
+          "line": 168,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        },
+        {
+          "template": "samarium",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/samarium/index.yaml",
+          "line": 332,
+          "key": "image",
+          "image": "ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867",
+          "repository": "ghcr.io/yangchuansheng/samarium",
+          "tag": "0.0.0-9514fcadb867",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "busybox",
+      "repository": "busybox",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 447,
+          "key": "image",
+          "image": "busybox",
+          "repository": "busybox",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "busybox:1.28",
+      "repository": "busybox",
+      "current_tag": "1.28",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 566,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 683,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 740,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 840,
+          "key": "image",
+          "image": "busybox:1.28",
+          "repository": "busybox",
+          "tag": "1.28",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "clickhouse/clickhouse-server:25.5.6",
+      "repository": "clickhouse/clickhouse-server",
+      "current_tag": "25.5.6",
+      "candidate_tag": "26.6.1",
+      "candidate_image": "clickhouse/clickhouse-server:26.6.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 524,
+          "key": "originImageName",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 548,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 570,
+          "key": "image",
+          "image": "clickhouse/clickhouse-server:25.5.6",
+          "repository": "clickhouse/clickhouse-server",
+          "tag": "25.5.6",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/signoz-otel-collector:v0.144.2",
+      "repository": "signoz/signoz-otel-collector",
+      "current_tag": "v0.144.2",
+      "candidate_tag": "v0.144.5",
+      "candidate_image": "signoz/signoz-otel-collector:v0.144.5",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 687,
+          "key": "image",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 821,
+          "key": "originImageName",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 844,
+          "key": "image",
+          "image": "signoz/signoz-otel-collector:v0.144.2",
+          "repository": "signoz/signoz-otel-collector",
+          "tag": "v0.144.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/signoz:v0.117.0",
+      "repository": "signoz/signoz",
+      "current_tag": "v0.117.0",
+      "candidate_tag": "v0.132.0",
+      "candidate_image": "signoz/signoz:v0.132.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 719,
+          "key": "originImageName",
+          "image": "signoz/signoz:v0.117.0",
+          "repository": "signoz/signoz",
+          "tag": "v0.117.0",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 744,
+          "key": "image",
+          "image": "signoz/signoz:v0.117.0",
+          "repository": "signoz/signoz",
+          "tag": "v0.117.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "signoz",
+      "image": "signoz/zookeeper:3.7.1",
+      "repository": "signoz/zookeeper",
+      "current_tag": "3.7.1",
+      "candidate_tag": "3.9.3",
+      "candidate_image": "signoz/zookeeper:3.9.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 421,
+          "key": "originImageName",
+          "image": "signoz/zookeeper:3.7.1",
+          "repository": "signoz/zookeeper",
+          "tag": "3.7.1",
+          "digest": null
+        },
+        {
+          "template": "signoz",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/signoz/index.yaml",
+          "line": 454,
+          "key": "image",
+          "image": "signoz/zookeeper:3.7.1",
+          "repository": "signoz/zookeeper",
+          "tag": "3.7.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sillytavern",
+      "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+      "repository": "ghcr.io/sillytavern/sillytavern",
+      "current_tag": "1.18.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sillytavern/index.yaml",
+          "line": 57,
+          "key": "originImageName",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        },
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sillytavern/index.yaml",
+          "line": 80,
+          "key": "image",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        },
+        {
+          "template": "sillytavern",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sillytavern/index.yaml",
+          "line": 154,
+          "key": "image",
+          "image": "ghcr.io/sillytavern/sillytavern:1.18.0",
+          "repository": "ghcr.io/sillytavern/sillytavern",
+          "tag": "1.18.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "skardi",
+      "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+      "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+      "current_tag": "0.3.0",
+      "candidate_tag": "0.4.0",
+      "candidate_image": "ghcr.io/skardilabs/skardi/skardi-server:0.4.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "skardi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml",
+          "line": 123,
+          "key": "originImageName",
+          "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+          "tag": "0.3.0",
+          "digest": null
+        },
+        {
+          "template": "skardi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/skardi/index.yaml",
+          "line": 143,
+          "key": "image",
+          "image": "ghcr.io/skardilabs/skardi/skardi-server:0.3.0",
+          "repository": "ghcr.io/skardilabs/skardi/skardi-server",
+          "tag": "0.3.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "stalwart",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+          "line": 156,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        },
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "stalwart",
+      "image": "stalwartlabs/stalwart:v0.16.7",
+      "repository": "stalwartlabs/stalwart",
+      "current_tag": "v0.16.7",
+      "candidate_tag": "v0.16.12",
+      "candidate_image": "stalwartlabs/stalwart:v0.16.12",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+          "line": 234,
+          "key": "originImageName",
+          "image": "stalwartlabs/stalwart:v0.16.7",
+          "repository": "stalwartlabs/stalwart",
+          "tag": "v0.16.7",
+          "digest": null
+        },
+        {
+          "template": "stalwart",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/stalwart/index.yaml",
+          "line": 302,
+          "key": "image",
+          "image": "stalwartlabs/stalwart:v0.16.7",
+          "repository": "stalwartlabs/stalwart",
+          "tag": "v0.16.7",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "steel-browser",
+      "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+      "repository": "ghcr.io/steel-dev/steel-browser",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "steel-browser",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/steel-browser/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+          "repository": "ghcr.io/steel-dev/steel-browser",
+          "tag": null,
+          "digest": "sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1"
+        },
+        {
+          "template": "steel-browser",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/steel-browser/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1",
+          "repository": "ghcr.io/steel-dev/steel-browser",
+          "tag": null,
+          "digest": "sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1"
+        }
+      ]
+    },
+    {
+      "template": "strapi",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "strapi",
+      "image": "vshadbolt/strapi:5.33.0",
+      "repository": "vshadbolt/strapi",
+      "current_tag": "5.33.0",
+      "candidate_tag": "5.50.0",
+      "candidate_image": "vshadbolt/strapi:5.50.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+          "line": 611,
+          "key": "originImageName",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        },
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+          "line": 632,
+          "key": "image",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        },
+        {
+          "template": "strapi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/strapi/index.yaml",
+          "line": 706,
+          "key": "image",
+          "image": "vshadbolt/strapi:5.33.0",
+          "repository": "vshadbolt/strapi",
+          "tag": "5.33.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sub2api",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml",
+          "line": 218,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "sub2api",
+      "image": "weishaw/sub2api:0.1.104",
+      "repository": "weishaw/sub2api",
+      "current_tag": "0.1.104",
+      "candidate_tag": "0.1.146",
+      "candidate_image": "weishaw/sub2api:0.1.146",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml",
+          "line": 368,
+          "key": "originImageName",
+          "image": "weishaw/sub2api:0.1.104",
+          "repository": "weishaw/sub2api",
+          "tag": "0.1.104",
+          "digest": null
+        },
+        {
+          "template": "sub2api",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/sub2api/index.yaml",
+          "line": 397,
+          "key": "image",
+          "image": "weishaw/sub2api:0.1.104",
+          "repository": "weishaw/sub2api",
+          "tag": "0.1.104",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "darthsim/imgproxy:v3.30.1",
+      "repository": "darthsim/imgproxy",
+      "current_tag": "v3.30.1",
+      "candidate_tag": "v4.0.11",
+      "candidate_image": "darthsim/imgproxy:v4.0.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1353,
+          "key": "originImageName",
+          "image": "darthsim/imgproxy:v3.30.1",
+          "repository": "darthsim/imgproxy",
+          "tag": "v3.30.1",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1373,
+          "key": "image",
+          "image": "darthsim/imgproxy:v3.30.1",
+          "repository": "darthsim/imgproxy",
+          "tag": "v3.30.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "kong:2.8.1",
+      "repository": "kong",
+      "current_tag": "2.8.1",
+      "candidate_tag": "3.9.3",
+      "candidate_image": "kong:3.9.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 848,
+          "key": "originImageName",
+          "image": "kong:2.8.1",
+          "repository": "kong",
+          "tag": "2.8.1",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 868,
+          "key": "image",
+          "image": "kong:2.8.1",
+          "repository": "kong",
+          "tag": "2.8.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "postgres:16.4",
+      "repository": "postgres",
+      "current_tag": "16.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 272,
+          "key": "image",
+          "image": "postgres:16.4",
+          "repository": "postgres",
+          "tag": "16.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+      "repository": "postgrest/postgrest",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "digest-only image requires manual release check",
+      "evidence": "image digest",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1061,
+          "key": "originImageName",
+          "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+          "repository": "postgrest/postgrest",
+          "tag": null,
+          "digest": "sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9"
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1081,
+          "key": "image",
+          "image": "postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9",
+          "repository": "postgrest/postgrest",
+          "tag": null,
+          "digest": "sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9"
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/edge-runtime:v1.70.3",
+      "repository": "supabase/edge-runtime",
+      "current_tag": "v1.70.3",
+      "candidate_tag": "v1.74.2",
+      "candidate_image": "supabase/edge-runtime:v1.74.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1492,
+          "key": "originImageName",
+          "image": "supabase/edge-runtime:v1.70.3",
+          "repository": "supabase/edge-runtime",
+          "tag": "v1.70.3",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1512,
+          "key": "image",
+          "image": "supabase/edge-runtime:v1.70.3",
+          "repository": "supabase/edge-runtime",
+          "tag": "v1.70.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/gotrue:v2.186.0",
+      "repository": "supabase/gotrue",
+      "current_tag": "v2.186.0",
+      "candidate_tag": "v2.192.0",
+      "candidate_image": "supabase/gotrue:v2.192.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 934,
+          "key": "originImageName",
+          "image": "supabase/gotrue:v2.186.0",
+          "repository": "supabase/gotrue",
+          "tag": "v2.186.0",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 954,
+          "key": "image",
+          "image": "supabase/gotrue:v2.186.0",
+          "repository": "supabase/gotrue",
+          "tag": "v2.186.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/logflare:1.31.2",
+      "repository": "supabase/logflare",
+      "current_tag": "1.31.2",
+      "candidate_tag": "1.46.0",
+      "candidate_image": "supabase/logflare:1.46.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1594,
+          "key": "originImageName",
+          "image": "supabase/logflare:1.31.2",
+          "repository": "supabase/logflare",
+          "tag": "1.31.2",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1614,
+          "key": "image",
+          "image": "supabase/logflare:1.31.2",
+          "repository": "supabase/logflare",
+          "tag": "1.31.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/postgres-meta:v0.95.2",
+      "repository": "supabase/postgres-meta",
+      "current_tag": "v0.95.2",
+      "candidate_tag": "v0.96.6",
+      "candidate_image": "supabase/postgres-meta:v0.96.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1430,
+          "key": "originImageName",
+          "image": "supabase/postgres-meta:v0.95.2",
+          "repository": "supabase/postgres-meta",
+          "tag": "v0.95.2",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1450,
+          "key": "image",
+          "image": "supabase/postgres-meta:v0.95.2",
+          "repository": "supabase/postgres-meta",
+          "tag": "v0.95.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/realtime:v2.76.5",
+      "repository": "supabase/realtime",
+      "current_tag": "v2.76.5",
+      "candidate_tag": "v2.112.9",
+      "candidate_image": "supabase/realtime:v2.112.9",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1133,
+          "key": "originImageName",
+          "image": "supabase/realtime:v2.76.5",
+          "repository": "supabase/realtime",
+          "tag": "v2.76.5",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1153,
+          "key": "image",
+          "image": "supabase/realtime:v2.76.5",
+          "repository": "supabase/realtime",
+          "tag": "v2.76.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/storage-api:v1.37.8",
+      "repository": "supabase/storage-api",
+      "current_tag": "v1.37.8",
+      "candidate_tag": "v1.64.0",
+      "candidate_image": "supabase/storage-api:v1.64.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1234,
+          "key": "originImageName",
+          "image": "supabase/storage-api:v1.37.8",
+          "repository": "supabase/storage-api",
+          "tag": "v1.37.8",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1254,
+          "key": "image",
+          "image": "supabase/storage-api:v1.37.8",
+          "repository": "supabase/storage-api",
+          "tag": "v1.37.8",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/studio:2026.02.16-sha-26c615c",
+      "repository": "supabase/studio",
+      "current_tag": "2026.02.16-sha-26c615c",
+      "candidate_tag": "2026.07.07-sha-a6a04f2",
+      "candidate_image": "supabase/studio:2026.07.07-sha-a6a04f2",
+      "action": "update",
+      "confidence": "medium",
+      "reason": "newer compatible date tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 707,
+          "key": "originImageName",
+          "image": "supabase/studio:2026.02.16-sha-26c615c",
+          "repository": "supabase/studio",
+          "tag": "2026.02.16-sha-26c615c",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 727,
+          "key": "image",
+          "image": "supabase/studio:2026.02.16-sha-26c615c",
+          "repository": "supabase/studio",
+          "tag": "2026.02.16-sha-26c615c",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "supabase/supavisor:2.7.4",
+      "repository": "supabase/supavisor",
+      "current_tag": "2.7.4",
+      "candidate_tag": "2.9.7",
+      "candidate_image": "supabase/supavisor:2.9.7",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1766,
+          "key": "originImageName",
+          "image": "supabase/supavisor:2.7.4",
+          "repository": "supabase/supavisor",
+          "tag": "2.7.4",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1786,
+          "key": "image",
+          "image": "supabase/supavisor:2.7.4",
+          "repository": "supabase/supavisor",
+          "tag": "2.7.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "supabase",
+      "image": "timberio/vector:0.53.0-alpine",
+      "repository": "timberio/vector",
+      "current_tag": "0.53.0-alpine",
+      "candidate_tag": "0.56.0-alpine",
+      "candidate_image": "timberio/vector:0.56.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1700,
+          "key": "originImageName",
+          "image": "timberio/vector:0.53.0-alpine",
+          "repository": "timberio/vector",
+          "tag": "0.53.0-alpine",
+          "digest": null
+        },
+        {
+          "template": "supabase",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/supabase/index.yaml",
+          "line": 1720,
+          "key": "image",
+          "image": "timberio/vector:0.53.0-alpine",
+          "repository": "timberio/vector",
+          "tag": "0.53.0-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "superset",
+      "image": "apachesuperset.docker.scarf.sh/apache/superset:6.1.0",
+      "repository": "apachesuperset.docker.scarf.sh/apache/superset",
+      "current_tag": "6.1.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "crane ls timed out after 20s",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "superset",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/superset/index.yaml",
+          "line": 471,
+          "key": "image",
+          "image": "apachesuperset.docker.scarf.sh/apache/superset:6.1.0",
+          "repository": "apachesuperset.docker.scarf.sh/apache/superset",
+          "tag": "6.1.0",
+          "digest": null
+        },
+        {
+          "template": "superset",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/superset/index.yaml",
+          "line": 551,
+          "key": "originImageName",
+          "image": "apachesuperset.docker.scarf.sh/apache/superset:6.1.0",
+          "repository": "apachesuperset.docker.scarf.sh/apache/superset",
+          "tag": "6.1.0",
+          "digest": null
+        },
+        {
+          "template": "superset",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/superset/index.yaml",
+          "line": 581,
+          "key": "image",
+          "image": "apachesuperset.docker.scarf.sh/apache/superset:6.1.0",
+          "repository": "apachesuperset.docker.scarf.sh/apache/superset",
+          "tag": "6.1.0",
+          "digest": null
+        },
+        {
+          "template": "superset",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/superset/index.yaml",
+          "line": 640,
+          "key": "image",
+          "image": "apachesuperset.docker.scarf.sh/apache/superset:6.1.0",
+          "repository": "apachesuperset.docker.scarf.sh/apache/superset",
+          "tag": "6.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "superset",
+      "image": "postgres:16.4-alpine",
+      "repository": "postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "superset",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/superset/index.yaml",
+          "line": 141,
+          "key": "image",
+          "image": "postgres:16.4-alpine",
+          "repository": "postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "surveyking",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+          "line": 129,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "surveyking",
+      "image": "surveyking/surveyking:v1.9.0",
+      "repository": "surveyking/surveyking",
+      "current_tag": "v1.9.0",
+      "candidate_tag": "v1.12.0",
+      "candidate_image": "surveyking/surveyking:v1.12.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+          "line": 170,
+          "key": "originImageName",
+          "image": "surveyking/surveyking:v1.9.0",
+          "repository": "surveyking/surveyking",
+          "tag": "v1.9.0",
+          "digest": null
+        },
+        {
+          "template": "surveyking",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/surveyking/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "surveyking/surveyking:v1.9.0",
+          "repository": "surveyking/surveyking",
+          "tag": "v1.9.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "syncthing",
+      "image": "syncthing/syncthing:2.1.1",
+      "repository": "syncthing/syncthing",
+      "current_tag": "2.1.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "syncthing",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/syncthing/index.yaml",
+          "line": 52,
+          "key": "originImageName",
+          "image": "syncthing/syncthing:2.1.1",
+          "repository": "syncthing/syncthing",
+          "tag": "2.1.1",
+          "digest": null
+        },
+        {
+          "template": "syncthing",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/syncthing/index.yaml",
+          "line": 81,
+          "key": "image",
+          "image": "syncthing/syncthing:2.1.1",
+          "repository": "syncthing/syncthing",
+          "tag": "2.1.1",
+          "digest": null
+        },
+        {
+          "template": "syncthing",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/syncthing/index.yaml",
+          "line": 115,
+          "key": "image",
+          "image": "syncthing/syncthing:2.1.1",
+          "repository": "syncthing/syncthing",
+          "tag": "2.1.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tailchat",
+      "image": "minio/minio",
+      "repository": "minio/minio",
+      "current_tag": null,
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+          "line": 267,
+          "key": "originImageName",
+          "image": "minio/minio",
+          "repository": "minio/minio",
+          "tag": null,
+          "digest": null
+        },
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+          "line": 289,
+          "key": "image",
+          "image": "minio/minio",
+          "repository": "minio/minio",
+          "tag": null,
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tailchat",
+      "image": "moonrailgun/tailchat:1.11.5",
+      "repository": "moonrailgun/tailchat",
+      "current_tag": "1.11.5",
+      "candidate_tag": "1.11.11",
+      "candidate_image": "moonrailgun/tailchat:1.11.11",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+          "line": 66,
+          "key": "originImageName",
+          "image": "moonrailgun/tailchat:1.11.5",
+          "repository": "moonrailgun/tailchat",
+          "tag": "1.11.5",
+          "digest": null
+        },
+        {
+          "template": "tailchat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tailchat/index.yaml",
+          "line": 86,
+          "key": "image",
+          "image": "moonrailgun/tailchat:1.11.5",
+          "repository": "moonrailgun/tailchat",
+          "tag": "1.11.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "teable",
+      "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+      "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "teable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/teable/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "teable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/teable/index.yaml",
+          "line": 69,
+          "key": "image",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "teable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/teable/index.yaml",
+          "line": 96,
+          "key": "image",
+          "image": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest",
+          "repository": "registry.cn-shenzhen.aliyuncs.com/teable/teable-ee",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "teable",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "teable",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/teable/index.yaml",
+          "line": 348,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tentix",
+      "image": "limbo2342/tentix:dev-2025-10-23-x.3",
+      "repository": "limbo2342/tentix",
+      "current_tag": "dev-2025-10-23-x.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tentix",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tentix/index.yaml",
+          "line": 211,
+          "key": "image",
+          "image": "limbo2342/tentix:dev-2025-10-23-x.3",
+          "repository": "limbo2342/tentix",
+          "tag": "dev-2025-10-23-x.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tentix",
+      "image": "limbo2342/tentix:migrate.10.22.x1",
+      "repository": "limbo2342/tentix",
+      "current_tag": "migrate.10.22.x1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tentix",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tentix/index.yaml",
+          "line": 188,
+          "key": "image",
+          "image": "limbo2342/tentix:migrate.10.22.x1",
+          "repository": "limbo2342/tentix",
+          "tag": "migrate.10.22.x1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tianji",
+      "image": "moonrailgun/tianji:1.18.5",
+      "repository": "moonrailgun/tianji",
+      "current_tag": "1.18.5",
+      "candidate_tag": "1.32.16",
+      "candidate_image": "moonrailgun/tianji:1.32.16",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "moonrailgun/tianji:1.18.5",
+          "repository": "moonrailgun/tianji",
+          "tag": "1.18.5",
+          "digest": null
+        },
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml",
+          "line": 74,
+          "key": "image",
+          "image": "moonrailgun/tianji:1.18.5",
+          "repository": "moonrailgun/tianji",
+          "tag": "1.18.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tianji",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "tianji",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tianji/index.yaml",
+          "line": 259,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tolgee",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml",
+          "line": 195,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tolgee",
+      "image": "tolgee/tolgee:v3.113.0",
+      "repository": "tolgee/tolgee",
+      "current_tag": "v3.113.0",
+      "candidate_tag": "v3.209.3",
+      "candidate_image": "tolgee/tolgee:v3.209.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml",
+          "line": 219,
+          "key": "originImageName",
+          "image": "tolgee/tolgee:v3.113.0",
+          "repository": "tolgee/tolgee",
+          "tag": "v3.113.0",
+          "digest": null
+        },
+        {
+          "template": "tolgee",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tolgee/index.yaml",
+          "line": 244,
+          "key": "image",
+          "image": "tolgee/tolgee:v3.113.0",
+          "repository": "tolgee/tolgee",
+          "tag": "v3.113.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "postgres:16-alpine",
+      "repository": "postgres",
+      "current_tag": "16-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 305,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 568,
+          "key": "image",
+          "image": "postgres:16-alpine",
+          "repository": "postgres",
+          "tag": "16-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "postgrest/postgrest:v12.0.2",
+      "repository": "postgrest/postgrest",
+      "current_tag": "v12.0.2",
+      "candidate_tag": "v13.0.8",
+      "candidate_image": "postgrest/postgrest:v13.0.8",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 455,
+          "key": "originImageName",
+          "image": "postgrest/postgrest:v12.0.2",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.0.2",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 475,
+          "key": "image",
+          "image": "postgrest/postgrest:v12.0.2",
+          "repository": "postgrest/postgrest",
+          "tag": "v12.0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tooljet",
+      "image": "tooljet/tooljet-ce:v3.20.170-lts",
+      "repository": "tooljet/tooljet-ce",
+      "current_tag": "v3.20.170-lts",
+      "candidate_tag": "v3.20.192-lts",
+      "candidate_image": "tooljet/tooljet-ce:v3.20.192-lts",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 548,
+          "key": "originImageName",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        },
+        {
+          "template": "tooljet",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tooljet/index.yaml",
+          "line": 616,
+          "key": "image",
+          "image": "tooljet/tooljet-ce:v3.20.170-lts",
+          "repository": "tooljet/tooljet-ce",
+          "tag": "v3.20.170-lts",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tradingagents",
+      "image": "alpine/git:2.49.1",
+      "repository": "alpine/git",
+      "current_tag": "2.49.1",
+      "candidate_tag": "2.54.0",
+      "candidate_image": "alpine/git:2.54.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tradingagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml",
+          "line": 244,
+          "key": "image",
+          "image": "alpine/git:2.49.1",
+          "repository": "alpine/git",
+          "tag": "2.49.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tradingagents",
+      "image": "python:3.12-slim",
+      "repository": "python",
+      "current_tag": "3.12-slim",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "tradingagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml",
+          "line": 219,
+          "key": "originImageName",
+          "image": "python:3.12-slim",
+          "repository": "python",
+          "tag": "3.12-slim",
+          "digest": null
+        },
+        {
+          "template": "tradingagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml",
+          "line": 272,
+          "key": "image",
+          "image": "python:3.12-slim",
+          "repository": "python",
+          "tag": "3.12-slim",
+          "digest": null
+        },
+        {
+          "template": "tradingagents",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tradingagents/index.yaml",
+          "line": 301,
+          "key": "image",
+          "image": "python:3.12-slim",
+          "repository": "python",
+          "tag": "3.12-slim",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "trendradar",
+      "image": "wantcat/trendradar:6.9.1",
+      "repository": "wantcat/trendradar",
+      "current_tag": "6.9.1",
+      "candidate_tag": "6.10.0",
+      "candidate_image": "wantcat/trendradar:6.10.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "trendradar",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/trendradar/index.yaml",
+          "line": 133,
+          "key": "originImageName",
+          "image": "wantcat/trendradar:6.9.1",
+          "repository": "wantcat/trendradar",
+          "tag": "6.9.1",
+          "digest": null
+        },
+        {
+          "template": "trendradar",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/trendradar/index.yaml",
+          "line": 154,
+          "key": "image",
+          "image": "wantcat/trendradar:6.9.1",
+          "repository": "wantcat/trendradar",
+          "tag": "6.9.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "tududi",
+      "image": "chrisvel/tududi:1.1.0",
+      "repository": "chrisvel/tududi",
+      "current_tag": "1.1.0",
+      "candidate_tag": "1.2.0",
+      "candidate_image": "chrisvel/tududi:1.2.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "tududi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml",
+          "line": 50,
+          "key": "originImageName",
+          "image": "chrisvel/tududi:1.1.0",
+          "repository": "chrisvel/tududi",
+          "tag": "1.1.0",
+          "digest": null
+        },
+        {
+          "template": "tududi",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/tududi/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "chrisvel/tududi:1.1.0",
+          "repository": "chrisvel/tududi",
+          "tag": "1.1.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "busybox:latest",
+      "repository": "busybox",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 337,
+          "key": "image",
+          "image": "busybox:latest",
+          "repository": "busybox",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "twenty",
+      "image": "twentycrm/twenty:v1.12.0",
+      "repository": "twentycrm/twenty",
+      "current_tag": "v1.12.0",
+      "candidate_tag": "v2.19.0",
+      "candidate_image": "twentycrm/twenty:v2.19.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 316,
+          "key": "originImageName",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 349,
+          "key": "image",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 452,
+          "key": "originImageName",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        },
+        {
+          "template": "twenty",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/twenty/index.yaml",
+          "line": 472,
+          "key": "image",
+          "image": "twentycrm/twenty:v1.12.0",
+          "repository": "twentycrm/twenty",
+          "tag": "v1.12.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "axllent/mailpit:v1.30.1",
+      "repository": "axllent/mailpit",
+      "current_tag": "v1.30.1",
+      "candidate_tag": "v1.30.3",
+      "candidate_image": "axllent/mailpit:v1.30.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 824,
+          "key": "originImageName",
+          "image": "axllent/mailpit:v1.30.1",
+          "repository": "axllent/mailpit",
+          "tag": "v1.30.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 846,
+          "key": "image",
+          "image": "axllent/mailpit:v1.30.1",
+          "repository": "axllent/mailpit",
+          "tag": "v1.30.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "baptistearno/typebot-builder:3.17.1",
+      "repository": "baptistearno/typebot-builder",
+      "current_tag": "3.17.1",
+      "candidate_tag": "3.17.2",
+      "candidate_image": "baptistearno/typebot-builder:3.17.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 431,
+          "key": "originImageName",
+          "image": "baptistearno/typebot-builder:3.17.1",
+          "repository": "baptistearno/typebot-builder",
+          "tag": "3.17.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 484,
+          "key": "image",
+          "image": "baptistearno/typebot-builder:3.17.1",
+          "repository": "baptistearno/typebot-builder",
+          "tag": "3.17.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "baptistearno/typebot-viewer:3.17.1",
+      "repository": "baptistearno/typebot-viewer",
+      "current_tag": "3.17.1",
+      "candidate_tag": "3.17.2",
+      "candidate_image": "baptistearno/typebot-viewer:3.17.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 656,
+          "key": "originImageName",
+          "image": "baptistearno/typebot-viewer:3.17.1",
+          "repository": "baptistearno/typebot-viewer",
+          "tag": "3.17.1",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 709,
+          "key": "image",
+          "image": "baptistearno/typebot-viewer:3.17.1",
+          "repository": "baptistearno/typebot-viewer",
+          "tag": "3.17.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 265,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typebot",
+      "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+      "repository": "public.ecr.aws/docker/library/redis",
+      "current_tag": "7.2.7-alpine",
+      "candidate_tag": "8.8.0-alpine",
+      "candidate_image": "public.ecr.aws/docker/library/redis:8.8.0-alpine",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 453,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        },
+        {
+          "template": "typebot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typebot/index.yaml",
+          "line": 678,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/redis:7.2.7-alpine",
+          "repository": "public.ecr.aws/docker/library/redis",
+          "tag": "7.2.7-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typesense",
+      "image": "typesense/typesense:29.0",
+      "repository": "typesense/typesense",
+      "current_tag": "29.0",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typesense",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typesense/index.yaml",
+          "line": 41,
+          "key": "originImageName",
+          "image": "typesense/typesense:29.0",
+          "repository": "typesense/typesense",
+          "tag": "29.0",
+          "digest": null
+        },
+        {
+          "template": "typesense",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typesense/index.yaml",
+          "line": 62,
+          "key": "image",
+          "image": "typesense/typesense:29.0",
+          "repository": "typesense/typesense",
+          "tag": "29.0",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "typo3",
+      "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+      "repository": "martinhelmich/typo3",
+      "current_tag": "13.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml",
+          "line": 230,
+          "key": "originImageName",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        },
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml",
+          "line": 254,
+          "key": "image",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        },
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml",
+          "line": 398,
+          "key": "image",
+          "image": "martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25",
+          "repository": "martinhelmich/typo3",
+          "tag": "13.4",
+          "digest": "sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25"
+        }
+      ]
+    },
+    {
+      "template": "typo3",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "typo3",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/typo3/index.yaml",
+          "line": 154,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "ubuntu-sshd",
+      "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+      "repository": "takeyamajp/ubuntu-sshd",
+      "current_tag": "ubuntu22.04",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "ubuntu-sshd",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ubuntu-sshd/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+          "repository": "takeyamajp/ubuntu-sshd",
+          "tag": "ubuntu22.04",
+          "digest": null
+        },
+        {
+          "template": "ubuntu-sshd",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/ubuntu-sshd/index.yaml",
+          "line": 63,
+          "key": "image",
+          "image": "takeyamajp/ubuntu-sshd:ubuntu22.04",
+          "repository": "takeyamajp/ubuntu-sshd",
+          "tag": "ubuntu22.04",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "umami",
+      "image": "ghcr.io/umami-software/umami:3.0.2",
+      "repository": "ghcr.io/umami-software/umami",
+      "current_tag": "3.0.2",
+      "candidate_tag": "3.2.0",
+      "candidate_image": "ghcr.io/umami-software/umami:3.2.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "umami",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml",
+          "line": 58,
+          "key": "originImageName",
+          "image": "ghcr.io/umami-software/umami:3.0.2",
+          "repository": "ghcr.io/umami-software/umami",
+          "tag": "3.0.2",
+          "digest": null
+        },
+        {
+          "template": "umami",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml",
+          "line": 83,
+          "key": "image",
+          "image": "ghcr.io/umami-software/umami:3.0.2",
+          "repository": "ghcr.io/umami-software/umami",
+          "tag": "3.0.2",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "umami",
+      "image": "postgres:14-alpine",
+      "repository": "postgres",
+      "current_tag": "14-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "umami",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/umami/index.yaml",
+          "line": 257,
+          "key": "image",
+          "image": "postgres:14-alpine",
+          "repository": "postgres",
+          "tag": "14-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "uptime-kuma",
+      "image": "louislam/uptime-kuma:1.23.13",
+      "repository": "louislam/uptime-kuma",
+      "current_tag": "1.23.13",
+      "candidate_tag": "2.4.0",
+      "candidate_image": "louislam/uptime-kuma:2.4.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "uptime-kuma",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "louislam/uptime-kuma:1.23.13",
+          "repository": "louislam/uptime-kuma",
+          "tag": "1.23.13",
+          "digest": null
+        },
+        {
+          "template": "uptime-kuma",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/uptime-kuma/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "louislam/uptime-kuma:1.23.13",
+          "repository": "louislam/uptime-kuma",
+          "tag": "1.23.13",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "vaultwarden",
+      "image": "vaultwarden/server:latest",
+      "repository": "vaultwarden/server",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "vaultwarden",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/vaultwarden/index.yaml",
+          "line": 38,
+          "key": "originImageName",
+          "image": "vaultwarden/server:latest",
+          "repository": "vaultwarden/server",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "vaultwarden",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/vaultwarden/index.yaml",
+          "line": 61,
+          "key": "image",
+          "image": "vaultwarden/server:latest",
+          "repository": "vaultwarden/server",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "waha",
+      "image": "devlikeapro/waha:chrome-2026.5.1",
+      "repository": "devlikeapro/waha",
+      "current_tag": "chrome-2026.5.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "waha",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/waha/index.yaml",
+          "line": 162,
+          "key": "originImageName",
+          "image": "devlikeapro/waha:chrome-2026.5.1",
+          "repository": "devlikeapro/waha",
+          "tag": "chrome-2026.5.1",
+          "digest": null
+        },
+        {
+          "template": "waha",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/waha/index.yaml",
+          "line": 230,
+          "key": "image",
+          "image": "devlikeapro/waha:chrome-2026.5.1",
+          "repository": "devlikeapro/waha",
+          "tag": "chrome-2026.5.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "waha",
+      "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+      "repository": "public.ecr.aws/docker/library/postgres",
+      "current_tag": "16.4-alpine",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "waha",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/waha/index.yaml",
+          "line": 186,
+          "key": "image",
+          "image": "public.ecr.aws/docker/library/postgres:16.4-alpine",
+          "repository": "public.ecr.aws/docker/library/postgres",
+          "tag": "16.4-alpine",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "webos",
+      "image": "fs185085781/webos:v1.4.1",
+      "repository": "fs185085781/webos",
+      "current_tag": "v1.4.1",
+      "candidate_tag": "v1.4.4",
+      "candidate_image": "fs185085781/webos:v1.4.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "webos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml",
+          "line": 37,
+          "key": "originImageName",
+          "image": "fs185085781/webos:v1.4.1",
+          "repository": "fs185085781/webos",
+          "tag": "v1.4.1",
+          "digest": null
+        },
+        {
+          "template": "webos",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/webos/index.yaml",
+          "line": 60,
+          "key": "image",
+          "image": "fs185085781/webos:v1.4.1",
+          "repository": "fs185085781/webos",
+          "tag": "v1.4.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wechat",
+      "image": "ricwang/docker-wechat:4.0.0.30",
+      "repository": "ricwang/docker-wechat",
+      "current_tag": "4.0.0.30",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "wechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wechat/index.yaml",
+          "line": 47,
+          "key": "originImageName",
+          "image": "ricwang/docker-wechat:4.0.0.30",
+          "repository": "ricwang/docker-wechat",
+          "tag": "4.0.0.30",
+          "digest": null
+        },
+        {
+          "template": "wechat",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wechat/index.yaml",
+          "line": 70,
+          "key": "image",
+          "image": "ricwang/docker-wechat:4.0.0.30",
+          "repository": "ricwang/docker-wechat",
+          "tag": "4.0.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wechat2rss",
+      "image": "ttttmr/wechat2rss:latest",
+      "repository": "ttttmr/wechat2rss",
+      "current_tag": "latest",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "floating or missing tag requires manual pinning",
+      "evidence": "image tag",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "wechat2rss",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wechat2rss/index.yaml",
+          "line": 54,
+          "key": "originImageName",
+          "image": "ttttmr/wechat2rss:latest",
+          "repository": "ttttmr/wechat2rss",
+          "tag": "latest",
+          "digest": null
+        },
+        {
+          "template": "wechat2rss",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wechat2rss/index.yaml",
+          "line": 73,
+          "key": "image",
+          "image": "ttttmr/wechat2rss:latest",
+          "repository": "ttttmr/wechat2rss",
+          "tag": "latest",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wewe-rss",
+      "image": "cooderl/wewe-rss:v2.6.1",
+      "repository": "cooderl/wewe-rss",
+      "current_tag": "v2.6.1",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml",
+          "line": 174,
+          "key": "originImageName",
+          "image": "cooderl/wewe-rss:v2.6.1",
+          "repository": "cooderl/wewe-rss",
+          "tag": "v2.6.1",
+          "digest": null
+        },
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml",
+          "line": 193,
+          "key": "image",
+          "image": "cooderl/wewe-rss:v2.6.1",
+          "repository": "cooderl/wewe-rss",
+          "tag": "v2.6.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wewe-rss",
+      "image": "joseluisq/mysql-client:8.0.30",
+      "repository": "joseluisq/mysql-client",
+      "current_tag": "8.0.30",
+      "candidate_tag": "8.0.44",
+      "candidate_image": "joseluisq/mysql-client:8.0.44",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wewe-rss",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wewe-rss/index.yaml",
+          "line": 134,
+          "key": "image",
+          "image": "joseluisq/mysql-client:8.0.30",
+          "repository": "joseluisq/mysql-client",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+          "line": 150,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "wordpress:6.9.1-php8.3-apache",
+      "repository": "wordpress",
+      "current_tag": "6.9.1-php8.3-apache",
+      "candidate_tag": "7.0.0-php8.5-apache",
+      "candidate_image": "wordpress:7.0.0-php8.5-apache",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+          "line": 194,
+          "key": "originImageName",
+          "image": "wordpress:6.9.1-php8.3-apache",
+          "repository": "wordpress",
+          "tag": "6.9.1-php8.3-apache",
+          "digest": null
+        },
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+          "line": 333,
+          "key": "image",
+          "image": "wordpress:6.9.1-php8.3-apache",
+          "repository": "wordpress",
+          "tag": "6.9.1-php8.3-apache",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "woocommerce",
+      "image": "wordpress:cli-2.9.0-php8.3",
+      "repository": "wordpress",
+      "current_tag": "cli-2.9.0-php8.3",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "manual",
+      "confidence": "low",
+      "reason": "unsupported tag family",
+      "evidence": "tag parser",
+      "intended_action": "manual",
+      "records": [
+        {
+          "template": "woocommerce",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/woocommerce/index.yaml",
+          "line": 214,
+          "key": "image",
+          "image": "wordpress:cli-2.9.0-php8.3",
+          "repository": "wordpress",
+          "tag": "cli-2.9.0-php8.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wordpress",
+      "image": "wordpress:6.5.4",
+      "repository": "wordpress",
+      "current_tag": "6.5.4",
+      "candidate_tag": "7.0.0",
+      "candidate_image": "wordpress:7.0.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wordpress",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml",
+          "line": 48,
+          "key": "originImageName",
+          "image": "wordpress:6.5.4",
+          "repository": "wordpress",
+          "tag": "6.5.4",
+          "digest": null
+        },
+        {
+          "template": "wordpress",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wordpress/index.yaml",
+          "line": 71,
+          "key": "image",
+          "image": "wordpress:6.5.4",
+          "repository": "wordpress",
+          "tag": "6.5.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+      "repository": "ghcr.io/canner/wren-ai-service",
+      "current_tag": "0.15.17",
+      "candidate_tag": "0.29.3",
+      "candidate_image": "ghcr.io/canner/wren-ai-service:0.29.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 206,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "repository": "ghcr.io/canner/wren-ai-service",
+          "tag": "0.15.17",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 228,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-ai-service:0.15.17",
+          "repository": "ghcr.io/canner/wren-ai-service",
+          "tag": "0.15.17",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-bootstrap:0.1.5",
+      "repository": "ghcr.io/canner/wren-bootstrap",
+      "current_tag": "0.1.5",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "skip",
+      "confidence": "high",
+      "reason": "no newer compatible tag found",
+      "evidence": "crane ls",
+      "intended_action": "skip",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 313,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-bootstrap:0.1.5",
+          "repository": "ghcr.io/canner/wren-bootstrap",
+          "tag": "0.1.5",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+      "repository": "ghcr.io/canner/wren-engine-ibis",
+      "current_tag": "0.14.3",
+      "candidate_tag": "0.25.0",
+      "candidate_image": "ghcr.io/canner/wren-engine-ibis:0.25.0",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 383,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine-ibis",
+          "tag": "0.14.3",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 405,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-engine-ibis:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine-ibis",
+          "tag": "0.14.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-engine:0.14.3",
+      "repository": "ghcr.io/canner/wren-engine",
+      "current_tag": "0.14.3",
+      "candidate_tag": "0.24.6",
+      "candidate_image": "ghcr.io/canner/wren-engine:0.24.6",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 291,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-engine:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine",
+          "tag": "0.14.3",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 325,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-engine:0.14.3",
+          "repository": "ghcr.io/canner/wren-engine",
+          "tag": "0.14.3",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "ghcr.io/canner/wren-ui:0.20.1",
+      "repository": "ghcr.io/canner/wren-ui",
+      "current_tag": "0.20.1",
+      "candidate_tag": "0.32.2",
+      "candidate_image": "ghcr.io/canner/wren-ui:0.32.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 644,
+          "key": "originImageName",
+          "image": "ghcr.io/canner/wren-ui:0.20.1",
+          "repository": "ghcr.io/canner/wren-ui",
+          "tag": "0.20.1",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 666,
+          "key": "image",
+          "image": "ghcr.io/canner/wren-ui:0.20.1",
+          "repository": "ghcr.io/canner/wren-ui",
+          "tag": "0.20.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "qdrant/qdrant:v1.13.4",
+      "repository": "qdrant/qdrant",
+      "current_tag": "v1.13.4",
+      "candidate_tag": "v1.18.2",
+      "candidate_image": "qdrant/qdrant:v1.18.2",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 466,
+          "key": "originImageName",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 488,
+          "key": "image",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        },
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 516,
+          "key": "image",
+          "image": "qdrant/qdrant:v1.13.4",
+          "repository": "qdrant/qdrant",
+          "tag": "v1.13.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "wrenai",
+      "image": "senzing/postgresql-client:2.2.4",
+      "repository": "senzing/postgresql-client",
+      "current_tag": "2.2.4",
+      "candidate_tag": null,
+      "candidate_image": null,
+      "action": "blocked",
+      "confidence": "low",
+      "reason": "Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]]",
+      "evidence": "crane ls",
+      "intended_action": "blocked",
+      "records": [
+        {
+          "template": "wrenai",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/wrenai/index.yaml",
+          "line": 864,
+          "key": "image",
+          "image": "senzing/postgresql-client:2.2.4",
+          "repository": "senzing/postgresql-client",
+          "tag": "2.2.4",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "yourls",
+      "image": "mysql:8.0.30",
+      "repository": "mysql",
+      "current_tag": "8.0.30",
+      "candidate_tag": "9.7.1",
+      "candidate_image": "mysql:9.7.1",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+          "line": 140,
+          "key": "image",
+          "image": "mysql:8.0.30",
+          "repository": "mysql",
+          "tag": "8.0.30",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "yourls",
+      "image": "yourls:1.10.1",
+      "repository": "yourls",
+      "current_tag": "1.10.1",
+      "candidate_tag": "1.10.4",
+      "candidate_image": "yourls:1.10.4",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+          "line": 178,
+          "key": "originImageName",
+          "image": "yourls:1.10.1",
+          "repository": "yourls",
+          "tag": "1.10.1",
+          "digest": null
+        },
+        {
+          "template": "yourls",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/yourls/index.yaml",
+          "line": 203,
+          "key": "image",
+          "image": "yourls:1.10.1",
+          "repository": "yourls",
+          "tag": "1.10.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zitadel",
+      "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+      "repository": "ghcr.io/zitadel/zitadel",
+      "current_tag": "v4.10.1",
+      "candidate_tag": "v4.15.3",
+      "candidate_image": "ghcr.io/zitadel/zitadel:v4.15.3",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zitadel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml",
+          "line": 135,
+          "key": "originImageName",
+          "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "repository": "ghcr.io/zitadel/zitadel",
+          "tag": "v4.10.1",
+          "digest": null
+        },
+        {
+          "template": "zitadel",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zitadel/index.yaml",
+          "line": 155,
+          "key": "image",
+          "image": "ghcr.io/zitadel/zitadel:v4.10.1",
+          "repository": "ghcr.io/zitadel/zitadel",
+          "tag": "v4.10.1",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zot",
+      "image": "ghcr.io/project-zot/zot:v2.1.14",
+      "repository": "ghcr.io/project-zot/zot",
+      "current_tag": "v2.1.14",
+      "candidate_tag": "v2.1.18",
+      "candidate_image": "ghcr.io/project-zot/zot:v2.1.18",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+          "line": 144,
+          "key": "originImageName",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+          "line": 234,
+          "key": "image",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+          "line": 296,
+          "key": "originImageName",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        },
+        {
+          "template": "zot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+          "line": 316,
+          "key": "image",
+          "image": "ghcr.io/project-zot/zot:v2.1.14",
+          "repository": "ghcr.io/project-zot/zot",
+          "tag": "v2.1.14",
+          "digest": null
+        }
+      ]
+    },
+    {
+      "template": "zot",
+      "image": "httpd:2.4.63-alpine3.22",
+      "repository": "httpd",
+      "current_tag": "2.4.63-alpine3.22",
+      "candidate_tag": "2.4.68-alpine3.24",
+      "candidate_image": "httpd:2.4.68-alpine3.24",
+      "action": "update",
+      "confidence": "high",
+      "reason": "newer compatible semver tag found",
+      "evidence": "crane ls",
+      "intended_action": "update",
+      "records": [
+        {
+          "template": "zot",
+          "path": "/Users/longnv/bin/repo/templates-version-refresh-20260708/template/zot/index.yaml",
+          "line": 164,
+          "key": "image",
+          "image": "httpd:2.4.63-alpine3.22",
+          "repository": "httpd",
+          "tag": "2.4.63-alpine3.22",
+          "digest": null
+        }
+      ]
+    }
+  ]
+}

--- a/.sealos/update-reports/template-version-updates.md
+++ b/.sealos/update-reports/template-version-updates.md
@@ -1,0 +1,2925 @@
+# Sealos Template Version Update Report
+
+Generated: 2026-07-08 11:01:47 UTC
+Repo: `/Users/longnv/bin/repo/templates-version-refresh-20260708`
+
+## Summary
+
+| Action | Count |
+|--------|-------|
+| update | 273 |
+| manual | 227 |
+| blocked | 21 |
+| skip | 66 |
+
+## Candidates
+
+| Template | Current image | Candidate | Action | Confidence | Reason | Evidence |
+|----------|---------------|-----------|--------|------------|--------|----------|
+| AllinSSL | `docker.io/allinssl/allinssl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| AllinSSL | `docker.io/allinssl/allinssl:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| OpenDeepWiki | `${{ inputs.wiki_image }}` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| OpenDeepWiki | `${{ inputs.wiki_web_image }}` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| Reactive-Resume | `amruthpillai/reactive-resume:v4.1.2` | `amruthpillai/reactive-resume:v5.2.2` | update | high | newer compatible semver tag found | crane ls |
+| Reactive-Resume | `bitnamilegacy/postgresql:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| Reactive-Resume | `ghcr.io/browserless/chromium:v2.11.0` | `ghcr.io/browserless/chromium:v2.54.2` | update | high | newer compatible semver tag found | crane ls |
+| Reactive-Resume | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| Reactive-Resume | `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z` |  | manual | low | unsupported tag family | tag parser |
+| Readeck | `codeberg.org/readeck/readeck:0.16.0` | `codeberg.org/readeck/readeck:0.22.3` | update | high | newer compatible semver tag found | crane ls |
+| Ruiqi-Waf | `limbo2342/ruiqi-waf:sha-32b359f` |  | manual | low | unsupported tag family | tag parser |
+| ace-step | `ghcr.io/ace-step/ace-step-1.5:v0.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| affine | `ghcr.io/toeverything/affine:0.26.7` |  | skip | high | no newer compatible tag found | crane ls |
+| affine | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| agora | `agoracn/token:0.1.2023053011` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `airbyte/bootloader:2.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `airbyte/cron:2.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `airbyte/server:2.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `airbyte/worker:2.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `bitnamilegacy/kubectl:1.33.4` |  | skip | high | no newer compatible tag found | crane ls |
+| airbyte | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| airbyte | `temporalio/auto-setup:1.29.7` |  | skip | high | no newer compatible tag found | crane ls |
+| anki-sync-server | `ghcr.io/yangchuansheng/anki-sync-server:24.06.3` |  | manual | low | unsupported tag family | tag parser |
+| anything-llm | `mintplexlabs/anythingllm:1.14.0` | `mintplexlabs/anythingllm:1.15.0` | update | high | newer compatible semver tag found | crane ls |
+| apitable | `apitable/backend-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600` |  | manual | low | digest-only image requires manual release check | image digest |
+| apitable | `apitable/imageproxy-server:v0.13.4-alpha_build13` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b` |  | manual | low | digest-only image requires manual release check | image digest |
+| apitable | `apitable/init-db:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/room-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `apitable/web-server:v1.13.0-beta.1_2016` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `busybox:1.38.0` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `mysql:9.7.1` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `nginx:1.31.2-alpine` |  | skip | high | no newer compatible tag found | crane ls |
+| apitable | `rabbitmq:4.3.2-management` |  | skip | high | no newer compatible tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_cloud:0.15.22` | `appflowyinc/appflowy_cloud:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_web:0.14.9` | `appflowyinc/appflowy_web:0.15.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/appflowy_worker:0.15.22` | `appflowyinc/appflowy_worker:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `appflowyinc/gotrue:0.15.22` | `appflowyinc/gotrue:0.16.5` | update | high | newer compatible semver tag found | crane ls |
+| appflowy | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| appsmith | `appsmith/appsmith-ce:v1.29` |  | manual | low | unsupported tag family | tag parser |
+| appwrite | `appwrite/appwrite:1.9.0` | `appwrite/appwrite:1.9.5` | update | high | newer compatible semver tag found | crane ls |
+| appwrite | `appwrite/console:7.8.26` | `appwrite/console:8.7.19` | update | high | newer compatible semver tag found | crane ls |
+| appwrite | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| artalk | `artalk/artalk-go:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| asktable | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| asktable | `registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| asktable | `registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| authentik | `ghcr.io/goauthentik/server:2025.12.3` | `ghcr.io/goauthentik/server:2026.5.4` | update | high | newer compatible semver tag found | crane ls |
+| authentik | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| banana-slides | `anoinex/banana-slides-backend:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| banana-slides | `anoinex/banana-slides-frontend:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| billionmail | `alpine/openssl:3.5.4` | `alpine/openssl:3.5.7` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692` | `billionmail/core:4.9.5` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| billionmail | `python:3.12.12-alpine` | `python:3.14.6-alpine` | update | high | newer compatible semver tag found | crane ls |
+| billionmail | `roundcube/roundcubemail:1.6.11-fpm-alpine` | `roundcube/roundcubemail:1.7.2-fpm-alpine` | update | high | newer compatible semver tag found | crane ls |
+| blossom | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| blossom | `jasminexzzz/blossom:1.16.0` |  | skip | high | no newer compatible tag found | crane ls |
+| btpanel | `btpanel/baota:nas` |  | manual | low | unsupported tag family | tag parser |
+| budibase | `budibase/apps:3.15.0` | `budibase/apps:3.39.27` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `budibase/couchdb:v3.3.3-sqs-v2.1.1` |  | skip | high | no newer compatible tag found | crane ls |
+| budibase | `budibase/proxy:3.15.0` | `budibase/proxy:3.39.27` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `budibase/worker:3.15.0` | `budibase/worker:3.39.27` | update | high | newer compatible semver tag found | crane ls |
+| budibase | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb-scheduler:1.6.11` | `docker.io/bunkerity/bunkerweb-scheduler:1.6.12` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb-ui:1.6.11` | `docker.io/bunkerity/bunkerweb-ui:1.6.12` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/bunkerity/bunkerweb:1.6.11` | `docker.io/bunkerity/bunkerweb:1.6.12` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/library/busybox:1.36.1` | `docker.io/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| bunkerweb | `docker.io/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| bunkerweb | `docker.io/traefik/whoami:v1.11.0` |  | skip | high | no newer compatible tag found | crane ls |
+| bytebase | `bytebase/bytebase:3.6.1` | `bytebase/bytebase:3.20.0` | update | high | newer compatible semver tag found | crane ls |
+| calcom | `calcom.docker.scarf.sh/calcom/cal.com:v6.2.0` |  | skip | high | no newer compatible tag found | crane ls |
+| calcom | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| cap | `ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad` |  | manual | low | digest-only image requires manual release check | image digest |
+| cap | `ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57` |  | manual | low | digest-only image requires manual release check | image digest |
+| cap | `mysql:8.0.46-debian` |  | skip | high | no newer compatible tag found | crane ls |
+| casdoor | `casbin/casdoor:v1.702.0` | `casbin/casdoor:v2.190.0` | update | high | newer compatible semver tag found | crane ls |
+| casdoor | `casbin/casdoor:v2.32.0` | `casbin/casdoor:v2.190.0` | update | high | newer compatible semver tag found | crane ls |
+| casdoor | `mysql:8.0` |  | manual | low | unsupported tag family | tag parser |
+| casdoor | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| changedetection | `ghcr.io/dgtlmoon/changedetection.io:0.50.43` | `ghcr.io/dgtlmoon/changedetection.io:0.55.7` | update | high | newer compatible semver tag found | crane ls |
+| chatany | `licoy/chatany:v3.5.0` |  | skip | high | no newer compatible tag found | crane ls |
+| chatbot-ui | `ghcr.io/mckaywrigley/chatbot-ui:main` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| chatgpt-next-web | `yidadaa/chatgpt-next-web:v2.12.4` | `yidadaa/chatgpt-next-web:v2.16.1` | update | high | newer compatible semver tag found | crane ls |
+| chatgpt-on-wechat | `zhayujie/chatgpt-on-wechat:1.6.8` | `zhayujie/chatgpt-on-wechat:2.1.3` | update | high | newer compatible semver tag found | crane ls |
+| chatgpt-web | `chenzhaoyu94/chatgpt-web` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| chatnio | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| chatnio | `programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d` |  | manual | low | digest-only image requires manual release check | image digest |
+| chatwoot | `chatwoot/chatwoot:v4.7.0` | `chatwoot/chatwoot:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| chatwoot | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| chrome | `lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95` |  | manual | low | unsupported tag family | tag parser |
+| cloudreve | `arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| cloudreve | `cloudreve/cloudreve` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| cobalt | `ghcr.io/imputnet/cobalt:7.13.3` | `ghcr.io/imputnet/cobalt:11.7.1` | update | high | newer compatible semver tag found | crane ls |
+| code-server | `codercom/code-server:4.90.3-39` | `codercom/code-server:4.127.0-39` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `alpine/curl:8.12.1` | `alpine/curl:8.21.0` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3` |  | manual | low | digest-only image requires manual release check | image digest |
+| coze-studio | `bitnamilegacy/elasticsearch:8.18.0` | `bitnamilegacy/elasticsearch:9.1.2` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0` |  | manual | low | digest-only image requires manual release check | image digest |
+| coze-studio | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `cozedev/coze-studio-server:0.5.1` |  | skip | high | no newer compatible tag found | crane ls |
+| coze-studio | `cozedev/coze-studio-web:0.5.1` |  | skip | high | no newer compatible tag found | crane ls |
+| coze-studio | `milvusdb/milvus:v2.5.10` | `milvusdb/milvus:v2.6.19` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1` |  | manual | low | unsupported tag family | tag parser |
+| coze-studio | `mysql:8.0.36` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| coze-studio | `nsqio/nsq:v1.2.1` | `nsqio/nsq:v1.3.0` | update | high | newer compatible semver tag found | crane ls |
+| crawl4ai | `unclecode/crawl4ai:0.8.9` | `unclecode/crawl4ai:0.9.0` | update | high | newer compatible semver tag found | crane ls |
+| crmeb | `ghcr.io/yangchuansheng/crmeb:v5.4.0` |  | skip | high | no newer compatible tag found | crane ls |
+| crmeb | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| crmeb | `nginx:alpine3.20` |  | manual | low | unsupported tag family | tag parser |
+| cronicle | `soulteary/cronicle:0.9.46` | `soulteary/cronicle:0.9.80` | update | high | newer compatible semver tag found | crane ls |
+| dataease | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| dataease | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| dataease | `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12` | `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.25` | update | high | newer compatible semver tag found | crane ls |
+| dbgate | `dbgate/dbgate:5.3.1-alpine` | `dbgate/dbgate:7.2.1-alpine` | update | high | newer compatible semver tag found | crane ls |
+| deeplx | `ghcr.io/owo-network/deeplx:v0.9.5` | `ghcr.io/owo-network/deeplx:v1.2.2` | update | high | newer compatible semver tag found | crane ls |
+| derper | `bitnamilegacy/kubectl:1.28.9` | `bitnamilegacy/kubectl:1.33.4` | update | high | newer compatible semver tag found | crane ls |
+| derper | `ghcr.io/yangchuansheng/derper:v1.99.0-pre` | `ghcr.io/yangchuansheng/derper:v1.101.0-pre` | update | high | newer compatible semver tag found | crane ls |
+| dify | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-api:1.11.2` | `langgenius/dify-api:1.15.0` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-plugin-daemon:0.5.2-local` | `langgenius/dify-plugin-daemon:0.6.3-local` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-sandbox:0.2.12` | `langgenius/dify-sandbox:0.2.15` | update | high | newer compatible semver tag found | crane ls |
+| dify | `langgenius/dify-web:1.11.2` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| dify | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| dify | `semitechnologies/weaviate:1.27.0` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| directus | `directus/directus:11.17.4` | `directus/directus:12.1.1` | update | high | newer compatible semver tag found | crane ls |
+| directus | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| directus | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| directus | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| docker-stacks | `jupyter/scipy-notebook:2023-10-20` |  | skip | high | no newer compatible tag found | crane ls |
+| docuseal | `docuseal/docuseal:3.0.1` | `docuseal/docuseal:3.1.3` | update | high | newer compatible semver tag found | crane ls |
+| docuseal | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| dolibarr | `dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865` |  | skip | high | no newer compatible tag found | crane ls |
+| dolibarr | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| drawdb | `ghcr.io/drawdb-io/drawdb:v1.5.0` | `ghcr.io/drawdb-io/drawdb:v1.8.1` | update | high | newer compatible semver tag found | crane ls |
+| drizzle-studio | `ghcr.io/drizzle-team/gateway:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| eaglercraft-server | `ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1@sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810` |  | skip | high | no newer compatible tag found | crane ls |
+| edgequake | `ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2` | `ghcr.io/raphaelmansuy/edgequake-frontend:0.15.0` | update | high | newer compatible semver tag found | crane ls |
+| edgequake | `ghcr.io/raphaelmansuy/edgequake:0.12.2` | `ghcr.io/raphaelmansuy/edgequake:0.15.0` | update | high | newer compatible semver tag found | crane ls |
+| edgequake | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| elasticsearch | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| elasticsearch | `docker.elastic.co/elasticsearch/elasticsearch:9.4.1` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| emqx | `emqx/emqx:5.8.9` | `emqx/emqx:6.2.2` | update | high | newer compatible semver tag found | crane ls |
+| enshrouded | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| enshrouded | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| enshrouded | `registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2` |  | manual | low | unsupported tag family | tag parser |
+| erpnext | `frappe/erpnext:v16.21.1` | `frappe/erpnext:v16.26.2` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `mariadb:11.4.7` | `mariadb:12.3.2` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| erpnext | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| ever-gauzy | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| ever-gauzy | `ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4` |  | manual | low | digest-only image requires manual release check | image digest |
+| ever-gauzy | `ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493` |  | manual | low | digest-only image requires manual release check | image digest |
+| ever-gauzy | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| evolution-api | `evoapicloud/evolution-api:v2.3.7` |  | skip | high | no newer compatible tag found | crane ls |
+| evolution-api | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| evolution-api | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| evolution-api | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| excalidraw | `excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f` |  | manual | low | digest-only image requires manual release check | image digest |
+| fast-poster | `fastposter/fastposter:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| fastgpt | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-milvus | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.23` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v1.0.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22` | `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.15.1` | update | high | newer compatible semver tag found | crane ls |
+| fastgpt-pro | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8` | `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.6.5` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-api-server:5.0.5` | `featbit/featbit-api-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-data-analytics-server:5.0.5` | `featbit/featbit-data-analytics-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-evaluation-server:5.0.5` | `featbit/featbit-evaluation-server:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `featbit/featbit-ui:5.0.5` | `featbit/featbit-ui:5.4.2` | update | high | newer compatible semver tag found | crane ls |
+| featbit-standard | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| filecodebox | `lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2` |  | manual | low | digest-only image requires manual release check | image digest |
+| fireboom | `fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f` |  | manual | low | digest-only image requires manual release check | image digest |
+| firecrawl | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| firecrawl | `ghcr.io/firecrawl/firecrawl@sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c` |  | manual | low | digest-only image requires manual release check | image digest |
+| firecrawl | `ghcr.io/firecrawl/playwright-service@sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e` |  | manual | low | digest-only image requires manual release check | image digest |
+| firecrawl | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| firecrawl | `rabbitmq:3.13.7-management` | `rabbitmq:4.3.2-management` | update | high | newer compatible semver tag found | crane ls |
+| firecrawl | `redis:7.2.7-alpine` | `redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| firefox | `jlesage/firefox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| flarum | `crazymax/flarum:1.8.10` |  | skip | high | no newer compatible tag found | crane ls |
+| flarum | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| flowise | `flowiseai/flowise:3.0.5` | `flowiseai/flowise:3.1.3` | update | high | newer compatible semver tag found | crane ls |
+| flowise | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| formbricks | `ghcr.io/formbricks/formbricks:4.9.7` | `ghcr.io/formbricks/formbricks:5.1.4` | update | high | newer compatible semver tag found | crane ls |
+| formbricks | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| frp | `bitnamilegacy/kubectl:1.28.9` | `bitnamilegacy/kubectl:1.33.4` | update | high | newer compatible semver tag found | crane ls |
+| frp | `snowdreamtech/frps:0.59` |  | manual | low | unsupported tag family | tag parser |
+| full-stack-fastapi | `ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0` |  | skip | high | no newer compatible tag found | crane ls |
+| full-stack-fastapi | `ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0` |  | skip | high | no newer compatible tag found | crane ls |
+| full-stack-fastapi | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| ghost | `ghost:6.44.1-alpine` | `ghost:6.51.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| ghost | `public.ecr.aws/docker/library/mysql:8.0.30` | `public.ecr.aws/docker/library/mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| ghost | `public.ecr.aws/docker/library/node:22-alpine` |  | manual | low | unsupported tag family | tag parser |
+| gitea | `gitea/gitea:1.22.0-rootless` | `gitea/gitea:1.26.4-rootless` | update | high | newer compatible semver tag found | crane ls |
+| glance | `glanceapp/glance` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| glance | `glanceapp/glance:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| glitchtip | `glitchtip/glitchtip:v4.1.5` | `glitchtip/glitchtip:v6.0.3` | update | high | newer compatible semver tag found | crane ls |
+| glitchtip | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| gpt-academic | `ghcr.io/binary-husky/gpt_academic_nolocal:master` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| grafana | `grafana/grafana:13.0.2` | `grafana/grafana:13.1.0` | update | high | newer compatible semver tag found | crane ls |
+| grafana | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| grafana-otel | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| grafana-otel | `grafana/grafana:12.3.0` | `grafana/grafana:13.1.0` | update | high | newer compatible semver tag found | crane ls |
+| grafana-otel | `otel/opentelemetry-collector:0.99.0` | `otel/opentelemetry-collector:0.156.0` | update | high | newer compatible semver tag found | crane ls |
+| grafana-otel | `prom/prometheus:v3.8.0` | `prom/prometheus:v3.13.0` | update | high | newer compatible semver tag found | crane ls |
+| halo | `halohub/halo:2.18.0` | `halohub/halo:2.25.4` | update | high | newer compatible semver tag found | crane ls |
+| halo | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| happy-server | `ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe` |  | manual | low | digest-only image requires manual release check | image digest |
+| happy-server | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| harbor | `goharbor/harbor-core:v2.14.4` | `goharbor/harbor-core:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-jobservice:v2.14.4` | `goharbor/harbor-jobservice:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-portal:v2.14.4` | `goharbor/harbor-portal:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/harbor-registryctl:v2.14.4` | `goharbor/harbor-registryctl:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/registry-photon:v2.14.4` | `goharbor/registry-photon:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `goharbor/trivy-adapter-photon:v2.14.4` | `goharbor/trivy-adapter-photon:v2.15.2` | update | high | newer compatible semver tag found | crane ls |
+| harbor | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| hasura | `hasura/graphql-data-connector:v2.48.11` | `hasura/graphql-data-connector:v2.49.4` | update | high | newer compatible semver tag found | crane ls |
+| hasura | `hasura/graphql-engine:v2.48.11` | `hasura/graphql-engine:v2.49.4` | update | high | newer compatible semver tag found | crane ls |
+| headscale | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| headscale | `ghcr.io/tale/headplane:0.6.3` | `ghcr.io/tale/headplane:0.7.0` | update | high | newer compatible semver tag found | crane ls |
+| headscale | `headscale/headscale:0.29.0-beta.1-debug` |  | skip | high | no newer compatible tag found | crane ls |
+| headscale | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| heyform | `heyform/community-edition:v3.0.0-rc.7` |  | skip | high | no newer compatible tag found | crane ls |
+| illa-builder | `illasoft/illa-builder:v4.8.2` | `illasoft/illa-builder:v4.8.5` | update | high | newer compatible semver tag found | crane ls |
+| immich | `ghcr.io/immich-app/immich-machine-learning:v2.7.5` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| immich | `ghcr.io/immich-app/immich-server:v2.7.5` | `ghcr.io/immich-app/immich-server:v3.0.1` | update | high | newer compatible semver tag found | crane ls |
+| immich | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| influxdb | `docker.io/library/influxdb:2.9.1` |  | skip | high | no newer compatible tag found | crane ls |
+| inpaint-web | `yangchuansheng/inpaint-web` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| insforge | `apecloud/kubeblocks-tools:0.9.3` | `apecloud/kubeblocks-tools:1.0.2` | update | high | newer compatible semver tag found | crane ls |
+| insforge | `ghcr.io/insforge/deno-runtime:2.0.6` |  | skip | high | no newer compatible tag found | crane ls |
+| insforge | `ghcr.io/insforge/insforge-oss:v2.1.8` | `ghcr.io/insforge/insforge-oss:v2.2.6` | update | high | newer compatible semver tag found | crane ls |
+| insforge | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| insforge | `postgrest/postgrest:v12.2.12` | `postgrest/postgrest:v13.0.8` | update | high | newer compatible semver tag found | crane ls |
+| it-tools | `ghcr.io/corentinth/it-tools:2024.5.13-a0bc346` |  | skip | high | no newer compatible tag found | crane ls |
+| jellyfin | `jellyfin/jellyfin:10.10.7` | `jellyfin/jellyfin:10.11.11` | update | high | newer compatible semver tag found | crane ls |
+| joplin | `joplin/server:3.7.1` |  | skip | high | no newer compatible tag found | crane ls |
+| joplin | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| jsoncrack | `shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef` |  | manual | low | digest-only image requires manual release check | image digest |
+| kanboard | `kanboard/kanboard:v1.2.50` | `kanboard/kanboard:v1.2.52` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `ghcr.io/usekaneo/api:1.1.8` | `ghcr.io/usekaneo/api:2.9.0` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `ghcr.io/usekaneo/web:1.1.8` | `ghcr.io/usekaneo/web:2.9.0` | update | high | newer compatible semver tag found | crane ls |
+| kaneo | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| keycloak | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| keycloak | `quay.io/keycloak/keycloak:26.3.2` | `quay.io/keycloak/keycloak:26.6.4` | update | high | newer compatible semver tag found | crane ls |
+| keystone | `node:22.22.1-alpine` | `node:26.4.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| keystone | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| kitten-tts | `ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2` |  | manual | low | unsupported tag family | tag parser |
+| kodcloud | `kodcloud/kodbox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| kuboard | `eipwork/kuboard:v3` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| kuvasz | `kuvaszmonitoring/kuvasz:3.11.0` | `kuvaszmonitoring/kuvasz:4.0.1` | update | high | newer compatible semver tag found | crane ls |
+| kuvasz | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/laf-server:sha-ef30cd9` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/laf-web:sha-e9d012d` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/runtime-node-init:sha-67b3cd6` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/lafyun/runtime-node:sha-67b3cd6` |  | manual | low | unsupported tag family | tag parser |
+| laf | `docker.io/library/nginx:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| laf | `quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z` |  | manual | low | unsupported tag family | tag parser |
+| laf | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| laf | `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z` |  | manual | low | unsupported tag family | tag parser |
+| laf | `quay.io/prometheus/prometheus:v2.45.0` | `quay.io/prometheus/prometheus:v3.13.0` | update | high | newer compatible semver tag found | crane ls |
+| langflow | `langflowai/langflow:1.9.5` | `langflowai/langflow:1.10.2` | update | high | newer compatible semver tag found | crane ls |
+| langflow | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `clickhouse/clickhouse-server:25.4.2` | `clickhouse/clickhouse-server:26.6.1` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `docker.io/langfuse/langfuse-worker:3.180.0` | `docker.io/langfuse/langfuse-worker:3.207.0` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `docker.io/langfuse/langfuse:3.180.0` | `docker.io/langfuse/langfuse:3.207.0` | update | high | newer compatible semver tag found | crane ls |
+| langfuse | `minio/minio:RELEASE.2025-09-07T16-13-09Z` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| langfuse | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| librechat | `getmeili/meilisearch:v1.5` |  | manual | low | unsupported tag family | tag parser |
+| librechat | `ghcr.io/danny-avila/librechat:v0.7.3` | `ghcr.io/danny-avila/librechat:v0.8.7` | update | high | newer compatible semver tag found | crane ls |
+| liebianbao | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| liebianbao | `docker.io/arey/mysql-client:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| liebianbao | `docker.io/labring4docker/php-custom:7.2-fpm` |  | manual | low | unsupported tag family | tag parser |
+| liebianbao | `labring4docker/php-custom:7.2-fpm` |  | manual | low | unsupported tag family | tag parser |
+| liebianbao | `nginx:1.25.2` | `nginx:1.31.2` | update | high | newer compatible semver tag found | crane ls |
+| listmonk | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| listmonk | `listmonk/listmonk:v6.1.0` | `listmonk/listmonk:v6.2.0` | update | high | newer compatible semver tag found | crane ls |
+| listmonk | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| litellm | `litellm/litellm-database:v1.88.1` | `litellm/litellm-database:v1.91.0` | update | high | newer compatible semver tag found | crane ls |
+| litellm | `minio/mc:RELEASE.2025-05-21T01-59-54Z` |  | manual | low | unsupported tag family | tag parser |
+| litellm | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| llama2-chinese | `luanshaotong/text-generation-webui-cpu:dev` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| llama3-8b-chinese | `registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m` |  | manual | low | unsupported tag family | tag parser |
+| llmgateway | `ghcr.io/theopenco/llmgateway-api:v1.3.0` | `ghcr.io/theopenco/llmgateway-api:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-docs:v1.3.0` | `ghcr.io/theopenco/llmgateway-docs:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-gateway:v1.3.0` | `ghcr.io/theopenco/llmgateway-gateway:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-ui:v1.3.0` | `ghcr.io/theopenco/llmgateway-ui:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `ghcr.io/theopenco/llmgateway-worker:v1.3.0` | `ghcr.io/theopenco/llmgateway-worker:v1.7.0` | update | high | newer compatible semver tag found | crane ls |
+| llmgateway | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| llmgateway | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| lobe-chat | `lobehub/lobe-chat:1.143.3` |  | skip | high | no newer compatible tag found | crane ls |
+| lobe-chat-db | `lobehub/lobe-chat-database:1.143.2` | `lobehub/lobe-chat-database:1.143.3` | update | high | newer compatible semver tag found | crane ls |
+| lobe-chat-db | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| logto | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| logto | `svhd/logto:1.40.1` | `svhd/logto:1.41.0` | update | high | newer compatible semver tag found | crane ls |
+| loki | `busybox:1.37.0` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| loki | `docker.io/grafana/loki:3.7.2` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| mage-ai | `mageai/mageai:0.9.79` |  | skip | high | no newer compatible tag found | crane ls |
+| mage-ai | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `ghcr.io/mastodon/mastodon-streaming:v4.5.11` | `ghcr.io/mastodon/mastodon-streaming:v4.6.3` | update | high | newer compatible semver tag found | crane ls |
+| mastodon | `ghcr.io/mastodon/mastodon:v4.5.11` | `ghcr.io/mastodon/mastodon:v4.6.3` | update | high | newer compatible semver tag found | crane ls |
+| mastodon | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| mastodon | `public.ecr.aws/docker/library/redis:7-alpine` |  | manual | low | unsupported tag family | tag parser |
+| matomo | `matomo:5.10.0-apache` | `matomo:5.11.2-apache` | update | high | newer compatible semver tag found | crane ls |
+| matomo | `mysql:8.0.44` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| matrixgorilla | `${{ defaults.app_name }}-api` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| matrixgorilla | `${{ defaults.app_name }}-web` |  | manual | low | templated or unparseable image requires manual release check | local parse |
+| matrixgorilla | `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| matrixgorilla | `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mautic | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| mautic | `mautic/mautic:7.1.2-apache` | `mautic/mautic:7.1.3-apache` | update | high | newer compatible semver tag found | crane ls |
+| mautic | `mysql:8.4.2` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| mazanoke | `ghcr.io/civilblur/mazanoke:v1.1.6` |  | skip | high | no newer compatible tag found | crane ls |
+| meilisearch | `eyeix/meilisearch-ui:v0.15.1-lite` |  | skip | high | no newer compatible tag found | crane ls |
+| meilisearch | `getmeili/meilisearch:v1.45.1` | `getmeili/meilisearch:v1.49.0` | update | high | newer compatible semver tag found | crane ls |
+| memos | `ghcr.io/usememos/memos:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| metabase | `metabase/metabase:v0.61.3` | `metabase/metabase:v0.62.3` | update | high | newer compatible semver tag found | crane ls |
+| metabase | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| midjourney-ui | `erictik/midjourney-ui:1.1.47` |  | skip | high | no newer compatible tag found | crane ls |
+| mindoc | `registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1` |  | manual | low | unsupported tag family | tag parser |
+| mindoc | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| mindsdb | `mindsdb/mindsdb:v26.1.0` |  | skip | high | no newer compatible tag found | crane ls |
+| mindsdb | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| minecraft | `alpine:3.22.4` | `alpine:3.24.1` | update | high | newer compatible semver tag found | crane ls |
+| minecraft | `itzg/minecraft-server:2026.5.3-java25` | `itzg/minecraft-server:2026.7.0-java8` | update | high | newer compatible semver tag found | crane ls |
+| minio | `quay.io/minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mlflow | `ghcr.io/mlflow/mlflow:v3.12.0` | `ghcr.io/mlflow/mlflow:v3.14.0` | update | high | newer compatible semver tag found | crane ls |
+| mlflow | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| moneyprinterturbo | `ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| mongo-express | `mongo-express:1.0.2-20-alpine3.19` |  | skip | high | no newer compatible tag found | crane ls |
+| n8n | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| n8n | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| n8n | `n8nio/n8n:2.22.4` | `n8nio/n8n:2.30.1` | update | high | newer compatible semver tag found | crane ls |
+| n8n | `n8nio/runners:2.22.4` | `n8nio/runners:2.30.1` | update | high | newer compatible semver tag found | crane ls |
+| n8n | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| nacos | `mysql:8.0.44` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| nacos | `nacos/nacos-server:v3.2.2` |  | skip | high | no newer compatible tag found | crane ls |
+| nakama | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| nakama | `heroiclabs/nakama:3.39.0` |  | skip | high | no newer compatible tag found | crane ls |
+| nakama | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| netbird | `netbirdio/dashboard:v2.38.1` | `netbirdio/dashboard:v2.90.3` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/management:0.71.4` | `netbirdio/management:0.74.2` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/relay:0.71.4` | `netbirdio/relay:0.74.2` | update | high | newer compatible semver tag found | crane ls |
+| netbird | `netbirdio/signal:0.71.4` | `netbirdio/signal:0.74.2` | update | high | newer compatible semver tag found | crane ls |
+| new-api | `calciumion/new-api:v0.13.2` |  | skip | high | no newer compatible tag found | crane ls |
+| new-api | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| nexus | `alpine:3.22.2` | `alpine:3.24.1` | update | high | newer compatible semver tag found | crane ls |
+| nexus | `sonatype/nexus3:3.92.3` | `sonatype/nexus3:3.93.2` | update | high | newer compatible semver tag found | crane ls |
+| nocodb | `nocodb/nocodb:2026.05.2` | `nocodb/nocodb:2026.06.2` | update | medium | newer compatible date tag found | crane ls |
+| node-red | `nodered/node-red:4.1.10` | `nodered/node-red:5.0.1` | update | high | newer compatible semver tag found | crane ls |
+| nofx | `alpine/openssl:3.5.4` | `alpine/openssl:3.5.7` | update | high | newer compatible semver tag found | crane ls |
+| nofx | `ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7` |  | manual | low | digest-only image requires manual release check | image digest |
+| nofx | `ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887` |  | manual | low | digest-only image requires manual release check | image digest |
+| nofx | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| notifuse | `notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb` |  | manual | low | unsupported tag family | tag parser |
+| notifuse | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| nsfw | `ethandai4869/nsfw-auth` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| odoo | `odoo:18.0-20260609` |  | manual | low | unsupported tag family | tag parser |
+| odoo | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| odysseus | `chromadb/chroma:1.0.15` | `chromadb/chroma:1.5.9` | update | high | newer compatible semver tag found | crane ls |
+| odysseus | `ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0` | `ghcr.io/pewdiepie-archdaemon/odysseus:1.0.1` | update | high | newer compatible semver tag found | crane ls |
+| odysseus | `searxng/searxng:2026.5.31-7159b8aed` |  | skip | high | no newer compatible tag found | crane ls |
+| one-api | `ghcr.io/songquanpeng/one-api:v0.6.10` |  | skip | high | no newer compatible tag found | crane ls |
+| open-design | `docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13` |  | manual | low | digest-only image requires manual release check | image digest |
+| open-design | `nginxinc/nginx-unprivileged:1.25-alpine-slim` |  | manual | low | unsupported tag family | tag parser |
+| open-webui | `ghcr.io/open-webui/open-webui:v0.5.4` | `ghcr.io/open-webui/open-webui:v0.10.2` | update | high | newer compatible semver tag found | crane ls |
+| openagents | `ghcr.io/openagents-org/openagents:sha-48764c0` |  | manual | low | unsupported tag family | tag parser |
+| openai-proxy | `unickcheng/openai-proxy` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| opencart | `ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94` |  | manual | low | unsupported tag family | tag parser |
+| openclaw | `busybox:1.36` |  | manual | low | unsupported tag family | tag parser |
+| openclaw | `ghcr.io/openclaw/openclaw:2026.3.8` | `ghcr.io/openclaw/openclaw:2026.6.11` | update | high | newer compatible semver tag found | crane ls |
+| openhands | `ghcr.io/openhands/openhands:1.8.0` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| openlist | `openlistteam/openlist:v4.0.9-aria2` | `openlistteam/openlist:v4.2.3-aria2` | update | high | newer compatible semver tag found | crane ls |
+| openobserve | `public.ecr.aws/zinclabs/openobserve:v0.90.3` | `public.ecr.aws/zinclabs/openobserve:v0.91.1` | update | high | newer compatible semver tag found | crane ls |
+| outline | `outlinewiki/outline:1.8.0-1` | `outlinewiki/outline:1.8.2-0` | update | high | newer compatible semver tag found | crane ls |
+| outline | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| overleaf | `sharelatex/sharelatex:6.1.2` | `sharelatex/sharelatex:6.2.1` | update | high | newer compatible semver tag found | crane ls |
+| pageplug | `cloudtogouser/pageplug-ce:v1.9.35` | `cloudtogouser/pageplug-ce:v1.9.37` | update | high | newer compatible semver tag found | crane ls |
+| palacms | `ghcr.io/palacms/palacms:v3.0.0-beta.1` |  | blocked | low | 2026/07/08 18:56:21 No matching credentials were found for "ghcr.io"
+Error: reading tags for ghcr.io/palacms/palacms: GET https://ghcr.io/token?scope=repository%3Apalacms%2Fpalacms%3Apull&service=ghcr.io: DENIED: requested access to the resource is denied | crane ls |
+| palworld | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld | `hurlenko/filebrowser` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld | `thijsvanloef/palworld-server-docker` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-autobackup | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-export | `bitnamilegacy/kubectl` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-export | `hurlenko/filebrowser` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| palworld-management | `registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18` |  | skip | high | no newer compatible tag found | crane ls |
+| pangolin | `docker.io/fosrl/pangolin:1.15.2` | `docker.io/fosrl/pangolin:1.19.4` | update | high | newer compatible semver tag found | crane ls |
+| paperclip | `ghcr.io/paperclipai/paperclip:sha-b8725c5` |  | manual | low | unsupported tag family | tag parser |
+| paperclip | `public.ecr.aws/docker/library/busybox:1.36.1` | `public.ecr.aws/docker/library/busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| paperclip | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| paperless-ngx | `ghcr.io/paperless-ngx/paperless-ngx:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| paperless-ngx | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| payload | `ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c` |  | skip | high | no newer compatible tag found | crane ls |
+| payload | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| pdf2zh | `byaidu/pdf2zh:1.9.6` | `byaidu/pdf2zh:1.9.11` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/backend:2.1.2` | `penpotapp/backend:2.16.2` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/exporter:2.1.2` | `penpotapp/exporter:2.16.2` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `penpotapp/frontend:2.1.2` | `penpotapp/frontend:2.16.2` | update | high | newer compatible semver tag found | crane ls |
+| penpot | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| perplexica | `itzcrazykns1337/perplexica:v1.10.2` | `itzcrazykns1337/perplexica:v1.12.0` | update | high | newer compatible semver tag found | crane ls |
+| perplexica | `searxng/searxng:2025.2.20-28d1240fc` |  | skip | high | no newer compatible tag found | crane ls |
+| pgadmin4 | `dpage/pgadmin4:8.9` |  | manual | low | unsupported tag family | tag parser |
+| photoprism | `photoprism/photoprism:240711` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| phpmyadmin | `phpmyadmin:5.2.1` | `phpmyadmin:5.2.3` | update | high | newer compatible semver tag found | crane ls |
+| plane | `makeplane/plane-admin:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-backend:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-frontend:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `makeplane/plane-space:v0.22-dev` |  | manual | low | unsupported tag family | tag parser |
+| plane | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| planka | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| planka | `ghcr.io/plankanban/planka:2.1.1` |  | skip | high | no newer compatible tag found | crane ls |
+| planka | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| plausible | `clickhouse/clickhouse-server:23.3.7.5-alpine` |  | manual | low | unsupported tag family | tag parser |
+| plausible | `plausible/analytics:v2.0` |  | manual | low | unsupported tag family | tag parser |
+| pocket-id | `ghcr.io/pocket-id/pocket-id:v2.2.0` | `ghcr.io/pocket-id/pocket-id:v2.9.0` | update | high | newer compatible semver tag found | crane ls |
+| pocketbase | `adrianmusante/pocketbase:0.29.3` | `adrianmusante/pocketbase:0.39.5` | update | high | newer compatible semver tag found | crane ls |
+| pocketbase | `busybox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| posthog | `clickhouse/clickhouse-server:25.8.12.129` |  | manual | low | unsupported tag family | tag parser |
+| posthog | `docker.redpanda.com/redpandadata/redpanda:v25.1.9` | `docker.redpanda.com/redpandadata/redpanda:v26.1.12` | update | high | newer compatible semver tag found | crane ls |
+| posthog | `ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65` |  | manual | low | digest-only image requires manual release check | image digest |
+| posthog | `ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| posthog | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| posthog | `zookeeper:3.9.3` | `zookeeper:3.9.5` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `busybox:1.36.1` | `busybox:1.38.0` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `elasticsearch:7.17.27` | `elasticsearch:9.4.3` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `ghcr.io/gitroomhq/postiz-app:v2.21.8` | `ghcr.io/gitroomhq/postiz-app:v2.21.10` | update | high | newer compatible semver tag found | crane ls |
+| postiz | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| postiz | `temporalio/auto-setup:1.28.1` | `temporalio/auto-setup:1.29.7` | update | high | newer compatible semver tag found | crane ls |
+| presenton | `ghcr.io/presenton/presenton:v0.8.2-beta` | `ghcr.io/presenton/presenton:v0.8.9-beta` | update | high | newer compatible semver tag found | crane ls |
+| prestashop | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| prestashop | `prestashop/prestashop:9.1.3-apache` | `prestashop/prestashop:9.1.4-apache` | update | high | newer compatible semver tag found | crane ls |
+| privatebin | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| privatebin | `frooodle/privatebin:0.26.1-fat` |  | blocked | low | Error: reading tags for index.docker.io/frooodle/privatebin: GET https://index.docker.io/v2/frooodle/privatebin/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:frooodle/privatebin Type:repository]] | crane ls |
+| privatebin | `ghcr.io/privatebin/fs:1.7.4` | `ghcr.io/privatebin/fs:2.0.4` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `ghcr.io/pterodactyl/panel:v1.12.4` | `ghcr.io/pterodactyl/panel:v1.14.1` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `public.ecr.aws/docker/library/mysql:8.0.30` | `public.ecr.aws/docker/library/mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| pterodactyl | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| qinglong | `whyour/qinglong:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| quay | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| quay | `python:3.12.8-alpine3.20` | `python:3.14.6-alpine3.24` | update | high | newer compatible semver tag found | crane ls |
+| quay | `quay.io/projectquay/quay:v3.9.8` | `quay.io/projectquay/quay:v3.17.3` | update | high | newer compatible semver tag found | crane ls |
+| rclone | `rclone/rclone:1.74.3` |  | skip | high | no newer compatible tag found | crane ls |
+| redisinsight | `redislabs/redisinsight:2.52` |  | manual | low | unsupported tag family | tag parser |
+| refly | `mautic/mautic:5.2.3-fpm` | `mautic/mautic:7.1.3-fpm` | update | high | newer compatible semver tag found | crane ls |
+| refly | `reflyai/elasticsearch:7.10.2` |  | skip | high | no newer compatible tag found | crane ls |
+| refly | `reflyai/qdrant:v1.13.1` |  | skip | high | no newer compatible tag found | crane ls |
+| refly | `reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400` |  | manual | low | unsupported tag family | tag parser |
+| refly | `reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400` |  | manual | low | unsupported tag family | tag parser |
+| refly | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| registry | `joxit/docker-registry-ui:2.5.6-debian` | `joxit/docker-registry-ui:2.6.0-debian` | update | high | newer compatible semver tag found | crane ls |
+| registry | `registry:2.8.3` | `registry:3.1.1` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat | `mongo:6.0` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat | `registry.rocket.chat/rocketchat/rocket.chat:7.9.0` | `registry.rocket.chat/rocketchat/rocket.chat:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `mongo:6.0` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat-micro | `nats:2.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| rocketchat-micro | `natsio/nats-server-config-reloader:0.6.3` | `natsio/nats-server-config-reloader:0.23.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/account-service:7.9.0` | `rocketchat/account-service:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/authorization-service:7.9.0` | `rocketchat/authorization-service:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/ddp-streamer-service:7.9.0` | `rocketchat/ddp-streamer-service:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/presence-service:7.9.0` | `rocketchat/presence-service:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/rocket.chat:7.9.0` | `rocketchat/rocket.chat:8.6.0` | update | high | newer compatible semver tag found | crane ls |
+| rocketchat-micro | `rocketchat/stream-hub-service:7.9.0` | `rocketchat/stream-hub-service:7.13.9` | update | high | newer compatible semver tag found | crane ls |
+| rsshub | `browserless/chrome:1.61.1-chrome-stable` |  | skip | high | no newer compatible tag found | crane ls |
+| rsshub | `diygod/rsshub:2024-07-06` | `diygod/rsshub:2026-07-08` | update | medium | newer compatible date tag found | crane ls |
+| rustdesk | `rustdesk/rustdesk-server-s6:1.1.15` |  | skip | high | no newer compatible tag found | crane ls |
+| rustfs | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| rustfs | `rustfs/rustfs:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| rybbit | `clickhouse/clickhouse-server:25.4.2` | `clickhouse/clickhouse-server:26.6.1` | update | high | newer compatible semver tag found | crane ls |
+| rybbit | `ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba` |  | manual | low | unsupported tag family | tag parser |
+| rybbit | `ghcr.io/rybbit-io/rybbit-client:sha-aa404ba` |  | manual | low | unsupported tag family | tag parser |
+| rybbit | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| s-pdf | `alpine` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| s-pdf | `ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat` | `ghcr.io/stirling-tools/stirling-pdf:2.14.1-fat` | update | high | newer compatible semver tag found | crane ls |
+| s-pdf | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| samarium | `ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867` |  | skip | high | no newer compatible tag found | crane ls |
+| signoz | `busybox` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| signoz | `busybox:1.28` |  | manual | low | unsupported tag family | tag parser |
+| signoz | `clickhouse/clickhouse-server:25.5.6` | `clickhouse/clickhouse-server:26.6.1` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/signoz-otel-collector:v0.144.2` | `signoz/signoz-otel-collector:v0.144.5` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/signoz:v0.117.0` | `signoz/signoz:v0.132.0` | update | high | newer compatible semver tag found | crane ls |
+| signoz | `signoz/zookeeper:3.7.1` | `signoz/zookeeper:3.9.3` | update | high | newer compatible semver tag found | crane ls |
+| sillytavern | `ghcr.io/sillytavern/sillytavern:1.18.0` |  | skip | high | no newer compatible tag found | crane ls |
+| skardi | `ghcr.io/skardilabs/skardi/skardi-server:0.3.0` | `ghcr.io/skardilabs/skardi/skardi-server:0.4.0` | update | high | newer compatible semver tag found | crane ls |
+| stalwart | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| stalwart | `stalwartlabs/stalwart:v0.16.7` | `stalwartlabs/stalwart:v0.16.12` | update | high | newer compatible semver tag found | crane ls |
+| steel-browser | `ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1` |  | manual | low | digest-only image requires manual release check | image digest |
+| strapi | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| strapi | `vshadbolt/strapi:5.33.0` | `vshadbolt/strapi:5.50.0` | update | high | newer compatible semver tag found | crane ls |
+| sub2api | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| sub2api | `weishaw/sub2api:0.1.104` | `weishaw/sub2api:0.1.146` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `darthsim/imgproxy:v3.30.1` | `darthsim/imgproxy:v4.0.11` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `kong:2.8.1` | `kong:3.9.3` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `postgres:16.4` |  | manual | low | unsupported tag family | tag parser |
+| supabase | `postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9` |  | manual | low | digest-only image requires manual release check | image digest |
+| supabase | `supabase/edge-runtime:v1.70.3` | `supabase/edge-runtime:v1.74.2` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/gotrue:v2.186.0` | `supabase/gotrue:v2.192.0` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/logflare:1.31.2` | `supabase/logflare:1.46.0` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/postgres-meta:v0.95.2` | `supabase/postgres-meta:v0.96.6` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/realtime:v2.76.5` | `supabase/realtime:v2.112.9` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/storage-api:v1.37.8` | `supabase/storage-api:v1.64.0` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `supabase/studio:2026.02.16-sha-26c615c` | `supabase/studio:2026.07.07-sha-a6a04f2` | update | medium | newer compatible date tag found | crane ls |
+| supabase | `supabase/supavisor:2.7.4` | `supabase/supavisor:2.9.7` | update | high | newer compatible semver tag found | crane ls |
+| supabase | `timberio/vector:0.53.0-alpine` | `timberio/vector:0.56.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| superset | `apachesuperset.docker.scarf.sh/apache/superset:6.1.0` |  | blocked | low | crane ls timed out after 20s | crane ls |
+| superset | `postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| surveyking | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| surveyking | `surveyking/surveyking:v1.9.0` | `surveyking/surveyking:v1.12.0` | update | high | newer compatible semver tag found | crane ls |
+| syncthing | `syncthing/syncthing:2.1.1` |  | skip | high | no newer compatible tag found | crane ls |
+| tailchat | `minio/minio` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| tailchat | `moonrailgun/tailchat:1.11.5` | `moonrailgun/tailchat:1.11.11` | update | high | newer compatible semver tag found | crane ls |
+| teable | `registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| teable | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tentix | `limbo2342/tentix:dev-2025-10-23-x.3` |  | manual | low | unsupported tag family | tag parser |
+| tentix | `limbo2342/tentix:migrate.10.22.x1` |  | manual | low | unsupported tag family | tag parser |
+| tianji | `moonrailgun/tianji:1.18.5` | `moonrailgun/tianji:1.32.16` | update | high | newer compatible semver tag found | crane ls |
+| tianji | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tolgee | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| tolgee | `tolgee/tolgee:v3.113.0` | `tolgee/tolgee:v3.209.3` | update | high | newer compatible semver tag found | crane ls |
+| tooljet | `postgres:16-alpine` |  | manual | low | unsupported tag family | tag parser |
+| tooljet | `postgrest/postgrest:v12.0.2` | `postgrest/postgrest:v13.0.8` | update | high | newer compatible semver tag found | crane ls |
+| tooljet | `tooljet/tooljet-ce:v3.20.170-lts` | `tooljet/tooljet-ce:v3.20.192-lts` | update | high | newer compatible semver tag found | crane ls |
+| tradingagents | `alpine/git:2.49.1` | `alpine/git:2.54.0` | update | high | newer compatible semver tag found | crane ls |
+| tradingagents | `python:3.12-slim` |  | manual | low | unsupported tag family | tag parser |
+| trendradar | `wantcat/trendradar:6.9.1` | `wantcat/trendradar:6.10.0` | update | high | newer compatible semver tag found | crane ls |
+| tududi | `chrisvel/tududi:1.1.0` | `chrisvel/tududi:1.2.0` | update | high | newer compatible semver tag found | crane ls |
+| twenty | `busybox:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| twenty | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| twenty | `twentycrm/twenty:v1.12.0` | `twentycrm/twenty:v2.19.0` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `axllent/mailpit:v1.30.1` | `axllent/mailpit:v1.30.3` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `baptistearno/typebot-builder:3.17.1` | `baptistearno/typebot-builder:3.17.2` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `baptistearno/typebot-viewer:3.17.1` | `baptistearno/typebot-viewer:3.17.2` | update | high | newer compatible semver tag found | crane ls |
+| typebot | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| typebot | `public.ecr.aws/docker/library/redis:7.2.7-alpine` | `public.ecr.aws/docker/library/redis:8.8.0-alpine` | update | high | newer compatible semver tag found | crane ls |
+| typesense | `typesense/typesense:29.0` |  | manual | low | unsupported tag family | tag parser |
+| typo3 | `martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25` |  | manual | low | unsupported tag family | tag parser |
+| typo3 | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| ubuntu-sshd | `takeyamajp/ubuntu-sshd:ubuntu22.04` |  | manual | low | unsupported tag family | tag parser |
+| umami | `ghcr.io/umami-software/umami:3.0.2` | `ghcr.io/umami-software/umami:3.2.0` | update | high | newer compatible semver tag found | crane ls |
+| umami | `postgres:14-alpine` |  | manual | low | unsupported tag family | tag parser |
+| uptime-kuma | `louislam/uptime-kuma:1.23.13` | `louislam/uptime-kuma:2.4.0` | update | high | newer compatible semver tag found | crane ls |
+| vaultwarden | `vaultwarden/server:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| waha | `devlikeapro/waha:chrome-2026.5.1` |  | manual | low | unsupported tag family | tag parser |
+| waha | `public.ecr.aws/docker/library/postgres:16.4-alpine` |  | manual | low | unsupported tag family | tag parser |
+| webos | `fs185085781/webos:v1.4.1` | `fs185085781/webos:v1.4.4` | update | high | newer compatible semver tag found | crane ls |
+| wechat | `ricwang/docker-wechat:4.0.0.30` |  | manual | low | unsupported tag family | tag parser |
+| wechat2rss | `ttttmr/wechat2rss:latest` |  | manual | low | floating or missing tag requires manual pinning | image tag |
+| wewe-rss | `cooderl/wewe-rss:v2.6.1` |  | skip | high | no newer compatible tag found | crane ls |
+| wewe-rss | `joseluisq/mysql-client:8.0.30` | `joseluisq/mysql-client:8.0.44` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `wordpress:6.9.1-php8.3-apache` | `wordpress:7.0.0-php8.5-apache` | update | high | newer compatible semver tag found | crane ls |
+| woocommerce | `wordpress:cli-2.9.0-php8.3` |  | manual | low | unsupported tag family | tag parser |
+| wordpress | `wordpress:6.5.4` | `wordpress:7.0.0` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-ai-service:0.15.17` | `ghcr.io/canner/wren-ai-service:0.29.3` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-bootstrap:0.1.5` |  | skip | high | no newer compatible tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-engine-ibis:0.14.3` | `ghcr.io/canner/wren-engine-ibis:0.25.0` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-engine:0.14.3` | `ghcr.io/canner/wren-engine:0.24.6` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `ghcr.io/canner/wren-ui:0.20.1` | `ghcr.io/canner/wren-ui:0.32.2` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `qdrant/qdrant:v1.13.4` | `qdrant/qdrant:v1.18.2` | update | high | newer compatible semver tag found | crane ls |
+| wrenai | `senzing/postgresql-client:2.2.4` |  | blocked | low | Error: reading tags for index.docker.io/senzing/postgresql-client: GET https://index.docker.io/v2/senzing/postgresql-client/tags/list?n=1000: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:senzing/postgresql-client Type:repository]] | crane ls |
+| yourls | `mysql:8.0.30` | `mysql:9.7.1` | update | high | newer compatible semver tag found | crane ls |
+| yourls | `yourls:1.10.1` | `yourls:1.10.4` | update | high | newer compatible semver tag found | crane ls |
+| zitadel | `ghcr.io/zitadel/zitadel:v4.10.1` | `ghcr.io/zitadel/zitadel:v4.15.3` | update | high | newer compatible semver tag found | crane ls |
+| zot | `ghcr.io/project-zot/zot:v2.1.14` | `ghcr.io/project-zot/zot:v2.1.18` | update | high | newer compatible semver tag found | crane ls |
+| zot | `httpd:2.4.63-alpine3.22` | `httpd:2.4.68-alpine3.24` | update | high | newer compatible semver tag found | crane ls |
+
+## Record Locations
+
+### AllinSSL: `docker.io/allinssl/allinssl`
+- `originImageName` at `template/AllinSSL/index.yaml:52`
+
+### AllinSSL: `docker.io/allinssl/allinssl:latest`
+- `image` at `template/AllinSSL/index.yaml:70`
+
+### OpenDeepWiki: `${{ inputs.wiki_image }}`
+- `originImageName` at `template/OpenDeepWiki/index.yaml:132`
+- `image` at `template/OpenDeepWiki/index.yaml:159`
+
+### OpenDeepWiki: `${{ inputs.wiki_web_image }}`
+- `originImageName` at `template/OpenDeepWiki/index.yaml:302`
+- `image` at `template/OpenDeepWiki/index.yaml:327`
+
+### Reactive-Resume: `amruthpillai/reactive-resume:v4.1.2`
+- `image` at `template/Reactive-Resume/index.yaml:351`
+
+### Reactive-Resume: `bitnamilegacy/postgresql:latest`
+- `image` at `template/Reactive-Resume/index.yaml:541`
+- `image` at `template/Reactive-Resume/index.yaml:563`
+
+### Reactive-Resume: `ghcr.io/browserless/chromium:v2.11.0`
+- `image` at `template/Reactive-Resume/index.yaml:290`
+
+### Reactive-Resume: `quay.io/minio/minio`
+- `originImageName` at `template/Reactive-Resume/index.yaml:165`
+
+### Reactive-Resume: `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z`
+- `image` at `template/Reactive-Resume/index.yaml:198`
+
+### Readeck: `codeberg.org/readeck/readeck:0.16.0`
+- `originImageName` at `template/Readeck/index.yaml:36`
+- `image` at `template/Readeck/index.yaml:64`
+
+### Ruiqi-Waf: `limbo2342/ruiqi-waf:sha-32b359f`
+- `image` at `template/Ruiqi-Waf/index.yaml:164`
+
+### ace-step: `ghcr.io/ace-step/ace-step-1.5:v0.1.0`
+- `originImageName` at `template/ace-step/index.yaml:91`
+- `image` at `template/ace-step/index.yaml:114`
+
+### affine: `ghcr.io/toeverything/affine:0.26.7`
+- `image` at `template/affine/index.yaml:357`
+- `originImageName` at `template/affine/index.yaml:419`
+- `image` at `template/affine/index.yaml:490`
+
+### affine: `postgres:16-alpine`
+- `image` at `template/affine/index.yaml:253`
+- `image` at `template/affine/index.yaml:317`
+- `image` at `template/affine/index.yaml:444`
+
+### agora: `agoracn/token:0.1.2023053011`
+- `originImageName` at `template/agora/index.yaml:49`
+- `image` at `template/agora/index.yaml:69`
+
+### airbyte: `airbyte/bootloader:2.1.0`
+- `image` at `template/airbyte/index.yaml:953`
+
+### airbyte: `airbyte/cron:2.1.0`
+- `originImageName` at `template/airbyte/index.yaml:2010`
+- `image` at `template/airbyte/index.yaml:2066`
+
+### airbyte: `airbyte/server:2.1.0`
+- `originImageName` at `template/airbyte/index.yaml:1168`
+- `image` at `template/airbyte/index.yaml:1232`
+
+### airbyte: `airbyte/worker:2.1.0`
+- `originImageName` at `template/airbyte/index.yaml:1601`
+- `image` at `template/airbyte/index.yaml:1659`
+
+### airbyte: `bitnamilegacy/kubectl:1.33.4`
+- `image` at `template/airbyte/index.yaml:162`
+- `image` at `template/airbyte/index.yaml:780`
+- `image` at `template/airbyte/index.yaml:894`
+- `image` at `template/airbyte/index.yaml:924`
+- `image` at `template/airbyte/index.yaml:1076`
+- `image` at `template/airbyte/index.yaml:1191`
+- `image` at `template/airbyte/index.yaml:1624`
+- `image` at `template/airbyte/index.yaml:2031`
+- `image` at `template/airbyte/index.yaml:2263`
+
+### airbyte: `postgres:16.4-alpine`
+- `image` at `template/airbyte/index.yaml:607`
+- `image` at `template/airbyte/index.yaml:811`
+- `image` at `template/airbyte/index.yaml:1107`
+
+### airbyte: `temporalio/auto-setup:1.29.7`
+- `originImageName` at `template/airbyte/index.yaml:2242`
+- `image` at `template/airbyte/index.yaml:2298`
+
+### anki-sync-server: `ghcr.io/yangchuansheng/anki-sync-server:24.06.3`
+- `originImageName` at `template/anki-sync-server/index.yaml:45`
+- `image` at `template/anki-sync-server/index.yaml:68`
+
+### anything-llm: `mintplexlabs/anythingllm:1.14.0`
+- `originImageName` at `template/anything-llm/index.yaml:75`
+- `image` at `template/anything-llm/index.yaml:100`
+
+### apitable: `apitable/backend-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:1024`
+- `image` at `template/apitable/index.yaml:1107`
+
+### apitable: `apitable/databus-server@sha256:462fa8bea11df94642b80a58d683aaf9995d79061588843a9d6b7ee66a421600`
+- `originImageName` at `template/apitable/index.yaml:1564`
+- `image` at `template/apitable/index.yaml:1645`
+
+### apitable: `apitable/imageproxy-server:v0.13.4-alpha_build13`
+- `originImageName` at `template/apitable/index.yaml:1729`
+- `image` at `template/apitable/index.yaml:1749`
+
+### apitable: `apitable/init-appdata@sha256:4fa2ed5d1a5a3e2f7bd449352ec3054747127aabe4f91c62fc13f4660b25558b`
+- `originImageName` at `template/apitable/index.yaml:921`
+- `image` at `template/apitable/index.yaml:978`
+
+### apitable: `apitable/init-db:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:819`
+- `image` at `template/apitable/index.yaml:875`
+
+### apitable: `apitable/room-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:1249`
+- `image` at `template/apitable/index.yaml:1332`
+
+### apitable: `apitable/web-server:v1.13.0-beta.1_2016`
+- `originImageName` at `template/apitable/index.yaml:1486`
+- `image` at `template/apitable/index.yaml:1506`
+
+### apitable: `busybox:1.38.0`
+- `image` at `template/apitable/index.yaml:1085`
+- `image` at `template/apitable/index.yaml:1310`
+- `image` at `template/apitable/index.yaml:1624`
+
+### apitable: `mysql:9.7.1`
+- `originImageName` at `template/apitable/index.yaml:641`
+- `image` at `template/apitable/index.yaml:656`
+- `image` at `template/apitable/index.yaml:835`
+- `image` at `template/apitable/index.yaml:937`
+- `image` at `template/apitable/index.yaml:1045`
+- `image` at `template/apitable/index.yaml:1270`
+- `image` at `template/apitable/index.yaml:1584`
+
+### apitable: `nginx:1.31.2-alpine`
+- `originImageName` at `template/apitable/index.yaml:1808`
+- `image` at `template/apitable/index.yaml:1828`
+
+### apitable: `rabbitmq:4.3.2-management`
+- `originImageName` at `template/apitable/index.yaml:709`
+- `image` at `template/apitable/index.yaml:732`
+
+### appflowy: `appflowyinc/appflowy_cloud:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:491`
+- `image` at `template/appflowy/index.yaml:511`
+
+### appflowy: `appflowyinc/appflowy_web:0.14.9`
+- `originImageName` at `template/appflowy/index.yaml:820`
+- `image` at `template/appflowy/index.yaml:840`
+
+### appflowy: `appflowyinc/appflowy_worker:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:692`
+- `image` at `template/appflowy/index.yaml:712`
+
+### appflowy: `appflowyinc/gotrue:0.15.22`
+- `originImageName` at `template/appflowy/index.yaml:356`
+- `image` at `template/appflowy/index.yaml:376`
+
+### appflowy: `postgres:16.4-alpine`
+- `image` at `template/appflowy/index.yaml:205`
+
+### appsmith: `appsmith/appsmith-ce:v1.29`
+- `originImageName` at `template/appsmith/index.yaml:36`
+- `image` at `template/appsmith/index.yaml:59`
+
+### appwrite: `appwrite/appwrite:1.9.0`
+- `originImageName` at `template/appwrite/index.yaml:285`
+- `image` at `template/appwrite/index.yaml:356`
+
+### appwrite: `appwrite/console:7.8.26`
+- `originImageName` at `template/appwrite/index.yaml:556`
+- `image` at `template/appwrite/index.yaml:577`
+
+### appwrite: `busybox:1.36.1`
+- `image` at `template/appwrite/index.yaml:311`
+- `image` at `template/appwrite/index.yaml:333`
+
+### artalk: `artalk/artalk-go:latest`
+- `originImageName` at `template/artalk/index.yaml:43`
+- `image` at `template/artalk/index.yaml:66`
+
+### asktable: `postgres:14-alpine`
+- `image` at `template/asktable/index.yaml:71`
+
+### asktable: `registry.cn-shanghai.aliyuncs.com/datamini/asktable-all-in-one:latest`
+- `image` at `template/asktable/index.yaml:113`
+
+### asktable: `registry.cn-shanghai.aliyuncs.com/datamini/asktable-atbox:latest`
+- `image` at `template/asktable/index.yaml:209`
+
+### authentik: `ghcr.io/goauthentik/server:2025.12.3`
+- `originImageName` at `template/authentik/index.yaml:175`
+- `image` at `template/authentik/index.yaml:195`
+- `originImageName` at `template/authentik/index.yaml:290`
+- `image` at `template/authentik/index.yaml:310`
+
+### authentik: `postgres:16.4-alpine`
+- `image` at `template/authentik/index.yaml:130`
+
+### banana-slides: `anoinex/banana-slides-backend:latest`
+- `originImageName` at `template/banana-slides/index.yaml:112`
+- `image` at `template/banana-slides/index.yaml:132`
+
+### banana-slides: `anoinex/banana-slides-frontend:latest`
+- `originImageName` at `template/banana-slides/index.yaml:212`
+- `image` at `template/banana-slides/index.yaml:231`
+
+### billionmail: `alpine/openssl:3.5.4`
+- `image` at `template/billionmail/index.yaml:6468`
+
+### billionmail: `alpine/socat:1.8.0.0@sha256:a6be4c0262b339c53ddad723cdd178a1a13271e1137c65e27f90a08c16de02b8`
+- `image` at `template/billionmail/index.yaml:6692`
+- `image` at `template/billionmail/index.yaml:6723`
+- `image` at `template/billionmail/index.yaml:6755`
+
+### billionmail: `billionmail/core:4.9.3@sha256:b97c71b463e99368f0fb50a4f3088139c2f04a37171d3b660b92f946a3076692`
+- `originImageName` at `template/billionmail/index.yaml:6434`
+- `image` at `template/billionmail/index.yaml:7033`
+
+### billionmail: `billionmail/dovecot:1.6@sha256:bbf5c304f248141768d1dbdf26b190fd28b69de6969b90e994ee81f54b942fab`
+- `image` at `template/billionmail/index.yaml:6822`
+
+### billionmail: `billionmail/postfix:1.6@sha256:870656c055c83f4e4b83fcd4c2f9cecfbcd0d8e3a963ab7d0c9c88bd6b348342`
+- `image` at `template/billionmail/index.yaml:6901`
+
+### billionmail: `billionmail/rspamd:1.2@sha256:bed48c106e8b8fcbf0a133c86e90900e7e17d4dec14cc30a9ddf989ada74f058`
+- `image` at `template/billionmail/index.yaml:6775`
+
+### billionmail: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/billionmail/index.yaml:153`
+- `image` at `template/billionmail/index.yaml:6509`
+
+### billionmail: `python:3.12.12-alpine`
+- `image` at `template/billionmail/index.yaml:6672`
+
+### billionmail: `roundcube/roundcubemail:1.6.11-fpm-alpine`
+- `image` at `template/billionmail/index.yaml:6974`
+
+### blossom: `docker.io/arey/mysql-client:latest`
+- `image` at `template/blossom/index.yaml:315`
+
+### blossom: `jasminexzzz/blossom:1.16.0`
+- `originImageName` at `template/blossom/index.yaml:46`
+- `image` at `template/blossom/index.yaml:69`
+
+### btpanel: `btpanel/baota:nas`
+- `originImageName` at `template/btpanel/index.yaml:38`
+- `image` at `template/btpanel/index.yaml:56`
+
+### budibase: `budibase/apps:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:429`
+- `image` at `template/budibase/index.yaml:449`
+
+### budibase: `budibase/couchdb:v3.3.3-sqs-v2.1.1`
+- `originImageName` at `template/budibase/index.yaml:254`
+- `image` at `template/budibase/index.yaml:290`
+
+### budibase: `budibase/proxy:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:821`
+- `image` at `template/budibase/index.yaml:841`
+
+### budibase: `budibase/worker:3.15.0`
+- `originImageName` at `template/budibase/index.yaml:625`
+- `image` at `template/budibase/index.yaml:645`
+
+### budibase: `busybox:1.37.0`
+- `image` at `template/budibase/index.yaml:276`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb-scheduler:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:607`
+- `image` at `template/bunkerweb/index.yaml:680`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb-ui:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:855`
+- `image` at `template/bunkerweb/index.yaml:937`
+
+### bunkerweb: `docker.io/bunkerity/bunkerweb:1.6.11`
+- `originImageName` at `template/bunkerweb/index.yaml:418`
+- `image` at `template/bunkerweb/index.yaml:511`
+
+### bunkerweb: `docker.io/library/busybox:1.36.1`
+- `image` at `template/bunkerweb/index.yaml:487`
+- `image` at `template/bunkerweb/index.yaml:633`
+- `image` at `template/bunkerweb/index.yaml:656`
+
+### bunkerweb: `docker.io/library/postgres:16.4-alpine`
+- `image` at `template/bunkerweb/index.yaml:174`
+- `image` at `template/bunkerweb/index.yaml:446`
+- `image` at `template/bunkerweb/index.yaml:881`
+
+### bunkerweb: `docker.io/traefik/whoami:v1.11.0`
+- `originImageName` at `template/bunkerweb/index.yaml:349`
+- `image` at `template/bunkerweb/index.yaml:369`
+
+### bytebase: `bytebase/bytebase:3.6.1`
+- `originImageName` at `template/bytebase/index.yaml:45`
+- `image` at `template/bytebase/index.yaml:68`
+
+### calcom: `calcom.docker.scarf.sh/calcom/cal.com:v6.2.0`
+- `originImageName` at `template/calcom/index.yaml:217`
+- `image` at `template/calcom/index.yaml:237`
+
+### calcom: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/calcom/index.yaml:173`
+
+### cap: `ghcr.io/capsoftware/cap-media-server@sha256:243b69c5d8b132a425641b6e6ada79c119467cc88a6b9446dd4f8dea6b579fad`
+- `originImageName` at `template/cap/index.yaml:342`
+- `image` at `template/cap/index.yaml:362`
+
+### cap: `ghcr.io/capsoftware/cap-web@sha256:8d2e21251b404e2b15772ded7bbf129cf980e6446102ea9b1326567647891e57`
+- `originImageName` at `template/cap/index.yaml:207`
+- `image` at `template/cap/index.yaml:227`
+
+### cap: `mysql:8.0.46-debian`
+- `image` at `template/cap/index.yaml:165`
+
+### casdoor: `casbin/casdoor:v1.702.0`
+- `image` at `template/casdoor/index.yaml:425`
+
+### casdoor: `casbin/casdoor:v2.32.0`
+- `originImageName` at `template/casdoor/index.yaml:334`
+- `image` at `template/casdoor/index.yaml:355`
+
+### casdoor: `mysql:8.0`
+- `image` at `template/casdoor/index.yaml:165`
+
+### casdoor: `postgres:14-alpine`
+- `image` at `template/casdoor/index.yaml:308`
+
+### changedetection: `ghcr.io/dgtlmoon/changedetection.io:0.50.43`
+- `originImageName` at `template/changedetection/index.yaml:43`
+- `image` at `template/changedetection/index.yaml:64`
+
+### chatany: `licoy/chatany:v3.5.0`
+- `originImageName` at `template/chatany/index.yaml:81`
+- `image` at `template/chatany/index.yaml:106`
+
+### chatbot-ui: `ghcr.io/mckaywrigley/chatbot-ui:main`
+- `originImageName` at `template/chatbot-ui/index.yaml:41`
+- `image` at `template/chatbot-ui/index.yaml:66`
+
+### chatgpt-next-web: `yidadaa/chatgpt-next-web:v2.12.4`
+- `originImageName` at `template/chatgpt-next-web/index.yaml:89`
+- `image` at `template/chatgpt-next-web/index.yaml:114`
+
+### chatgpt-on-wechat: `zhayujie/chatgpt-on-wechat:1.6.8`
+- `originImageName` at `template/chatgpt-on-wechat/index.yaml:78`
+- `image` at `template/chatgpt-on-wechat/index.yaml:98`
+
+### chatgpt-web: `chenzhaoyu94/chatgpt-web`
+- `originImageName` at `template/chatgpt-web/index.yaml:83`
+- `image` at `template/chatgpt-web/index.yaml:108`
+
+### chatnio: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/chatnio/index.yaml:290`
+
+### chatnio: `programzmh/chatnio@sha256:97587b5cdd85a4f5a9aee509304c594c9d66fa5f71b2164b78c064cec9feed2d`
+- `originImageName` at `template/chatnio/index.yaml:37`
+- `image` at `template/chatnio/index.yaml:60`
+
+### chatwoot: `chatwoot/chatwoot:v4.7.0`
+- `image` at `template/chatwoot/index.yaml:171`
+- `originImageName` at `template/chatwoot/index.yaml:383`
+- `image` at `template/chatwoot/index.yaml:404`
+- `originImageName` at `template/chatwoot/index.yaml:507`
+- `image` at `template/chatwoot/index.yaml:528`
+
+### chatwoot: `postgres:14-alpine`
+- `image` at `template/chatwoot/index.yaml:141`
+
+### chrome: `lscr.io/linuxserver/chrome:148.0.7778.178-1-ls95`
+- `originImageName` at `template/chrome/index.yaml:75`
+- `image` at `template/chrome/index.yaml:104`
+
+### cloudreve: `arey/mysql-client:latest`
+- `image` at `template/cloudreve/index.yaml:77`
+
+### cloudreve: `cloudreve/cloudreve`
+- `originImageName` at `template/cloudreve/index.yaml:54`
+- `image` at `template/cloudreve/index.yaml:109`
+
+### cobalt: `ghcr.io/imputnet/cobalt:7.13.3`
+- `originImageName` at `template/cobalt/index.yaml:62`
+- `image` at `template/cobalt/index.yaml:83`
+
+### code-server: `codercom/code-server:4.90.3-39`
+- `originImageName` at `template/code-server/index.yaml:45`
+- `image` at `template/code-server/index.yaml:72`
+
+### coze-studio: `alpine/curl:8.12.1`
+- `image` at `template/coze-studio/index.yaml:1042`
+
+### coze-studio: `alpine/git@sha256:d453f54c83320412aa89c391b076930bd8569bc1012285e8c68ce2d4435826a3`
+- `image` at `template/coze-studio/index.yaml:915`
+
+### coze-studio: `bitnamilegacy/elasticsearch:8.18.0`
+- `originImageName` at `template/coze-studio/index.yaml:633`
+- `image` at `template/coze-studio/index.yaml:666`
+
+### coze-studio: `bitnamilegacy/etcd@sha256:1b9977cf4cce7546873e0ee50e684c38a38a4e7a27d22086fbd2b8a1b44a69d0`
+- `originImageName` at `template/coze-studio/index.yaml:518`
+- `image` at `template/coze-studio/index.yaml:551`
+
+### coze-studio: `busybox:1.36.1`
+- `image` at `template/coze-studio/index.yaml:540`
+- `image` at `template/coze-studio/index.yaml:655`
+- `image` at `template/coze-studio/index.yaml:908`
+- `image` at `template/coze-studio/index.yaml:982`
+- `image` at `template/coze-studio/index.yaml:989`
+- `image` at `template/coze-studio/index.yaml:996`
+- `image` at `template/coze-studio/index.yaml:1148`
+
+### coze-studio: `cozedev/coze-studio-server:0.5.1`
+- `originImageName` at `template/coze-studio/index.yaml:888`
+- `image` at `template/coze-studio/index.yaml:1156`
+
+### coze-studio: `cozedev/coze-studio-web:0.5.1`
+- `originImageName` at `template/coze-studio/index.yaml:1361`
+- `image` at `template/coze-studio/index.yaml:1379`
+
+### coze-studio: `milvusdb/milvus:v2.5.10`
+- `originImageName` at `template/coze-studio/index.yaml:755`
+- `image` at `template/coze-studio/index.yaml:775`
+
+### coze-studio: `minio/mc:RELEASE.2025-05-21T01-59-54Z-cpuv1`
+- `image` at `template/coze-studio/index.yaml:1003`
+
+### coze-studio: `mysql:8.0.36`
+- `image` at `template/coze-studio/index.yaml:937`
+
+### coze-studio: `nsqio/nsq:v1.2.1`
+- `originImageName` at `template/coze-studio/index.yaml:378`
+- `image` at `template/coze-studio/index.yaml:394`
+- `originImageName` at `template/coze-studio/index.yaml:447`
+- `image` at `template/coze-studio/index.yaml:463`
+
+### crawl4ai: `unclecode/crawl4ai:0.8.9`
+- `originImageName` at `template/crawl4ai/index.yaml:37`
+- `image` at `template/crawl4ai/index.yaml:59`
+
+### crmeb: `ghcr.io/yangchuansheng/crmeb:v5.4.0`
+- `originImageName` at `template/crmeb/index.yaml:350`
+- `image` at `template/crmeb/index.yaml:373`
+- `image` at `template/crmeb/index.yaml:404`
+
+### crmeb: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/crmeb/index.yaml:129`
+
+### crmeb: `nginx:alpine3.20`
+- `image` at `template/crmeb/index.yaml:381`
+
+### cronicle: `soulteary/cronicle:0.9.46`
+- `originImageName` at `template/cronicle/index.yaml:34`
+- `image` at `template/cronicle/index.yaml:62`
+
+### dataease: `busybox:1.36.1`
+- `image` at `template/dataease/index.yaml:63`
+
+### dataease: `docker.io/arey/mysql-client:latest`
+- `image` at `template/dataease/index.yaml:358`
+
+### dataease: `registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.10.12`
+- `originImageName` at `template/dataease/index.yaml:39`
+- `image` at `template/dataease/index.yaml:113`
+
+### dbgate: `dbgate/dbgate:5.3.1-alpine`
+- `originImageName` at `template/dbgate/index.yaml:50`
+- `image` at `template/dbgate/index.yaml:78`
+
+### deeplx: `ghcr.io/owo-network/deeplx:v0.9.5`
+- `originImageName` at `template/deeplx/index.yaml:40`
+- `image` at `template/deeplx/index.yaml:65`
+
+### derper: `bitnamilegacy/kubectl:1.28.9`
+- `image` at `template/derper/index.yaml:196`
+
+### derper: `ghcr.io/yangchuansheng/derper:v1.99.0-pre`
+- `originImageName` at `template/derper/index.yaml:110`
+- `image` at `template/derper/index.yaml:132`
+
+### dify: `busybox:1.37.0`
+- `image` at `template/dify/index.yaml:112`
+
+### dify: `langgenius/dify-api:1.11.2`
+- `originImageName` at `template/dify/index.yaml:54`
+- `image` at `template/dify/index.yaml:131`
+- `image` at `template/dify/index.yaml:273`
+
+### dify: `langgenius/dify-plugin-daemon:0.5.2-local`
+- `originImageName` at `template/dify/index.yaml:681`
+- `image` at `template/dify/index.yaml:740`
+
+### dify: `langgenius/dify-sandbox:0.2.12`
+- `originImageName` at `template/dify/index.yaml:601`
+- `image` at `template/dify/index.yaml:624`
+
+### dify: `langgenius/dify-web:1.11.2`
+- `originImageName` at `template/dify/index.yaml:414`
+- `image` at `template/dify/index.yaml:470`
+
+### dify: `postgres:14-alpine`
+- `image` at `template/dify/index.yaml:77`
+- `image` at `template/dify/index.yaml:434`
+- `image` at `template/dify/index.yaml:704`
+- `image` at `template/dify/index.yaml:965`
+
+### dify: `semitechnologies/weaviate:1.27.0`
+- `originImageName` at `template/dify/index.yaml:1120`
+- `image` at `template/dify/index.yaml:1141`
+
+### directus: `directus/directus:11.17.4`
+- `originImageName` at `template/directus/index.yaml:332`
+- `image` at `template/directus/index.yaml:449`
+
+### directus: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/directus/index.yaml:357`
+
+### directus: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/directus/index.yaml:165`
+- `image` at `template/directus/index.yaml:380`
+
+### directus: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/directus/index.yaml:421`
+
+### docker-stacks: `jupyter/scipy-notebook:2023-10-20`
+- `originImageName` at `template/docker-stacks/index.yaml:36`
+- `image` at `template/docker-stacks/index.yaml:57`
+
+### docuseal: `docuseal/docuseal:3.0.1`
+- `originImageName` at `template/docuseal/index.yaml:184`
+- `image` at `template/docuseal/index.yaml:207`
+
+### docuseal: `postgres:16-alpine`
+- `image` at `template/docuseal/index.yaml:139`
+
+### dolibarr: `dolibarr/dolibarr:23.0.3-php8.2@sha256:c3c17731287f1a6a30ec7e0a3e7a82adda7bc93abd79af94714709704c8a4865`
+- `originImageName` at `template/dolibarr/index.yaml:213`
+- `image` at `template/dolibarr/index.yaml:234`
+
+### dolibarr: `mysql:8.0.30`
+- `image` at `template/dolibarr/index.yaml:161`
+
+### drawdb: `ghcr.io/drawdb-io/drawdb:v1.5.0`
+- `originImageName` at `template/drawdb/index.yaml:60`
+- `image` at `template/drawdb/index.yaml:81`
+
+### drizzle-studio: `ghcr.io/drizzle-team/gateway:latest`
+- `originImageName` at `template/drizzle-studio/index.yaml:42`
+- `image` at `template/drizzle-studio/index.yaml:63`
+
+### eaglercraft-server: `ghcr.io/yangchuansheng/eaglerx1.8server:1.12.1@sha256:fc4da0d4bc7dc6aed9ed284085366f8f57b298a3f2f31572dbd35832c2e84810`
+- `originImageName` at `template/eaglercraft-server/index.yaml:49`
+- `image` at `template/eaglercraft-server/index.yaml:77`
+
+### edgequake: `ghcr.io/raphaelmansuy/edgequake-frontend:0.12.2`
+- `originImageName` at `template/edgequake/index.yaml:380`
+- `image` at `template/edgequake/index.yaml:400`
+
+### edgequake: `ghcr.io/raphaelmansuy/edgequake:0.12.2`
+- `originImageName` at `template/edgequake/index.yaml:282`
+- `image` at `template/edgequake/index.yaml:302`
+
+### edgequake: `postgres:16-alpine`
+- `image` at `template/edgequake/index.yaml:163`
+
+### elasticsearch: `busybox:1.37.0`
+- `image` at `template/elasticsearch/index.yaml:63`
+
+### elasticsearch: `docker.elastic.co/elasticsearch/elasticsearch:9.4.1`
+- `originImageName` at `template/elasticsearch/index.yaml:37`
+- `image` at `template/elasticsearch/index.yaml:84`
+
+### emqx: `emqx/emqx:5.8.9`
+- `originImageName` at `template/emqx/index.yaml:57`
+- `image` at `template/emqx/index.yaml:91`
+
+### enshrouded: `alpine`
+- `image` at `template/enshrouded/index.yaml:90`
+
+### enshrouded: `bitnamilegacy/kubectl`
+- `image` at `template/enshrouded/index.yaml:102`
+- `image` at `template/enshrouded/index.yaml:211`
+
+### enshrouded: `registry.cn-hangzhou.aliyuncs.com/luanshaotong/enshrouded:v0.2`
+- `originImageName` at `template/enshrouded/index.yaml:68`
+- `image` at `template/enshrouded/index.yaml:143`
+
+### erpnext: `frappe/erpnext:v16.21.1`
+- `image` at `template/erpnext/index.yaml:374`
+- `image` at `template/erpnext/index.yaml:530`
+- `originImageName` at `template/erpnext/index.yaml:666`
+- `image` at `template/erpnext/index.yaml:731`
+- `originImageName` at `template/erpnext/index.yaml:786`
+- `image` at `template/erpnext/index.yaml:882`
+- `originImageName` at `template/erpnext/index.yaml:962`
+- `image` at `template/erpnext/index.yaml:1027`
+- `originImageName` at `template/erpnext/index.yaml:1118`
+- `image` at `template/erpnext/index.yaml:1214`
+- `originImageName` at `template/erpnext/index.yaml:1275`
+- `image` at `template/erpnext/index.yaml:1371`
+- `originImageName` at `template/erpnext/index.yaml:1432`
+- `image` at `template/erpnext/index.yaml:1497`
+
+### erpnext: `mariadb:11.4.7`
+- `originImageName` at `template/erpnext/index.yaml:66`
+- `image` at `template/erpnext/index.yaml:89`
+
+### erpnext: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/erpnext/index.yaml:319`
+- `image` at `template/erpnext/index.yaml:475`
+- `image` at `template/erpnext/index.yaml:687`
+- `image` at `template/erpnext/index.yaml:710`
+- `image` at `template/erpnext/index.yaml:807`
+- `image` at `template/erpnext/index.yaml:861`
+- `image` at `template/erpnext/index.yaml:983`
+- `image` at `template/erpnext/index.yaml:1006`
+- `image` at `template/erpnext/index.yaml:1139`
+- `image` at `template/erpnext/index.yaml:1193`
+- `image` at `template/erpnext/index.yaml:1296`
+- `image` at `template/erpnext/index.yaml:1350`
+- `image` at `template/erpnext/index.yaml:1453`
+- `image` at `template/erpnext/index.yaml:1476`
+
+### erpnext: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/erpnext/index.yaml:342`
+- `image` at `template/erpnext/index.yaml:498`
+- `image` at `template/erpnext/index.yaml:830`
+- `image` at `template/erpnext/index.yaml:1162`
+- `image` at `template/erpnext/index.yaml:1319`
+
+### ever-gauzy: `busybox:1.36.1`
+- `image` at `template/ever-gauzy/index.yaml:208`
+
+### ever-gauzy: `ghcr.io/ever-co/gauzy-api-demo@sha256:9c7efab08c8f48892486099e0cd6edda4eddfa27743b09dd953145d8ff5a5cc4`
+- `originImageName` at `template/ever-gauzy/index.yaml:186`
+- `image` at `template/ever-gauzy/index.yaml:271`
+
+### ever-gauzy: `ghcr.io/ever-co/gauzy-webapp-demo@sha256:6370fc7dcc8eeba67cc75f8a88afb9f85552be1602769af78d4da0c23f42e493`
+- `originImageName` at `template/ever-gauzy/index.yaml:516`
+- `image` at `template/ever-gauzy/index.yaml:537`
+
+### ever-gauzy: `postgres:16.4-alpine`
+- `image` at `template/ever-gauzy/index.yaml:149`
+- `image` at `template/ever-gauzy/index.yaml:228`
+
+### evolution-api: `evoapicloud/evolution-api:v2.3.7`
+- `originImageName` at `template/evolution-api/index.yaml:315`
+- `image` at `template/evolution-api/index.yaml:424`
+
+### evolution-api: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/evolution-api/index.yaml:340`
+
+### evolution-api: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/evolution-api/index.yaml:152`
+- `image` at `template/evolution-api/index.yaml:361`
+
+### evolution-api: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/evolution-api/index.yaml:393`
+
+### excalidraw: `excalidraw/excalidraw@sha256:36cd9a135e25b17e7e0b1b1d64df5fc1dad651eac72b6f2aa9c1d5401eddc68f`
+- `originImageName` at `template/excalidraw/index.yaml:36`
+- `image` at `template/excalidraw/index.yaml:63`
+
+### fast-poster: `fastposter/fastposter:latest`
+- `originImageName` at `template/fast-poster/index.yaml:34`
+- `image` at `template/fast-poster/index.yaml:52`
+
+### fastgpt: `postgres:16-alpine`
+- `image` at `template/fastgpt/index.yaml:369`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:1013`
+- `image` at `template/fastgpt/index.yaml:1033`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:1126`
+- `image` at `template/fastgpt/index.yaml:1146`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt/index.yaml:852`
+- `image` at `template/fastgpt/index.yaml:872`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt/index.yaml:562`
+- `image` at `template/fastgpt/index.yaml:582`
+
+### fastgpt: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt/index.yaml:1238`
+- `image` at `template/fastgpt/index.yaml:1258`
+
+### fastgpt-milvus: `postgres:16-alpine`
+- `image` at `template/fastgpt-milvus/index.yaml:1176`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:678`
+- `image` at `template/fastgpt-milvus/index.yaml:704`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:774`
+- `image` at `template/fastgpt-milvus/index.yaml:800`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:417`
+- `image` at `template/fastgpt-milvus/index.yaml:443`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:136`
+- `image` at `template/fastgpt-milvus/index.yaml:156`
+
+### fastgpt-milvus: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt-milvus/index.yaml:580`
+- `image` at `template/fastgpt-milvus/index.yaml:606`
+
+### fastgpt-pro: `postgres:16-alpine`
+- `image` at `template/fastgpt-pro/index.yaml:370`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-code-sandbox:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1161`
+- `image` at `template/fastgpt-pro/index.yaml:1181`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-mcp_server:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1274`
+- `image` at `template/fastgpt-pro/index.yaml:1294`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-plugin:v0.6.2`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1000`
+- `image` at `template/fastgpt-pro/index.yaml:1020`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt-pro:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:855`
+- `image` at `template/fastgpt-pro/index.yaml:875`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/fastgpt/fastgpt:v4.14.22`
+- `originImageName` at `template/fastgpt-pro/index.yaml:563`
+- `image` at `template/fastgpt-pro/index.yaml:583`
+
+### fastgpt-pro: `registry.cn-hangzhou.aliyuncs.com/labring/aiproxy:v0.5.8`
+- `originImageName` at `template/fastgpt-pro/index.yaml:1386`
+- `image` at `template/fastgpt-pro/index.yaml:1406`
+
+### featbit-standard: `featbit/featbit-api-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1118`
+- `image` at `template/featbit-standard/index.yaml:1179`
+
+### featbit-standard: `featbit/featbit-data-analytics-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1247`
+- `image` at `template/featbit-standard/index.yaml:1308`
+
+### featbit-standard: `featbit/featbit-evaluation-server:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1370`
+- `image` at `template/featbit-standard/index.yaml:1431`
+
+### featbit-standard: `featbit/featbit-ui:5.0.5`
+- `originImageName` at `template/featbit-standard/index.yaml:1497`
+- `image` at `template/featbit-standard/index.yaml:1519`
+
+### featbit-standard: `postgres:16-alpine`
+- `image` at `template/featbit-standard/index.yaml:240`
+- `image` at `template/featbit-standard/index.yaml:1140`
+- `image` at `template/featbit-standard/index.yaml:1269`
+- `image` at `template/featbit-standard/index.yaml:1392`
+
+### filecodebox: `lanol/filecodebox@sha256:e3609361ae7dfb7b72fef94d97e58ea268b960c3dc70719b7221277612946ad2`
+- `originImageName` at `template/filecodebox/index.yaml:126`
+- `image` at `template/filecodebox/index.yaml:147`
+
+### fireboom: `fireboomapi/fireboom_server@sha256:27ff832760dec9cf205f02b3516ad6663fa7cbfcf35da1b49196acd00efb598f`
+- `originImageName` at `template/fireboom/index.yaml:38`
+- `image` at `template/fireboom/index.yaml:61`
+
+### firecrawl: `busybox:1.36.1`
+- `image` at `template/firecrawl/index.yaml:258`
+- `image` at `template/firecrawl/index.yaml:702`
+
+### firecrawl: `ghcr.io/firecrawl/firecrawl@sha256:3eee4a4059d78da747fc04db4649b35c0f2cdd50cb618a8e444b2e7f256b583c`
+- `originImageName` at `template/firecrawl/index.yaml:450`
+- `image` at `template/firecrawl/index.yaml:728`
+
+### firecrawl: `ghcr.io/firecrawl/playwright-service@sha256:f5ee76305462a3e43daf3f4f4fe2d63b57a13acc2d115214629e8feb888b289e`
+- `originImageName` at `template/firecrawl/index.yaml:366`
+- `image` at `template/firecrawl/index.yaml:389`
+
+### firecrawl: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/firecrawl/index.yaml:474`
+
+### firecrawl: `rabbitmq:3.13.7-management`
+- `originImageName` at `template/firecrawl/index.yaml:230`
+- `image` at `template/firecrawl/index.yaml:287`
+
+### firecrawl: `redis:7.2.7-alpine`
+- `originImageName` at `template/firecrawl/index.yaml:145`
+- `image` at `template/firecrawl/index.yaml:169`
+- `image` at `template/firecrawl/index.yaml:675`
+
+### firefox: `jlesage/firefox:latest`
+- `originImageName` at `template/firefox/index.yaml:37`
+- `image` at `template/firefox/index.yaml:60`
+
+### flarum: `crazymax/flarum:1.8.10`
+- `originImageName` at `template/flarum/index.yaml:129`
+- `image` at `template/flarum/index.yaml:202`
+
+### flarum: `mysql:8.0.30`
+- `image` at `template/flarum/index.yaml:155`
+
+### flowise: `flowiseai/flowise:3.0.5`
+- `originImageName` at `template/flowise/index.yaml:195`
+- `image` at `template/flowise/index.yaml:257`
+
+### flowise: `postgres:14-alpine`
+- `image` at `template/flowise/index.yaml:157`
+- `image` at `template/flowise/index.yaml:217`
+
+### formbricks: `ghcr.io/formbricks/formbricks:4.9.7`
+- `originImageName` at `template/formbricks/index.yaml:344`
+- `image` at `template/formbricks/index.yaml:370`
+- `image` at `template/formbricks/index.yaml:426`
+
+### formbricks: `postgres:16-alpine`
+- `image` at `template/formbricks/index.yaml:165`
+
+### frp: `bitnamilegacy/kubectl:1.28.9`
+- `image` at `template/frp/index.yaml:299`
+
+### frp: `snowdreamtech/frps:0.59`
+- `originImageName` at `template/frp/index.yaml:79`
+- `image` at `template/frp/index.yaml:104`
+
+### full-stack-fastapi: `ghcr.io/yangchuansheng/full-stack-fastapi-backend:0.8.0`
+- `image` at `template/full-stack-fastapi/index.yaml:232`
+- `originImageName` at `template/full-stack-fastapi/index.yaml:300`
+- `image` at `template/full-stack-fastapi/index.yaml:320`
+
+### full-stack-fastapi: `ghcr.io/yangchuansheng/full-stack-fastapi-frontend:0.8.0`
+- `originImageName` at `template/full-stack-fastapi/index.yaml:429`
+- `image` at `template/full-stack-fastapi/index.yaml:449`
+
+### full-stack-fastapi: `postgres:14-alpine`
+- `image` at `template/full-stack-fastapi/index.yaml:183`
+
+### ghost: `ghost:6.44.1-alpine`
+- `originImageName` at `template/ghost/index.yaml:250`
+- `image` at `template/ghost/index.yaml:339`
+
+### ghost: `public.ecr.aws/docker/library/mysql:8.0.30`
+- `image` at `template/ghost/index.yaml:155`
+- `image` at `template/ghost/index.yaml:300`
+
+### ghost: `public.ecr.aws/docker/library/node:22-alpine`
+- `image` at `template/ghost/index.yaml:277`
+
+### gitea: `gitea/gitea:1.22.0-rootless`
+- `originImageName` at `template/gitea/index.yaml:36`
+- `image` at `template/gitea/index.yaml:63`
+
+### glance: `glanceapp/glance`
+- `originImageName` at `template/glance/index.yaml:146`
+
+### glance: `glanceapp/glance:latest`
+- `image` at `template/glance/index.yaml:164`
+
+### glitchtip: `glitchtip/glitchtip:v4.1.5`
+- `originImageName` at `template/glitchtip/index.yaml:61`
+- `image` at `template/glitchtip/index.yaml:86`
+- `image` at `template/glitchtip/index.yaml:175`
+- `image` at `template/glitchtip/index.yaml:265`
+
+### glitchtip: `senzing/postgresql-client:2.2.4`
+- `image` at `template/glitchtip/index.yaml:623`
+
+### gpt-academic: `ghcr.io/binary-husky/gpt_academic_nolocal:master`
+- `originImageName` at `template/gpt-academic/index.yaml:63`
+- `image` at `template/gpt-academic/index.yaml:88`
+
+### grafana: `grafana/grafana:13.0.2`
+- `originImageName` at `template/grafana/index.yaml:193`
+- `image` at `template/grafana/index.yaml:217`
+
+### grafana: `postgres:16.4-alpine`
+- `image` at `template/grafana/index.yaml:142`
+
+### grafana-otel: `busybox`
+- `image` at `template/grafana-otel/index.yaml:242`
+- `image` at `template/grafana-otel/index.yaml:372`
+
+### grafana-otel: `grafana/grafana:12.3.0`
+- `originImageName` at `template/grafana-otel/index.yaml:351`
+- `image` at `template/grafana-otel/index.yaml:384`
+
+### grafana-otel: `otel/opentelemetry-collector:0.99.0`
+- `originImageName` at `template/grafana-otel/index.yaml:70`
+- `image` at `template/grafana-otel/index.yaml:91`
+
+### grafana-otel: `prom/prometheus:v3.8.0`
+- `originImageName` at `template/grafana-otel/index.yaml:221`
+- `image` at `template/grafana-otel/index.yaml:254`
+
+### halo: `halohub/halo:2.18.0`
+- `originImageName` at `template/halo/index.yaml:48`
+- `image` at `template/halo/index.yaml:71`
+
+### halo: `senzing/postgresql-client:2.2.4`
+- `image` at `template/halo/index.yaml:271`
+
+### happy-server: `ghcr.io/yangchuansheng/happy-server@sha256:6986ce15ac7c00604ab4aea89c9f9831b44746ec20da5cb5812ff1ab40317cfe`
+- `originImageName` at `template/happy-server/index.yaml:704`
+- `image` at `template/happy-server/index.yaml:724`
+
+### happy-server: `postgres:16.4-alpine`
+- `image` at `template/happy-server/index.yaml:523`
+
+### harbor: `goharbor/harbor-core:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:606`
+- `image` at `template/harbor/index.yaml:628`
+
+### harbor: `goharbor/harbor-jobservice:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:739`
+- `image` at `template/harbor/index.yaml:762`
+
+### harbor: `goharbor/harbor-portal:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:840`
+- `image` at `template/harbor/index.yaml:862`
+
+### harbor: `goharbor/harbor-registryctl:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:1041`
+- `image` at `template/harbor/index.yaml:1063`
+
+### harbor: `goharbor/registry-photon:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:903`
+- `image` at `template/harbor/index.yaml:926`
+
+### harbor: `goharbor/trivy-adapter-photon:v2.14.4`
+- `originImageName` at `template/harbor/index.yaml:1121`
+- `image` at `template/harbor/index.yaml:1146`
+
+### harbor: `postgres:16.4`
+- `image` at `template/harbor/index.yaml:163`
+
+### hasura: `hasura/graphql-data-connector:v2.48.11`
+- `originImageName` at `template/hasura/index.yaml:215`
+- `image` at `template/hasura/index.yaml:235`
+
+### hasura: `hasura/graphql-engine:v2.48.11`
+- `originImageName` at `template/hasura/index.yaml:121`
+- `image` at `template/hasura/index.yaml:141`
+
+### headscale: `alpine`
+- `image` at `template/headscale/index.yaml:945`
+
+### headscale: `ghcr.io/tale/headplane:0.6.3`
+- `image` at `template/headscale/index.yaml:1042`
+
+### headscale: `headscale/headscale:0.29.0-beta.1-debug`
+- `originImageName` at `template/headscale/index.yaml:879`
+- `image` at `template/headscale/index.yaml:998`
+
+### headscale: `postgres:16-alpine`
+- `image` at `template/headscale/index.yaml:140`
+- `image` at `template/headscale/index.yaml:906`
+
+### heyform: `heyform/community-edition:v3.0.0-rc.7`
+- `originImageName` at `template/heyform/index.yaml:271`
+- `image` at `template/heyform/index.yaml:293`
+
+### illa-builder: `illasoft/illa-builder:v4.8.2`
+- `originImageName` at `template/illa-builder/index.yaml:38`
+- `image` at `template/illa-builder/index.yaml:61`
+
+### immich: `ghcr.io/immich-app/immich-machine-learning:v2.7.5`
+- `originImageName` at `template/immich/index.yaml:506`
+- `image` at `template/immich/index.yaml:529`
+
+### immich: `ghcr.io/immich-app/immich-server:v2.7.5`
+- `originImageName` at `template/immich/index.yaml:319`
+- `image` at `template/immich/index.yaml:388`
+
+### immich: `postgres:16-alpine`
+- `image` at `template/immich/index.yaml:255`
+- `image` at `template/immich/index.yaml:342`
+
+### influxdb: `docker.io/library/influxdb:2.9.1`
+- `originImageName` at `template/influxdb/index.yaml:47`
+- `image` at `template/influxdb/index.yaml:71`
+
+### inpaint-web: `yangchuansheng/inpaint-web`
+- `originImageName` at `template/inpaint-web/index.yaml:35`
+- `image` at `template/inpaint-web/index.yaml:60`
+
+### insforge: `apecloud/kubeblocks-tools:0.9.3`
+- `image` at `template/insforge/index.yaml:265`
+- `image` at `template/insforge/index.yaml:352`
+
+### insforge: `ghcr.io/insforge/deno-runtime:2.0.6`
+- `originImageName` at `template/insforge/index.yaml:767`
+- `image` at `template/insforge/index.yaml:787`
+
+### insforge: `ghcr.io/insforge/insforge-oss:v2.1.8`
+- `originImageName` at `template/insforge/index.yaml:420`
+- `image` at `template/insforge/index.yaml:500`
+
+### insforge: `postgres:16-alpine`
+- `image` at `template/insforge/index.yaml:441`
+
+### insforge: `postgrest/postgrest:v12.2.12`
+- `originImageName` at `template/insforge/index.yaml:675`
+- `image` at `template/insforge/index.yaml:695`
+
+### it-tools: `ghcr.io/corentinth/it-tools:2024.5.13-a0bc346`
+- `originImageName` at `template/it-tools/index.yaml:36`
+- `image` at `template/it-tools/index.yaml:61`
+
+### jellyfin: `jellyfin/jellyfin:10.10.7`
+- `originImageName` at `template/jellyfin/index.yaml:38`
+- `image` at `template/jellyfin/index.yaml:63`
+
+### joplin: `joplin/server:3.7.1`
+- `originImageName` at `template/joplin/index.yaml:183`
+- `image` at `template/joplin/index.yaml:244`
+
+### joplin: `postgres:16.4-alpine`
+- `image` at `template/joplin/index.yaml:133`
+- `image` at `template/joplin/index.yaml:204`
+
+### jsoncrack: `shokohsc/jsoncrack@sha256:4360a0659ed2fc301904477b9eb3454f8ab7b67af611b1f25e79acfb6165c8ef`
+- `originImageName` at `template/jsoncrack/index.yaml:37`
+- `image` at `template/jsoncrack/index.yaml:65`
+
+### kanboard: `kanboard/kanboard:v1.2.50`
+- `originImageName` at `template/kanboard/index.yaml:121`
+- `image` at `template/kanboard/index.yaml:141`
+
+### kaneo: `ghcr.io/usekaneo/api:1.1.8`
+- `originImageName` at `template/kaneo/index.yaml:170`
+- `image` at `template/kaneo/index.yaml:190`
+
+### kaneo: `ghcr.io/usekaneo/web:1.1.8`
+- `originImageName` at `template/kaneo/index.yaml:234`
+- `image` at `template/kaneo/index.yaml:254`
+
+### kaneo: `postgres:14-alpine`
+- `image` at `template/kaneo/index.yaml:132`
+
+### keycloak: `postgres:14-alpine`
+- `image` at `template/keycloak/index.yaml:152`
+
+### keycloak: `quay.io/keycloak/keycloak:26.3.2`
+- `originImageName` at `template/keycloak/index.yaml:177`
+- `image` at `template/keycloak/index.yaml:198`
+
+### keystone: `node:22.22.1-alpine`
+- `originImageName` at `template/keystone/index.yaml:479`
+- `image` at `template/keystone/index.yaml:544`
+- `image` at `template/keystone/index.yaml:620`
+
+### keystone: `postgres:16.4-alpine`
+- `image` at `template/keystone/index.yaml:149`
+
+### kitten-tts: `ghcr.io/yangchuansheng/kitten-tts-server:cpu-v1.2`
+- `originImageName` at `template/kitten-tts/index.yaml:44`
+- `image` at `template/kitten-tts/index.yaml:65`
+- `image` at `template/kitten-tts/index.yaml:76`
+
+### kodcloud: `kodcloud/kodbox:latest`
+- `originImageName` at `template/kodcloud/index.yaml:44`
+- `image` at `template/kodcloud/index.yaml:67`
+
+### kuboard: `eipwork/kuboard:v3`
+- `originImageName` at `template/kuboard/index.yaml:39`
+- `image` at `template/kuboard/index.yaml:62`
+
+### kuvasz: `kuvaszmonitoring/kuvasz:3.11.0`
+- `originImageName` at `template/kuvasz/index.yaml:201`
+- `image` at `template/kuvasz/index.yaml:277`
+
+### kuvasz: `postgres:16.4-alpine`
+- `image` at `template/kuvasz/index.yaml:143`
+- `image` at `template/kuvasz/index.yaml:231`
+
+### laf: `docker.io/lafyun/laf-server:sha-ef30cd9`
+- `image` at `template/laf/index.yaml:209`
+
+### laf: `docker.io/lafyun/laf-web:sha-e9d012d`
+- `image` at `template/laf/index.yaml:328`
+
+### laf: `docker.io/lafyun/runtime-node-init:sha-67b3cd6`
+- `image` at `template/laf/index.yaml:1418`
+
+### laf: `docker.io/lafyun/runtime-node:sha-67b3cd6`
+- `image` at `template/laf/index.yaml:1396`
+
+### laf: `docker.io/library/nginx:latest`
+- `image` at `template/laf/index.yaml:1441`
+
+### laf: `quay.io/minio/mc:RELEASE.2022-11-07T23-47-39Z`
+- `image` at `template/laf/index.yaml:1094`
+- `image` at `template/laf/index.yaml:1148`
+
+### laf: `quay.io/minio/minio`
+- `originImageName` at `template/laf/index.yaml:975`
+
+### laf: `quay.io/minio/minio:RELEASE.2023-03-22T06-36-24Z`
+- `image` at `template/laf/index.yaml:1008`
+
+### laf: `quay.io/prometheus/prometheus:v2.45.0`
+- `image` at `template/laf/index.yaml:519`
+
+### langflow: `langflowai/langflow:1.9.5`
+- `originImageName` at `template/langflow/index.yaml:219`
+- `image` at `template/langflow/index.yaml:247`
+
+### langflow: `postgres:16-alpine`
+- `image` at `template/langflow/index.yaml:157`
+
+### langfuse: `clickhouse/clickhouse-server:25.4.2`
+- `originImageName` at `template/langfuse/index.yaml:385`
+- `image` at `template/langfuse/index.yaml:409`
+
+### langfuse: `docker.io/langfuse/langfuse-worker:3.180.0`
+- `originImageName` at `template/langfuse/index.yaml:528`
+- `image` at `template/langfuse/index.yaml:622`
+
+### langfuse: `docker.io/langfuse/langfuse:3.180.0`
+- `originImageName` at `template/langfuse/index.yaml:786`
+- `image` at `template/langfuse/index.yaml:839`
+
+### langfuse: `minio/minio:RELEASE.2025-09-07T16-13-09Z`
+- `originImageName` at `template/langfuse/index.yaml:1042`
+- `image` at `template/langfuse/index.yaml:1065`
+
+### langfuse: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/langfuse/index.yaml:184`
+- `image` at `template/langfuse/index.yaml:550`
+
+### langfuse: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/langfuse/index.yaml:591`
+- `image` at `template/langfuse/index.yaml:808`
+
+### librechat: `getmeili/meilisearch:v1.5`
+- `originImageName` at `template/librechat/index.yaml:260`
+- `image` at `template/librechat/index.yaml:283`
+
+### librechat: `ghcr.io/danny-avila/librechat:v0.7.3`
+- `originImageName` at `template/librechat/index.yaml:52`
+- `image` at `template/librechat/index.yaml:75`
+
+### liebianbao: `busybox:1.36.1`
+- `image` at `template/liebianbao/index.yaml:99`
+
+### liebianbao: `docker.io/arey/mysql-client:latest`
+- `image` at `template/liebianbao/index.yaml:712`
+
+### liebianbao: `docker.io/labring4docker/php-custom:7.2-fpm`
+- `image` at `template/liebianbao/index.yaml:135`
+
+### liebianbao: `labring4docker/php-custom:7.2-fpm`
+- `originImageName` at `template/liebianbao/index.yaml:78`
+
+### liebianbao: `nginx:1.25.2`
+- `image` at `template/liebianbao/index.yaml:253`
+
+### listmonk: `busybox:1.37.0`
+- `image` at `template/listmonk/index.yaml:252`
+
+### listmonk: `listmonk/listmonk:v6.1.0`
+- `originImageName` at `template/listmonk/index.yaml:224`
+- `image` at `template/listmonk/index.yaml:274`
+- `image` at `template/listmonk/index.yaml:343`
+
+### listmonk: `postgres:16.4-alpine`
+- `image` at `template/listmonk/index.yaml:151`
+
+### litellm: `litellm/litellm-database:v1.88.1`
+- `originImageName` at `template/litellm/index.yaml:255`
+- `image` at `template/litellm/index.yaml:322`
+
+### litellm: `minio/mc:RELEASE.2025-05-21T01-59-54Z`
+- `image` at `template/litellm/index.yaml:280`
+
+### litellm: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/litellm/index.yaml:199`
+
+### llama2-chinese: `luanshaotong/text-generation-webui-cpu:dev`
+- `originImageName` at `template/llama2-chinese/index.yaml:64`
+- `image` at `template/llama2-chinese/index.yaml:89`
+
+### llama3-8b-chinese: `registry.cn-hangzhou.aliyuncs.com/yangchuansheng/llama-3-8b-chinese:q4_k_m`
+- `originImageName` at `template/llama3-8b-chinese/index.yaml:35`
+- `image` at `template/llama3-8b-chinese/index.yaml:59`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-api:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:357`
+- `image` at `template/llmgateway/index.yaml:442`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-docs:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:1195`
+- `image` at `template/llmgateway/index.yaml:1217`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-gateway:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:590`
+- `image` at `template/llmgateway/index.yaml:716`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-ui:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:1066`
+- `image` at `template/llmgateway/index.yaml:1087`
+
+### llmgateway: `ghcr.io/theopenco/llmgateway-worker:v1.3.0`
+- `originImageName` at `template/llmgateway/index.yaml:874`
+- `image` at `template/llmgateway/index.yaml:1001`
+
+### llmgateway: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/llmgateway/index.yaml:157`
+- `image` at `template/llmgateway/index.yaml:378`
+- `image` at `template/llmgateway/index.yaml:611`
+- `image` at `template/llmgateway/index.yaml:652`
+- `image` at `template/llmgateway/index.yaml:896`
+- `image` at `template/llmgateway/index.yaml:937`
+
+### llmgateway: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/llmgateway/index.yaml:419`
+- `image` at `template/llmgateway/index.yaml:693`
+- `image` at `template/llmgateway/index.yaml:978`
+
+### lobe-chat: `lobehub/lobe-chat:1.143.3`
+- `originImageName` at `template/lobe-chat/index.yaml:61`
+- `image` at `template/lobe-chat/index.yaml:87`
+
+### lobe-chat-db: `lobehub/lobe-chat-database:1.143.2`
+- `originImageName` at `template/lobe-chat-db/index.yaml:212`
+- `image` at `template/lobe-chat-db/index.yaml:237`
+
+### lobe-chat-db: `postgres:14-alpine`
+- `image` at `template/lobe-chat-db/index.yaml:172`
+
+### logto: `postgres:16.4-alpine`
+- `image` at `template/logto/index.yaml:127`
+
+### logto: `svhd/logto:1.40.1`
+- `originImageName` at `template/logto/index.yaml:179`
+- `image` at `template/logto/index.yaml:204`
+- `image` at `template/logto/index.yaml:253`
+
+### loki: `busybox:1.37.0`
+- `image` at `template/loki/index.yaml:57`
+
+### loki: `docker.io/grafana/loki:3.7.2`
+- `originImageName` at `template/loki/index.yaml:36`
+- `image` at `template/loki/index.yaml:77`
+
+### mage-ai: `mageai/mageai:0.9.79`
+- `originImageName` at `template/mage-ai/index.yaml:211`
+- `image` at `template/mage-ai/index.yaml:233`
+- `image` at `template/mage-ai/index.yaml:283`
+
+### mage-ai: `postgres:16.4-alpine`
+- `image` at `template/mage-ai/index.yaml:150`
+
+### mastodon: `ghcr.io/mastodon/mastodon-streaming:v4.5.11`
+- `originImageName` at `template/mastodon/index.yaml:937`
+- `image` at `template/mastodon/index.yaml:1004`
+
+### mastodon: `ghcr.io/mastodon/mastodon:v4.5.11`
+- `image` at `template/mastodon/index.yaml:455`
+- `originImageName` at `template/mastodon/index.yaml:572`
+- `image` at `template/mastodon/index.yaml:639`
+- `originImageName` at `template/mastodon/index.yaml:753`
+- `image` at `template/mastodon/index.yaml:817`
+
+### mastodon: `postgres:16.4-alpine`
+- `image` at `template/mastodon/index.yaml:333`
+
+### mastodon: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/mastodon/index.yaml:598`
+- `image` at `template/mastodon/index.yaml:776`
+- `image` at `template/mastodon/index.yaml:963`
+
+### mastodon: `public.ecr.aws/docker/library/redis:7-alpine`
+- `image` at `template/mastodon/index.yaml:434`
+
+### matomo: `matomo:5.10.0-apache`
+- `originImageName` at `template/matomo/index.yaml:179`
+- `image` at `template/matomo/index.yaml:201`
+
+### matomo: `mysql:8.0.44`
+- `image` at `template/matomo/index.yaml:135`
+
+### matrixgorilla: `${{ defaults.app_name }}-api`
+- `originImageName` at `template/matrixgorilla/index.yaml:79`
+
+### matrixgorilla: `${{ defaults.app_name }}-web`
+- `originImageName` at `template/matrixgorilla/index.yaml:35`
+
+### matrixgorilla: `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-api:latest`
+- `image` at `template/matrixgorilla/index.yaml:101`
+
+### matrixgorilla: `registry.cn-beijing.aliyuncs.com/juliangxingqiu/sealos-java-web:latest`
+- `image` at `template/matrixgorilla/index.yaml:58`
+
+### mautic: `busybox:1.36.1`
+- `image` at `template/mautic/index.yaml:473`
+- `image` at `template/mautic/index.yaml:597`
+
+### mautic: `mautic/mautic:7.1.2-apache`
+- `originImageName` at `template/mautic/index.yaml:242`
+- `image` at `template/mautic/index.yaml:266`
+- `image` at `template/mautic/index.yaml:316`
+- `image` at `template/mautic/index.yaml:343`
+- `originImageName` at `template/mautic/index.yaml:440`
+- `image` at `template/mautic/index.yaml:492`
+- `originImageName` at `template/mautic/index.yaml:564`
+- `image` at `template/mautic/index.yaml:616`
+
+### mautic: `mysql:8.4.2`
+- `image` at `template/mautic/index.yaml:141`
+
+### mazanoke: `ghcr.io/civilblur/mazanoke:v1.1.6`
+- `originImageName` at `template/mazanoke/index.yaml:37`
+- `image` at `template/mazanoke/index.yaml:63`
+
+### meilisearch: `eyeix/meilisearch-ui:v0.15.1-lite`
+- `originImageName` at `template/meilisearch/index.yaml:133`
+- `image` at `template/meilisearch/index.yaml:153`
+
+### meilisearch: `getmeili/meilisearch:v1.45.1`
+- `originImageName` at `template/meilisearch/index.yaml:44`
+- `image` at `template/meilisearch/index.yaml:68`
+
+### memos: `ghcr.io/usememos/memos:latest`
+- `originImageName` at `template/memos/index.yaml:39`
+- `image` at `template/memos/index.yaml:62`
+
+### metabase: `metabase/metabase:v0.61.3`
+- `originImageName` at `template/metabase/index.yaml:171`
+- `image` at `template/metabase/index.yaml:194`
+
+### metabase: `postgres:16-alpine`
+- `image` at `template/metabase/index.yaml:128`
+
+### midjourney-ui: `erictik/midjourney-ui:1.1.47`
+- `originImageName` at `template/midjourney-ui/index.yaml:57`
+- `image` at `template/midjourney-ui/index.yaml:82`
+
+### mindoc: `registry.cn-hangzhou.aliyuncs.com/mindoc-org/mindoc:v2.2-beta.1`
+- `originImageName` at `template/mindoc/index.yaml:274`
+- `image` at `template/mindoc/index.yaml:299`
+
+### mindoc: `senzing/postgresql-client:2.2.4`
+- `image` at `template/mindoc/index.yaml:133`
+
+### mindsdb: `mindsdb/mindsdb:v26.1.0`
+- `originImageName` at `template/mindsdb/index.yaml:253`
+- `image` at `template/mindsdb/index.yaml:323`
+- `image` at `template/mindsdb/index.yaml:365`
+
+### mindsdb: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/mindsdb/index.yaml:156`
+- `image` at `template/mindsdb/index.yaml:276`
+
+### minecraft: `alpine:3.22.4`
+- `image` at `template/minecraft/index.yaml:71`
+
+### minecraft: `itzg/minecraft-server:2026.5.3-java25`
+- `originImageName` at `template/minecraft/index.yaml:48`
+- `image` at `template/minecraft/index.yaml:91`
+
+### minio: `quay.io/minio/minio`
+- `originImageName` at `template/minio/index.yaml:57`
+- `image` at `template/minio/index.yaml:80`
+
+### mlflow: `ghcr.io/mlflow/mlflow:v3.12.0`
+- `originImageName` at `template/mlflow/index.yaml:201`
+- `image` at `template/mlflow/index.yaml:270`
+
+### mlflow: `senzing/postgresql-client:2.2.4`
+- `image` at `template/mlflow/index.yaml:151`
+- `image` at `template/mlflow/index.yaml:222`
+
+### moneyprinterturbo: `ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200`
+- `originImageName` at `template/moneyprinterturbo/index.yaml:37`
+- `image` at `template/moneyprinterturbo/index.yaml:60`
+
+### mongo-express: `mongo-express:1.0.2-20-alpine3.19`
+- `originImageName` at `template/mongo-express/index.yaml:127`
+- `image` at `template/mongo-express/index.yaml:147`
+
+### n8n: `alpine`
+- `image` at `template/n8n/index.yaml:362`
+
+### n8n: `busybox:1.36`
+- `image` at `template/n8n/index.yaml:605`
+
+### n8n: `n8nio/n8n:2.22.4`
+- `originImageName` at `template/n8n/index.yaml:337`
+- `image` at `template/n8n/index.yaml:370`
+- `originImageName` at `template/n8n/index.yaml:583`
+- `image` at `template/n8n/index.yaml:624`
+
+### n8n: `n8nio/runners:2.22.4`
+- `originImageName` at `template/n8n/index.yaml:522`
+- `image` at `template/n8n/index.yaml:544`
+- `originImageName` at `template/n8n/index.yaml:711`
+- `image` at `template/n8n/index.yaml:733`
+
+### n8n: `postgres:16-alpine`
+- `image` at `template/n8n/index.yaml:296`
+
+### nacos: `mysql:8.0.44`
+- `image` at `template/nacos/index.yaml:347`
+
+### nacos: `nacos/nacos-server:v3.2.2`
+- `originImageName` at `template/nacos/index.yaml:410`
+- `image` at `template/nacos/index.yaml:432`
+- `originImageName` at `template/nacos/index.yaml:545`
+- `image` at `template/nacos/index.yaml:567`
+
+### nakama: `busybox:1.36`
+- `image` at `template/nakama/index.yaml:261`
+
+### nakama: `heroiclabs/nakama:3.39.0`
+- `originImageName` at `template/nakama/index.yaml:237`
+- `image` at `template/nakama/index.yaml:327`
+- `image` at `template/nakama/index.yaml:370`
+
+### nakama: `postgres:16-alpine`
+- `image` at `template/nakama/index.yaml:187`
+- `image` at `template/nakama/index.yaml:278`
+
+### netbird: `netbirdio/dashboard:v2.38.1`
+- `originImageName` at `template/netbird/index.yaml:150`
+- `image` at `template/netbird/index.yaml:170`
+
+### netbird: `netbirdio/management:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:217`
+- `image` at `template/netbird/index.yaml:238`
+
+### netbird: `netbirdio/relay:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:356`
+- `image` at `template/netbird/index.yaml:376`
+
+### netbird: `netbirdio/signal:0.71.4`
+- `originImageName` at `template/netbird/index.yaml:295`
+- `image` at `template/netbird/index.yaml:316`
+
+### new-api: `calciumion/new-api:v0.13.2`
+- `originImageName` at `template/new-api/index.yaml:304`
+- `image` at `template/new-api/index.yaml:326`
+
+### new-api: `postgres:16.4`
+- `image` at `template/new-api/index.yaml:252`
+
+### nexus: `alpine:3.22.2`
+- `image` at `template/nexus/index.yaml:61`
+
+### nexus: `sonatype/nexus3:3.92.3`
+- `originImageName` at `template/nexus/index.yaml:37`
+- `image` at `template/nexus/index.yaml:79`
+
+### nocodb: `nocodb/nocodb:2026.05.2`
+- `originImageName` at `template/nocodb/index.yaml:132`
+- `image` at `template/nocodb/index.yaml:156`
+
+### node-red: `nodered/node-red:4.1.10`
+- `originImageName` at `template/node-red/index.yaml:36`
+- `image` at `template/node-red/index.yaml:61`
+
+### nofx: `alpine/openssl:3.5.4`
+- `image` at `template/nofx/index.yaml:210`
+
+### nofx: `ghcr.io/nofxaios/nofx/nofx-backend@sha256:32d77ff9761ba8b068f95a5a4c8fee0a7745c8a927300b7d658e593b1e654ae7`
+- `originImageName` at `template/nofx/index.yaml:189`
+- `image` at `template/nofx/index.yaml:273`
+
+### nofx: `ghcr.io/nofxaios/nofx/nofx-frontend@sha256:6c1e56336433e82eb5e750034d2991a8dbebd89a6b19119c4b12601ef1842887`
+- `originImageName` at `template/nofx/index.yaml:427`
+- `image` at `template/nofx/index.yaml:448`
+
+### nofx: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/nofx/index.yaml:136`
+- `image` at `template/nofx/index.yaml:231`
+
+### notifuse: `notifuse/notifuse:v32.1@sha256:fdee58fc36e50cf3f64c007dbf07549842280022828fd6c051f6454084a66cfb`
+- `originImageName` at `template/notifuse/index.yaml:175`
+- `image` at `template/notifuse/index.yaml:250`
+
+### notifuse: `postgres:16.4-alpine`
+- `image` at `template/notifuse/index.yaml:138`
+- `image` at `template/notifuse/index.yaml:196`
+
+### nsfw: `ethandai4869/nsfw-auth`
+- `originImageName` at `template/nsfw/index.yaml:40`
+- `image` at `template/nsfw/index.yaml:65`
+
+### odoo: `odoo:18.0-20260609`
+- `originImageName` at `template/odoo/index.yaml:212`
+- `image` at `template/odoo/index.yaml:238`
+- `image` at `template/odoo/index.yaml:301`
+
+### odoo: `postgres:16.4-alpine`
+- `image` at `template/odoo/index.yaml:138`
+
+### odysseus: `chromadb/chroma:1.0.15`
+- `originImageName` at `template/odysseus/index.yaml:73`
+- `image` at `template/odysseus/index.yaml:94`
+
+### odysseus: `ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0`
+- `originImageName` at `template/odysseus/index.yaml:272`
+- `image` at `template/odysseus/index.yaml:294`
+
+### odysseus: `searxng/searxng:2026.5.31-7159b8aed`
+- `originImageName` at `template/odysseus/index.yaml:169`
+- `image` at `template/odysseus/index.yaml:190`
+
+### one-api: `ghcr.io/songquanpeng/one-api:v0.6.10`
+- `originImageName` at `template/one-api/index.yaml:51`
+- `image` at `template/one-api/index.yaml:79`
+
+### open-design: `docker.io/vanjayak/open-design@sha256:a3b0f7b043aec134e857513f1480b2da6aaaab641af2d7337999c9090a5c1e13`
+- `originImageName` at `template/open-design/index.yaml:101`
+- `image` at `template/open-design/index.yaml:130`
+
+### open-design: `nginxinc/nginx-unprivileged:1.25-alpine-slim`
+- `originImageName` at `template/open-design/index.yaml:222`
+- `image` at `template/open-design/index.yaml:248`
+
+### open-webui: `ghcr.io/open-webui/open-webui:v0.5.4`
+- `originImageName` at `template/open-webui/index.yaml:36`
+- `image` at `template/open-webui/index.yaml:59`
+- `image` at `template/open-webui/index.yaml:65`
+- `image` at `template/open-webui/index.yaml:74`
+
+### openagents: `ghcr.io/openagents-org/openagents:sha-48764c0`
+- `originImageName` at `template/openagents/index.yaml:52`
+- `image` at `template/openagents/index.yaml:73`
+
+### openai-proxy: `unickcheng/openai-proxy`
+- `originImageName` at `template/openai-proxy/index.yaml:38`
+- `image` at `template/openai-proxy/index.yaml:63`
+
+### opencart: `ghcr.io/yangchuansheng/opencart:4.1.0.3@sha256:eb92c3f24fe3a2b44a09af51dcd8c2ba9aeb2454b26dcae9e85036afb1d04d94`
+- `originImageName` at `template/opencart/index.yaml:139`
+- `image` at `template/opencart/index.yaml:160`
+
+### openclaw: `busybox:1.36`
+- `image` at `template/openclaw/index.yaml:85`
+
+### openclaw: `ghcr.io/openclaw/openclaw:2026.3.8`
+- `originImageName` at `template/openclaw/index.yaml:62`
+- `image` at `template/openclaw/index.yaml:102`
+- `image` at `template/openclaw/index.yaml:160`
+
+### openhands: `ghcr.io/openhands/openhands:1.8.0`
+- `originImageName` at `template/openhands/index.yaml:51`
+- `image` at `template/openhands/index.yaml:73`
+
+### openlist: `openlistteam/openlist:v4.0.9-aria2`
+- `originImageName` at `template/openlist/index.yaml:49`
+- `image` at `template/openlist/index.yaml:72`
+
+### openobserve: `public.ecr.aws/zinclabs/openobserve:v0.90.3`
+- `originImageName` at `template/openobserve/index.yaml:68`
+- `image` at `template/openobserve/index.yaml:97`
+
+### outline: `outlinewiki/outline:1.8.0-1`
+- `originImageName` at `template/outline/index.yaml:427`
+- `image` at `template/outline/index.yaml:448`
+
+### outline: `postgres:16.4`
+- `image` at `template/outline/index.yaml:384`
+
+### overleaf: `sharelatex/sharelatex:6.1.2`
+- `originImageName` at `template/overleaf/index.yaml:260`
+- `image` at `template/overleaf/index.yaml:284`
+
+### pageplug: `cloudtogouser/pageplug-ce:v1.9.35`
+- `originImageName` at `template/pageplug/index.yaml:38`
+- `image` at `template/pageplug/index.yaml:61`
+
+### palacms: `ghcr.io/palacms/palacms:v3.0.0-beta.1`
+- `originImageName` at `template/palacms/index.yaml:38`
+- `image` at `template/palacms/index.yaml:59`
+
+### palworld: `alpine`
+- `image` at `template/palworld/index.yaml:85`
+
+### palworld: `hurlenko/filebrowser`
+- `image` at `template/palworld/index.yaml:158`
+
+### palworld: `thijsvanloef/palworld-server-docker`
+- `originImageName` at `template/palworld/index.yaml:62`
+- `image` at `template/palworld/index.yaml:103`
+
+### palworld-autobackup: `bitnamilegacy/kubectl`
+- `image` at `template/palworld-autobackup/index.yaml:63`
+
+### palworld-export: `bitnamilegacy/kubectl`
+- `image` at `template/palworld-export/index.yaml:64`
+
+### palworld-export: `hurlenko/filebrowser`
+- `originImageName` at `template/palworld-export/index.yaml:42`
+- `image` at `template/palworld-export/index.yaml:76`
+
+### palworld-management: `registry.cn-hangzhou.aliyuncs.com/bxy4543/palworld-server-tool:2024-02-18`
+- `originImageName` at `template/palworld-management/index.yaml:66`
+- `image` at `template/palworld-management/index.yaml:90`
+
+### pangolin: `docker.io/fosrl/pangolin:1.15.2`
+- `originImageName` at `template/pangolin/index.yaml:102`
+- `image` at `template/pangolin/index.yaml:122`
+
+### paperclip: `ghcr.io/paperclipai/paperclip:sha-b8725c5`
+- `originImageName` at `template/paperclip/index.yaml:231`
+- `image` at `template/paperclip/index.yaml:319`
+- `image` at `template/paperclip/index.yaml:470`
+- `image` at `template/paperclip/index.yaml:692`
+
+### paperclip: `public.ecr.aws/docker/library/busybox:1.36.1`
+- `image` at `template/paperclip/index.yaml:257`
+
+### paperclip: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/paperclip/index.yaml:178`
+- `image` at `template/paperclip/index.yaml:278`
+
+### paperless-ngx: `ghcr.io/paperless-ngx/paperless-ngx:latest`
+- `originImageName` at `template/paperless-ngx/index.yaml:318`
+- `image` at `template/paperless-ngx/index.yaml:339`
+
+### paperless-ngx: `postgres:14-alpine`
+- `image` at `template/paperless-ngx/index.yaml:294`
+
+### payload: `ghcr.io/yangchuansheng/payload:3.82.1-a7dd17c9be0c`
+- `originImageName` at `template/payload/index.yaml:178`
+- `image` at `template/payload/index.yaml:200`
+
+### payload: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/payload/index.yaml:134`
+
+### pdf2zh: `byaidu/pdf2zh:1.9.6`
+- `originImageName` at `template/pdf2zh/index.yaml:38`
+- `image` at `template/pdf2zh/index.yaml:63`
+
+### penpot: `penpotapp/backend:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:281`
+- `image` at `template/penpot/index.yaml:307`
+
+### penpot: `penpotapp/exporter:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:422`
+- `image` at `template/penpot/index.yaml:447`
+
+### penpot: `penpotapp/frontend:2.1.2`
+- `originImageName` at `template/penpot/index.yaml:496`
+- `image` at `template/penpot/index.yaml:523`
+
+### penpot: `senzing/postgresql-client:2.2.4`
+- `image` at `template/penpot/index.yaml:132`
+
+### perplexica: `itzcrazykns1337/perplexica:v1.10.2`
+- `originImageName` at `template/perplexica/index.yaml:261`
+- `image` at `template/perplexica/index.yaml:284`
+
+### perplexica: `searxng/searxng:2025.2.20-28d1240fc`
+- `originImageName` at `template/perplexica/index.yaml:133`
+- `image` at `template/perplexica/index.yaml:158`
+
+### pgadmin4: `dpage/pgadmin4:8.9`
+- `originImageName` at `template/pgadmin4/index.yaml:45`
+- `image` at `template/pgadmin4/index.yaml:65`
+
+### photoprism: `photoprism/photoprism:240711`
+- `originImageName` at `template/photoprism/index.yaml:48`
+- `image` at `template/photoprism/index.yaml:71`
+
+### phpmyadmin: `phpmyadmin:5.2.1`
+- `originImageName` at `template/phpmyadmin/index.yaml:35`
+- `image` at `template/phpmyadmin/index.yaml:55`
+
+### plane: `makeplane/plane-admin:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:433`
+- `image` at `template/plane/index.yaml:458`
+
+### plane: `makeplane/plane-backend:v0.22-dev`
+- `image` at `template/plane/index.yaml:193`
+- `originImageName` at `template/plane/index.yaml:511`
+- `image` at `template/plane/index.yaml:536`
+- `originImageName` at `template/plane/index.yaml:678`
+- `image` at `template/plane/index.yaml:703`
+- `originImageName` at `template/plane/index.yaml:820`
+- `image` at `template/plane/index.yaml:845`
+
+### plane: `makeplane/plane-frontend:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:1037`
+- `image` at `template/plane/index.yaml:1062`
+
+### plane: `makeplane/plane-space:v0.22-dev`
+- `originImageName` at `template/plane/index.yaml:962`
+- `image` at `template/plane/index.yaml:987`
+
+### plane: `senzing/postgresql-client:2.2.4`
+- `image` at `template/plane/index.yaml:145`
+
+### planka: `busybox:1.36.1`
+- `image` at `template/planka/index.yaml:219`
+
+### planka: `ghcr.io/plankanban/planka:2.1.1`
+- `originImageName` at `template/planka/index.yaml:198`
+- `image` at `template/planka/index.yaml:249`
+
+### planka: `postgres:16-alpine`
+- `image` at `template/planka/index.yaml:153`
+
+### plausible: `clickhouse/clickhouse-server:23.3.7.5-alpine`
+- `originImageName` at `template/plausible/index.yaml:187`
+- `image` at `template/plausible/index.yaml:208`
+
+### plausible: `plausible/analytics:v2.0`
+- `originImageName` at `template/plausible/index.yaml:282`
+- `image` at `template/plausible/index.yaml:307`
+
+### pocket-id: `ghcr.io/pocket-id/pocket-id:v2.2.0`
+- `originImageName` at `template/pocket-id/index.yaml:40`
+- `image` at `template/pocket-id/index.yaml:60`
+
+### pocketbase: `adrianmusante/pocketbase:0.29.3`
+- `originImageName` at `template/pocketbase/index.yaml:58`
+- `image` at `template/pocketbase/index.yaml:87`
+
+### pocketbase: `busybox:latest`
+- `image` at `template/pocketbase/index.yaml:79`
+
+### posthog: `clickhouse/clickhouse-server:25.8.12.129`
+- `originImageName` at `template/posthog/index.yaml:1559`
+- `image` at `template/posthog/index.yaml:1579`
+
+### posthog: `docker.redpanda.com/redpandadata/redpanda:v25.1.9`
+- `originImageName` at `template/posthog/index.yaml:339`
+- `image` at `template/posthog/index.yaml:360`
+
+### posthog: `ghcr.io/posthog/posthog-node@sha256:fd156e690ca1bb7cc1abd370e513ac532c57726ee11029721623f0db5b90b72a`
+- `originImageName` at `template/posthog/index.yaml:968`
+- `image` at `template/posthog/index.yaml:1005`
+- `image` at `template/posthog/index.yaml:1068`
+
+### posthog: `ghcr.io/posthog/posthog/capture@sha256:864754478dbbd589f17cb4543d07e1b0f63acbca8e0bceca13de10669500375b`
+- `originImageName` at `template/posthog/index.yaml:1302`
+- `image` at `template/posthog/index.yaml:1322`
+- `originImageName` at `template/posthog/index.yaml:1359`
+- `image` at `template/posthog/index.yaml:1379`
+
+### posthog: `ghcr.io/posthog/posthog/feature-flags@sha256:1e79e6e7e5b58da18e27ebdf0ef9b41d6c04136eac42bb9490e73a9a62f94f65`
+- `image` at `template/posthog/index.yaml:988`
+- `originImageName` at `template/posthog/index.yaml:1414`
+- `image` at `template/posthog/index.yaml:1434`
+
+### posthog: `ghcr.io/posthog/posthog:86d6812c7de75c6c869b935e17baf45bf295bfd5`
+- `originImageName` at `template/posthog/index.yaml:600`
+- `image` at `template/posthog/index.yaml:620`
+- `originImageName` at `template/posthog/index.yaml:784`
+- `image` at `template/posthog/index.yaml:804`
+
+### posthog: `postgres:16.4`
+- `image` at `template/posthog/index.yaml:146`
+
+### posthog: `zookeeper:3.9.3`
+- `originImageName` at `template/posthog/index.yaml:481`
+- `image` at `template/posthog/index.yaml:502`
+
+### postiz: `busybox:1.36.1`
+- `image` at `template/postiz/index.yaml:326`
+- `image` at `template/postiz/index.yaml:531`
+
+### postiz: `elasticsearch:7.17.27`
+- `originImageName` at `template/postiz/index.yaml:305`
+- `image` at `template/postiz/index.yaml:341`
+
+### postiz: `ghcr.io/gitroomhq/postiz-app:v2.21.8`
+- `originImageName` at `template/postiz/index.yaml:510`
+- `image` at `template/postiz/index.yaml:583`
+
+### postiz: `postgres:16-alpine`
+- `image` at `template/postiz/index.yaml:129`
+
+### postiz: `temporalio/auto-setup:1.28.1`
+- `originImageName` at `template/postiz/index.yaml:400`
+- `image` at `template/postiz/index.yaml:420`
+
+### presenton: `ghcr.io/presenton/presenton:v0.8.2-beta`
+- `originImageName` at `template/presenton/index.yaml:37`
+- `image` at `template/presenton/index.yaml:59`
+
+### prestashop: `mysql:8.0.30`
+- `image` at `template/prestashop/index.yaml:141`
+
+### prestashop: `prestashop/prestashop:9.1.3-apache`
+- `originImageName` at `template/prestashop/index.yaml:216`
+- `image` at `template/prestashop/index.yaml:237`
+
+### privatebin: `alpine`
+- `image` at `template/privatebin/index.yaml:272`
+
+### privatebin: `frooodle/privatebin:0.26.1-fat`
+- `originImageName` at `template/privatebin/index.yaml:249`
+
+### privatebin: `ghcr.io/privatebin/fs:1.7.4`
+- `image` at `template/privatebin/index.yaml:280`
+
+### pterodactyl: `ghcr.io/pterodactyl/panel:v1.12.4`
+- `image` at `template/pterodactyl/index.yaml:399`
+- `originImageName` at `template/pterodactyl/index.yaml:545`
+- `image` at `template/pterodactyl/index.yaml:677`
+
+### pterodactyl: `public.ecr.aws/docker/library/mysql:8.0.30`
+- `image` at `template/pterodactyl/index.yaml:183`
+- `image` at `template/pterodactyl/index.yaml:568`
+- `image` at `template/pterodactyl/index.yaml:636`
+
+### pterodactyl: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/pterodactyl/index.yaml:368`
+- `image` at `template/pterodactyl/index.yaml:606`
+
+### qinglong: `whyour/qinglong:latest`
+- `originImageName` at `template/qinglong/index.yaml:38`
+- `image` at `template/qinglong/index.yaml:61`
+
+### quay: `postgres:16.4`
+- `image` at `template/quay/index.yaml:150`
+
+### quay: `python:3.12.8-alpine3.20`
+- `image` at `template/quay/index.yaml:541`
+
+### quay: `quay.io/projectquay/quay:v3.9.8`
+- `originImageName` at `template/quay/index.yaml:301`
+- `image` at `template/quay/index.yaml:332`
+
+### rclone: `rclone/rclone:1.74.3`
+- `originImageName` at `template/rclone/index.yaml:48`
+- `image` at `template/rclone/index.yaml:69`
+
+### redisinsight: `redislabs/redisinsight:2.52`
+- `originImageName` at `template/redisinsight/index.yaml:34`
+- `image` at `template/redisinsight/index.yaml:54`
+
+### refly: `mautic/mautic:5.2.3-fpm`
+- `image` at `template/refly/index.yaml:409`
+
+### refly: `reflyai/elasticsearch:7.10.2`
+- `originImageName` at `template/refly/index.yaml:386`
+- `image` at `template/refly/index.yaml:417`
+
+### refly: `reflyai/qdrant:v1.13.1`
+- `originImageName` at `template/refly/index.yaml:305`
+- `image` at `template/refly/index.yaml:328`
+
+### refly: `reflyai/refly-api:8d870210470801f62a4d2adb3423c947afddf400`
+- `originImageName` at `template/refly/index.yaml:479`
+- `image` at `template/refly/index.yaml:504`
+
+### refly: `reflyai/refly-web:8d870210470801f62a4d2adb3423c947afddf400`
+- `originImageName` at `template/refly/index.yaml:824`
+- `image` at `template/refly/index.yaml:849`
+
+### refly: `senzing/postgresql-client:2.2.4`
+- `image` at `template/refly/index.yaml:165`
+
+### registry: `joxit/docker-registry-ui:2.5.6-debian`
+- `originImageName` at `template/registry/index.yaml:206`
+- `image` at `template/registry/index.yaml:230`
+
+### registry: `registry:2.8.3`
+- `originImageName` at `template/registry/index.yaml:35`
+- `image` at `template/registry/index.yaml:57`
+
+### rocketchat: `mongo:6.0`
+- `image` at `template/rocketchat/index.yaml:132`
+
+### rocketchat: `registry.rocket.chat/rocketchat/rocket.chat:7.9.0`
+- `originImageName` at `template/rocketchat/index.yaml:183`
+- `image` at `template/rocketchat/index.yaml:203`
+
+### rocketchat-micro: `mongo:6.0`
+- `image` at `template/rocketchat-micro/index.yaml:130`
+
+### rocketchat-micro: `nats:2.4-alpine`
+- `originImageName` at `template/rocketchat-micro/index.yaml:332`
+- `image` at `template/rocketchat-micro/index.yaml:367`
+
+### rocketchat-micro: `natsio/nats-server-config-reloader:0.6.3`
+- `image` at `template/rocketchat-micro/index.yaml:438`
+
+### rocketchat-micro: `rocketchat/account-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:517`
+- `image` at `template/rocketchat-micro/index.yaml:542`
+
+### rocketchat-micro: `rocketchat/authorization-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:606`
+- `image` at `template/rocketchat-micro/index.yaml:631`
+
+### rocketchat-micro: `rocketchat/ddp-streamer-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:695`
+- `image` at `template/rocketchat-micro/index.yaml:720`
+
+### rocketchat-micro: `rocketchat/presence-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:793`
+- `image` at `template/rocketchat-micro/index.yaml:818`
+
+### rocketchat-micro: `rocketchat/rocket.chat:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:224`
+- `image` at `template/rocketchat-micro/index.yaml:249`
+
+### rocketchat-micro: `rocketchat/stream-hub-service:7.9.0`
+- `originImageName` at `template/rocketchat-micro/index.yaml:882`
+- `image` at `template/rocketchat-micro/index.yaml:907`
+
+### rsshub: `browserless/chrome:1.61.1-chrome-stable`
+- `originImageName` at `template/rsshub/index.yaml:133`
+- `image` at `template/rsshub/index.yaml:157`
+
+### rsshub: `diygod/rsshub:2024-07-06`
+- `originImageName` at `template/rsshub/index.yaml:46`
+- `image` at `template/rsshub/index.yaml:71`
+
+### rustdesk: `rustdesk/rustdesk-server-s6:1.1.15`
+- `originImageName` at `template/rustdesk/index.yaml:45`
+- `image` at `template/rustdesk/index.yaml:69`
+
+### rustfs: `busybox`
+- `image` at `template/rustfs/index.yaml:83`
+
+### rustfs: `rustfs/rustfs:latest`
+- `originImageName` at `template/rustfs/index.yaml:54`
+- `image` at `template/rustfs/index.yaml:114`
+
+### rybbit: `clickhouse/clickhouse-server:25.4.2`
+- `originImageName` at `template/rybbit/index.yaml:234`
+- `image` at `template/rybbit/index.yaml:258`
+- `image` at `template/rybbit/index.yaml:419`
+
+### rybbit: `ghcr.io/rybbit-io/rybbit-backend:sha-aa404ba`
+- `originImageName` at `template/rybbit/index.yaml:392`
+- `image` at `template/rybbit/index.yaml:464`
+
+### rybbit: `ghcr.io/rybbit-io/rybbit-client:sha-aa404ba`
+- `originImageName` at `template/rybbit/index.yaml:605`
+- `image` at `template/rybbit/index.yaml:632`
+
+### rybbit: `postgres:16.4-alpine`
+- `image` at `template/rybbit/index.yaml:135`
+- `image` at `template/rybbit/index.yaml:432`
+
+### s-pdf: `alpine`
+- `image` at `template/s-pdf/index.yaml:251`
+
+### s-pdf: `ghcr.io/stirling-tools/stirling-pdf:1.2.0-fat`
+- `originImageName` at `template/s-pdf/index.yaml:228`
+- `image` at `template/s-pdf/index.yaml:259`
+
+### s-pdf: `postgres:14-alpine`
+- `image` at `template/s-pdf/index.yaml:203`
+
+### samarium: `ghcr.io/yangchuansheng/samarium:0.0.0-9514fcadb867`
+- `originImageName` at `template/samarium/index.yaml:142`
+- `image` at `template/samarium/index.yaml:168`
+- `image` at `template/samarium/index.yaml:332`
+
+### signoz: `busybox`
+- `image` at `template/signoz/index.yaml:447`
+
+### signoz: `busybox:1.28`
+- `image` at `template/signoz/index.yaml:566`
+- `image` at `template/signoz/index.yaml:683`
+- `image` at `template/signoz/index.yaml:740`
+- `image` at `template/signoz/index.yaml:840`
+
+### signoz: `clickhouse/clickhouse-server:25.5.6`
+- `originImageName` at `template/signoz/index.yaml:524`
+- `image` at `template/signoz/index.yaml:548`
+- `image` at `template/signoz/index.yaml:570`
+
+### signoz: `signoz/signoz-otel-collector:v0.144.2`
+- `image` at `template/signoz/index.yaml:687`
+- `originImageName` at `template/signoz/index.yaml:821`
+- `image` at `template/signoz/index.yaml:844`
+
+### signoz: `signoz/signoz:v0.117.0`
+- `originImageName` at `template/signoz/index.yaml:719`
+- `image` at `template/signoz/index.yaml:744`
+
+### signoz: `signoz/zookeeper:3.7.1`
+- `originImageName` at `template/signoz/index.yaml:421`
+- `image` at `template/signoz/index.yaml:454`
+
+### sillytavern: `ghcr.io/sillytavern/sillytavern:1.18.0`
+- `originImageName` at `template/sillytavern/index.yaml:57`
+- `image` at `template/sillytavern/index.yaml:80`
+- `image` at `template/sillytavern/index.yaml:154`
+
+### skardi: `ghcr.io/skardilabs/skardi/skardi-server:0.3.0`
+- `originImageName` at `template/skardi/index.yaml:123`
+- `image` at `template/skardi/index.yaml:143`
+
+### stalwart: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/stalwart/index.yaml:156`
+- `image` at `template/stalwart/index.yaml:259`
+
+### stalwart: `stalwartlabs/stalwart:v0.16.7`
+- `originImageName` at `template/stalwart/index.yaml:234`
+- `image` at `template/stalwart/index.yaml:302`
+
+### steel-browser: `ghcr.io/steel-dev/steel-browser@sha256:cbf4a44d575c0ae83d00d4ba6bb455d24980de0ced2b06fe8b890e835c923bd1`
+- `originImageName` at `template/steel-browser/index.yaml:38`
+- `image` at `template/steel-browser/index.yaml:62`
+
+### strapi: `postgres:14-alpine`
+- `image` at `template/strapi/index.yaml:164`
+
+### strapi: `vshadbolt/strapi:5.33.0`
+- `originImageName` at `template/strapi/index.yaml:611`
+- `image` at `template/strapi/index.yaml:632`
+- `image` at `template/strapi/index.yaml:706`
+
+### sub2api: `postgres:16-alpine`
+- `image` at `template/sub2api/index.yaml:218`
+
+### sub2api: `weishaw/sub2api:0.1.104`
+- `originImageName` at `template/sub2api/index.yaml:368`
+- `image` at `template/sub2api/index.yaml:397`
+
+### supabase: `darthsim/imgproxy:v3.30.1`
+- `originImageName` at `template/supabase/index.yaml:1353`
+- `image` at `template/supabase/index.yaml:1373`
+
+### supabase: `kong:2.8.1`
+- `originImageName` at `template/supabase/index.yaml:848`
+- `image` at `template/supabase/index.yaml:868`
+
+### supabase: `postgres:16.4`
+- `image` at `template/supabase/index.yaml:272`
+
+### supabase: `postgrest/postgrest@sha256:b574528fe109c8343c1247155734d03df8c34b462f342dca0ccc20244fc36ef9`
+- `originImageName` at `template/supabase/index.yaml:1061`
+- `image` at `template/supabase/index.yaml:1081`
+
+### supabase: `supabase/edge-runtime:v1.70.3`
+- `originImageName` at `template/supabase/index.yaml:1492`
+- `image` at `template/supabase/index.yaml:1512`
+
+### supabase: `supabase/gotrue:v2.186.0`
+- `originImageName` at `template/supabase/index.yaml:934`
+- `image` at `template/supabase/index.yaml:954`
+
+### supabase: `supabase/logflare:1.31.2`
+- `originImageName` at `template/supabase/index.yaml:1594`
+- `image` at `template/supabase/index.yaml:1614`
+
+### supabase: `supabase/postgres-meta:v0.95.2`
+- `originImageName` at `template/supabase/index.yaml:1430`
+- `image` at `template/supabase/index.yaml:1450`
+
+### supabase: `supabase/realtime:v2.76.5`
+- `originImageName` at `template/supabase/index.yaml:1133`
+- `image` at `template/supabase/index.yaml:1153`
+
+### supabase: `supabase/storage-api:v1.37.8`
+- `originImageName` at `template/supabase/index.yaml:1234`
+- `image` at `template/supabase/index.yaml:1254`
+
+### supabase: `supabase/studio:2026.02.16-sha-26c615c`
+- `originImageName` at `template/supabase/index.yaml:707`
+- `image` at `template/supabase/index.yaml:727`
+
+### supabase: `supabase/supavisor:2.7.4`
+- `originImageName` at `template/supabase/index.yaml:1766`
+- `image` at `template/supabase/index.yaml:1786`
+
+### supabase: `timberio/vector:0.53.0-alpine`
+- `originImageName` at `template/supabase/index.yaml:1700`
+- `image` at `template/supabase/index.yaml:1720`
+
+### superset: `apachesuperset.docker.scarf.sh/apache/superset:6.1.0`
+- `image` at `template/superset/index.yaml:471`
+- `originImageName` at `template/superset/index.yaml:551`
+- `image` at `template/superset/index.yaml:581`
+- `image` at `template/superset/index.yaml:640`
+
+### superset: `postgres:16.4-alpine`
+- `image` at `template/superset/index.yaml:141`
+
+### surveyking: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/surveyking/index.yaml:129`
+
+### surveyking: `surveyking/surveyking:v1.9.0`
+- `originImageName` at `template/surveyking/index.yaml:170`
+- `image` at `template/surveyking/index.yaml:193`
+
+### syncthing: `syncthing/syncthing:2.1.1`
+- `originImageName` at `template/syncthing/index.yaml:52`
+- `image` at `template/syncthing/index.yaml:81`
+- `image` at `template/syncthing/index.yaml:115`
+
+### tailchat: `minio/minio`
+- `originImageName` at `template/tailchat/index.yaml:267`
+- `image` at `template/tailchat/index.yaml:289`
+
+### tailchat: `moonrailgun/tailchat:1.11.5`
+- `originImageName` at `template/tailchat/index.yaml:66`
+- `image` at `template/tailchat/index.yaml:86`
+
+### teable: `registry.cn-shenzhen.aliyuncs.com/teable/teable-ee:latest`
+- `originImageName` at `template/teable/index.yaml:47`
+- `image` at `template/teable/index.yaml:69`
+- `image` at `template/teable/index.yaml:96`
+
+### teable: `senzing/postgresql-client:2.2.4`
+- `image` at `template/teable/index.yaml:348`
+
+### tentix: `limbo2342/tentix:dev-2025-10-23-x.3`
+- `image` at `template/tentix/index.yaml:211`
+
+### tentix: `limbo2342/tentix:migrate.10.22.x1`
+- `image` at `template/tentix/index.yaml:188`
+
+### tianji: `moonrailgun/tianji:1.18.5`
+- `originImageName` at `template/tianji/index.yaml:50`
+- `image` at `template/tianji/index.yaml:74`
+
+### tianji: `senzing/postgresql-client:2.2.4`
+- `image` at `template/tianji/index.yaml:259`
+
+### tolgee: `senzing/postgresql-client:2.2.4`
+- `image` at `template/tolgee/index.yaml:195`
+
+### tolgee: `tolgee/tolgee:v3.113.0`
+- `originImageName` at `template/tolgee/index.yaml:219`
+- `image` at `template/tolgee/index.yaml:244`
+
+### tooljet: `postgres:16-alpine`
+- `image` at `template/tooljet/index.yaml:257`
+- `image` at `template/tooljet/index.yaml:305`
+- `image` at `template/tooljet/index.yaml:568`
+
+### tooljet: `postgrest/postgrest:v12.0.2`
+- `originImageName` at `template/tooljet/index.yaml:455`
+- `image` at `template/tooljet/index.yaml:475`
+
+### tooljet: `tooljet/tooljet-ce:v3.20.170-lts`
+- `image` at `template/tooljet/index.yaml:333`
+- `originImageName` at `template/tooljet/index.yaml:548`
+- `image` at `template/tooljet/index.yaml:616`
+
+### tradingagents: `alpine/git:2.49.1`
+- `image` at `template/tradingagents/index.yaml:244`
+
+### tradingagents: `python:3.12-slim`
+- `originImageName` at `template/tradingagents/index.yaml:219`
+- `image` at `template/tradingagents/index.yaml:272`
+- `image` at `template/tradingagents/index.yaml:301`
+
+### trendradar: `wantcat/trendradar:6.9.1`
+- `originImageName` at `template/trendradar/index.yaml:133`
+- `image` at `template/trendradar/index.yaml:154`
+
+### tududi: `chrisvel/tududi:1.1.0`
+- `originImageName` at `template/tududi/index.yaml:50`
+- `image` at `template/tududi/index.yaml:73`
+
+### twenty: `busybox:latest`
+- `image` at `template/twenty/index.yaml:337`
+
+### twenty: `postgres:14-alpine`
+- `image` at `template/twenty/index.yaml:155`
+
+### twenty: `twentycrm/twenty:v1.12.0`
+- `originImageName` at `template/twenty/index.yaml:316`
+- `image` at `template/twenty/index.yaml:349`
+- `originImageName` at `template/twenty/index.yaml:452`
+- `image` at `template/twenty/index.yaml:472`
+
+### typebot: `axllent/mailpit:v1.30.1`
+- `originImageName` at `template/typebot/index.yaml:824`
+- `image` at `template/typebot/index.yaml:846`
+
+### typebot: `baptistearno/typebot-builder:3.17.1`
+- `originImageName` at `template/typebot/index.yaml:431`
+- `image` at `template/typebot/index.yaml:484`
+
+### typebot: `baptistearno/typebot-viewer:3.17.1`
+- `originImageName` at `template/typebot/index.yaml:656`
+- `image` at `template/typebot/index.yaml:709`
+
+### typebot: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/typebot/index.yaml:265`
+
+### typebot: `public.ecr.aws/docker/library/redis:7.2.7-alpine`
+- `image` at `template/typebot/index.yaml:453`
+- `image` at `template/typebot/index.yaml:678`
+
+### typesense: `typesense/typesense:29.0`
+- `originImageName` at `template/typesense/index.yaml:41`
+- `image` at `template/typesense/index.yaml:62`
+
+### typo3: `martinhelmich/typo3:13.4@sha256:7436d068b583c1dae2dd37ebca973b957de5371fe2acfdf9239598c3a8dbda25`
+- `originImageName` at `template/typo3/index.yaml:230`
+- `image` at `template/typo3/index.yaml:254`
+- `image` at `template/typo3/index.yaml:398`
+
+### typo3: `mysql:8.0.30`
+- `image` at `template/typo3/index.yaml:154`
+
+### ubuntu-sshd: `takeyamajp/ubuntu-sshd:ubuntu22.04`
+- `originImageName` at `template/ubuntu-sshd/index.yaml:38`
+- `image` at `template/ubuntu-sshd/index.yaml:63`
+
+### umami: `ghcr.io/umami-software/umami:3.0.2`
+- `originImageName` at `template/umami/index.yaml:58`
+- `image` at `template/umami/index.yaml:83`
+
+### umami: `postgres:14-alpine`
+- `image` at `template/umami/index.yaml:257`
+
+### uptime-kuma: `louislam/uptime-kuma:1.23.13`
+- `originImageName` at `template/uptime-kuma/index.yaml:38`
+- `image` at `template/uptime-kuma/index.yaml:61`
+
+### vaultwarden: `vaultwarden/server:latest`
+- `originImageName` at `template/vaultwarden/index.yaml:38`
+- `image` at `template/vaultwarden/index.yaml:61`
+
+### waha: `devlikeapro/waha:chrome-2026.5.1`
+- `originImageName` at `template/waha/index.yaml:162`
+- `image` at `template/waha/index.yaml:230`
+
+### waha: `public.ecr.aws/docker/library/postgres:16.4-alpine`
+- `image` at `template/waha/index.yaml:186`
+
+### webos: `fs185085781/webos:v1.4.1`
+- `originImageName` at `template/webos/index.yaml:37`
+- `image` at `template/webos/index.yaml:60`
+
+### wechat: `ricwang/docker-wechat:4.0.0.30`
+- `originImageName` at `template/wechat/index.yaml:47`
+- `image` at `template/wechat/index.yaml:70`
+
+### wechat2rss: `ttttmr/wechat2rss:latest`
+- `originImageName` at `template/wechat2rss/index.yaml:54`
+- `image` at `template/wechat2rss/index.yaml:73`
+
+### wewe-rss: `cooderl/wewe-rss:v2.6.1`
+- `originImageName` at `template/wewe-rss/index.yaml:174`
+- `image` at `template/wewe-rss/index.yaml:193`
+
+### wewe-rss: `joseluisq/mysql-client:8.0.30`
+- `image` at `template/wewe-rss/index.yaml:134`
+
+### woocommerce: `mysql:8.0.30`
+- `image` at `template/woocommerce/index.yaml:150`
+
+### woocommerce: `wordpress:6.9.1-php8.3-apache`
+- `originImageName` at `template/woocommerce/index.yaml:194`
+- `image` at `template/woocommerce/index.yaml:333`
+
+### woocommerce: `wordpress:cli-2.9.0-php8.3`
+- `image` at `template/woocommerce/index.yaml:214`
+
+### wordpress: `wordpress:6.5.4`
+- `originImageName` at `template/wordpress/index.yaml:48`
+- `image` at `template/wordpress/index.yaml:71`
+
+### wrenai: `ghcr.io/canner/wren-ai-service:0.15.17`
+- `originImageName` at `template/wrenai/index.yaml:206`
+- `image` at `template/wrenai/index.yaml:228`
+
+### wrenai: `ghcr.io/canner/wren-bootstrap:0.1.5`
+- `image` at `template/wrenai/index.yaml:313`
+
+### wrenai: `ghcr.io/canner/wren-engine-ibis:0.14.3`
+- `originImageName` at `template/wrenai/index.yaml:383`
+- `image` at `template/wrenai/index.yaml:405`
+
+### wrenai: `ghcr.io/canner/wren-engine:0.14.3`
+- `originImageName` at `template/wrenai/index.yaml:291`
+- `image` at `template/wrenai/index.yaml:325`
+
+### wrenai: `ghcr.io/canner/wren-ui:0.20.1`
+- `originImageName` at `template/wrenai/index.yaml:644`
+- `image` at `template/wrenai/index.yaml:666`
+
+### wrenai: `qdrant/qdrant:v1.13.4`
+- `originImageName` at `template/wrenai/index.yaml:466`
+- `image` at `template/wrenai/index.yaml:488`
+- `image` at `template/wrenai/index.yaml:516`
+
+### wrenai: `senzing/postgresql-client:2.2.4`
+- `image` at `template/wrenai/index.yaml:864`
+
+### yourls: `mysql:8.0.30`
+- `image` at `template/yourls/index.yaml:140`
+
+### yourls: `yourls:1.10.1`
+- `originImageName` at `template/yourls/index.yaml:178`
+- `image` at `template/yourls/index.yaml:203`
+
+### zitadel: `ghcr.io/zitadel/zitadel:v4.10.1`
+- `originImageName` at `template/zitadel/index.yaml:135`
+- `image` at `template/zitadel/index.yaml:155`
+
+### zot: `ghcr.io/project-zot/zot:v2.1.14`
+- `originImageName` at `template/zot/index.yaml:144`
+- `image` at `template/zot/index.yaml:234`
+- `originImageName` at `template/zot/index.yaml:296`
+- `image` at `template/zot/index.yaml:316`
+
+### zot: `httpd:2.4.63-alpine3.22`
+- `image` at `template/zot/index.yaml:164`

--- a/template/appwrite/index.yaml
+++ b/template/appwrite/index.yaml
@@ -282,7 +282,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: appwrite/appwrite:1.9.0
+    originImageName: appwrite/appwrite:1.9.5
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -308,7 +308,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: wait-for-data-store
-          image: busybox:1.36.1
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           env:
             - name: MONGO_HOST
@@ -330,7 +330,7 @@ spec:
               cpu: 20m
               memory: 25Mi
         - name: wait-for-cache
-          image: busybox:1.36.1
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST
@@ -353,7 +353,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: appwrite/appwrite:1.9.0
+          image: appwrite/appwrite:1.9.5
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -553,7 +553,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-console
   annotations:
-    originImageName: appwrite/console:7.8.26
+    originImageName: appwrite/console:8.7.19
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -574,7 +574,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-console
-          image: appwrite/console:7.8.26
+          image: appwrite/console:8.7.19
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/template/cobalt/index.yaml
+++ b/template/cobalt/index.yaml
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/imputnet/cobalt:7.13.3
+    originImageName: ghcr.io/imputnet/cobalt:11.7.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -80,7 +80,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/imputnet/cobalt:7.13.3
+          image: ghcr.io/imputnet/cobalt:11.7.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/template/derper/index.yaml
+++ b/template/derper/index.yaml
@@ -107,7 +107,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/yangchuansheng/derper:v1.99.0-pre
+    originImageName: ghcr.io/yangchuansheng/derper:v1.101.0-pre
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -129,7 +129,7 @@ spec:
         - name: ${{ defaults.app_name }}
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/yangchuansheng/derper:v1.99.0-pre
+          image: ghcr.io/yangchuansheng/derper:v1.101.0-pre
           imagePullPolicy: IfNotPresent
           env:
             - name: DERP_DOMAIN
@@ -193,7 +193,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: config-updater
-          image: bitnamilegacy/kubectl:1.28.9
+          image: bitnamilegacy/kubectl:1.33.4
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/template/dolibarr/index.yaml
+++ b/template/dolibarr/index.yaml
@@ -158,7 +158,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: mysql-init
-          image: mysql:8.0.30
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/template/evolution-api/index.yaml
+++ b/template/evolution-api/index.yaml
@@ -337,7 +337,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: fix-evolution-volume-permissions
-          image: public.ecr.aws/docker/library/busybox:1.36.1
+          image: public.ecr.aws/docker/library/busybox:1.38.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -390,7 +390,7 @@ spec:
               mountPath: /pg-secret
               readOnly: true
         - name: wait-for-redis
-          image: public.ecr.aws/docker/library/redis:7.2.7-alpine
+          image: public.ecr.aws/docker/library/redis:8.8.0-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST

--- a/template/ghost/index.yaml
+++ b/template/ghost/index.yaml
@@ -152,7 +152,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: mysql-init
-          image: public.ecr.aws/docker/library/mysql:8.0.30
+          image: public.ecr.aws/docker/library/mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -247,7 +247,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghost:6.44.1-alpine
+    originImageName: ghost:6.51.0-alpine
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.resource-override-source: https://github.com/docker-library/docs/blob/master/ghost/README.md#production-mode
@@ -297,7 +297,7 @@ spec:
               mountPath: /var/lib/ghost/content
         ${{ endif() }}
         - name: wait-for-mysql
-          image: public.ecr.aws/docker/library/mysql:8.0.30
+          image: public.ecr.aws/docker/library/mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -336,7 +336,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghost:6.44.1-alpine
+          image: ghost:6.51.0-alpine
           imagePullPolicy: IfNotPresent
           command:
             - /usr/local/bin/ghost-sealos-entrypoint.sh

--- a/template/grafana/index.yaml
+++ b/template/grafana/index.yaml
@@ -190,7 +190,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: grafana/grafana:13.0.2
+    originImageName: grafana/grafana:13.1.0
     deploy.cloud.sealos.io/minReplicas: "1"
     deploy.cloud.sealos.io/maxReplicas: "1"
   labels:
@@ -214,7 +214,7 @@ spec:
         fsGroup: 472
       containers:
         - name: ${{ defaults.app_name }}
-          image: grafana/grafana:13.0.2
+          image: grafana/grafana:13.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: GF_SERVER_ROOT_URL

--- a/template/jellyfin/index.yaml
+++ b/template/jellyfin/index.yaml
@@ -35,7 +35,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: jellyfin/jellyfin:10.10.7
+    originImageName: jellyfin/jellyfin:10.11.11
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -60,7 +60,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: ${{ defaults.app_name }}
-          image: jellyfin/jellyfin:10.10.7
+          image: jellyfin/jellyfin:10.11.11
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/template/langflow/index.yaml
+++ b/template/langflow/index.yaml
@@ -216,7 +216,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: langflowai/langflow:1.9.5
+    originImageName: langflowai/langflow:1.10.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -244,7 +244,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ${{ defaults.app_name }}
-          image: langflowai/langflow:1.9.5
+          image: langflowai/langflow:1.10.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/template/listmonk/index.yaml
+++ b/template/listmonk/index.yaml
@@ -221,7 +221,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: listmonk/listmonk:v6.1.0
+    originImageName: listmonk/listmonk:v6.2.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -249,7 +249,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: init-uploads
-          image: busybox:1.37.0
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -271,7 +271,7 @@ spec:
             - name: vn-listmonkvn-uploads
               mountPath: /listmonk/uploads
         - name: listmonk-setup
-          image: listmonk/listmonk:v6.1.0
+          image: listmonk/listmonk:v6.2.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -340,7 +340,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: listmonk/listmonk:v6.1.0
+          image: listmonk/listmonk:v6.2.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/template/litellm/index.yaml
+++ b/template/litellm/index.yaml
@@ -252,10 +252,10 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: litellm/litellm-database:v1.88.1
+    originImageName: litellm/litellm-database:v1.91.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
-    docker-to-sealos.resource-override-source: "Live Sealos validation on 2026-06-11: litellm/litellm-database:v1.88.1 was OOMKilled with 768Mi during startup; use the next valid Sealos memory ladder tier, 2048Mi."
+    docker-to-sealos.resource-override-source: "Live Sealos validation on 2026-06-11: litellm/litellm-database:v1.91.0 was OOMKilled with 768Mi during startup; use the next valid Sealos memory ladder tier, 2048Mi."
   labels:
     app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
@@ -319,7 +319,7 @@ spec:
       ${{ endif() }}
       containers:
         - name: ${{ defaults.app_name }}
-          image: litellm/litellm-database:v1.88.1
+          image: litellm/litellm-database:v1.91.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/template/logto/index.yaml
+++ b/template/logto/index.yaml
@@ -176,7 +176,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: svhd/logto:1.40.1
+    originImageName: svhd/logto:1.41.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -201,7 +201,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: db-seed
-          image: svhd/logto:1.40.1
+          image: svhd/logto:1.41.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -250,7 +250,7 @@ spec:
               memory: 256Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: svhd/logto:1.40.1
+          image: svhd/logto:1.41.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/template/loki/index.yaml
+++ b/template/loki/index.yaml
@@ -54,7 +54,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: init-loki-data
-          image: busybox:1.37.0
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/template/matomo/index.yaml
+++ b/template/matomo/index.yaml
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
         - name: mysql-init
-          image: mysql:8.0.44
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -176,7 +176,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: matomo:5.10.0-apache
+    originImageName: matomo:5.11.2-apache
     docker-to-sealos.resource-override-source: 'Sealos validation on 2026-06-03: Matomo setup exceeded a 256Mi container limit and was OOMKilled; 512Mi is required to complete the installation wizard reliably.'
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
@@ -198,7 +198,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: matomo:5.10.0-apache
+          image: matomo:5.11.2-apache
           imagePullPolicy: IfNotPresent
           startupProbe:
             tcpSocket:

--- a/template/mautic/index.yaml
+++ b/template/mautic/index.yaml
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: mysql-init
-          image: mysql:8.4.2
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -239,7 +239,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: mautic/mautic:7.1.2-apache
+    originImageName: mautic/mautic:7.1.3-apache
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -263,7 +263,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mysql
-          image: mautic/mautic:7.1.2-apache
+          image: mautic/mautic:7.1.3-apache
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -313,7 +313,7 @@ spec:
                 exit(1);
               '
         - name: take-data-dir-ownership
-          image: mautic/mautic:7.1.2-apache
+          image: mautic/mautic:7.1.3-apache
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -340,7 +340,7 @@ spec:
               mountPath: /mnt/media-images
       containers:
         - name: ${{ defaults.app_name }}
-          image: mautic/mautic:7.1.2-apache
+          image: mautic/mautic:7.1.3-apache
           imagePullPolicy: IfNotPresent
           env:
             - name: PHP_INI_VALUE_DATE_TIMEZONE
@@ -437,7 +437,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-cron
   annotations:
-    originImageName: mautic/mautic:7.1.2-apache
+    originImageName: mautic/mautic:7.1.3-apache
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -470,7 +470,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
         - name: wait-for-mautic-config
-          image: busybox:1.36.1
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -489,7 +489,7 @@ spec:
               mountPath: /mnt/config
       containers:
         - name: ${{ defaults.app_name }}-cron
-          image: mautic/mautic:7.1.2-apache
+          image: mautic/mautic:7.1.3-apache
           imagePullPolicy: IfNotPresent
           env:
             - name: PHP_INI_VALUE_DATE_TIMEZONE
@@ -561,7 +561,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-worker
   annotations:
-    originImageName: mautic/mautic:7.1.2-apache
+    originImageName: mautic/mautic:7.1.3-apache
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -594,7 +594,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       initContainers:
         - name: wait-for-mautic-config
-          image: busybox:1.36.1
+          image: busybox:1.38.0
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -613,7 +613,7 @@ spec:
               mountPath: /mnt/config
       containers:
         - name: ${{ defaults.app_name }}-worker
-          image: mautic/mautic:7.1.2-apache
+          image: mautic/mautic:7.1.3-apache
           imagePullPolicy: IfNotPresent
           env:
             - name: PHP_INI_VALUE_DATE_TIMEZONE

--- a/template/meilisearch/index.yaml
+++ b/template/meilisearch/index.yaml
@@ -41,7 +41,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: getmeili/meilisearch:v1.45.1
+    originImageName: getmeili/meilisearch:v1.49.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.resource-override-source: 'Live validation on Sealos usw-1 (2026-05-29): Meilisearch v1.45.1 cold-started, served /health, /version, index creation, document ingestion, and search with 100m CPU / 128Mi memory; observed usage 3-4m CPU and 10Mi memory, restartCount=0.'
@@ -65,7 +65,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: getmeili/meilisearch:v1.45.1
+          image: getmeili/meilisearch:v1.49.0
           env:
             - name: MEILI_ENV
               value: production

--- a/template/minecraft/index.yaml
+++ b/template/minecraft/index.yaml
@@ -45,7 +45,7 @@ kind: StatefulSet
 metadata:
     name: ${{ defaults.app_name }}
     annotations:
-        originImageName: itzg/minecraft-server:2026.5.3-java25
+        originImageName: itzg/minecraft-server:2026.7.0-java8
         deploy.cloud.sealos.io/minReplicas: "1"
         deploy.cloud.sealos.io/maxReplicas: "1"
     labels:
@@ -68,7 +68,7 @@ spec:
             automountServiceAccountToken: false
             initContainers:
                 - name: take-data-dir-ownership
-                  image: alpine:3.22.4
+                  image: alpine:3.24.1
                   imagePullPolicy: IfNotPresent
                   resources:
                       requests:
@@ -88,7 +88,7 @@ spec:
                         mountPath: /data
             containers:
                 - name: ${{ defaults.app_name }}
-                  image: itzg/minecraft-server:2026.5.3-java25
+                  image: itzg/minecraft-server:2026.7.0-java8
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: EULA

--- a/template/netbird/index.yaml
+++ b/template/netbird/index.yaml
@@ -147,7 +147,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-dashboard
   annotations:
-    originImageName: netbirdio/dashboard:v2.38.1
+    originImageName: netbirdio/dashboard:v2.90.3
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -167,7 +167,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-dashboard
-          image: netbirdio/dashboard:v2.38.1
+          image: netbirdio/dashboard:v2.90.3
           imagePullPolicy: IfNotPresent
           env:
             - name: NETBIRD_MGMT_API_ENDPOINT
@@ -214,7 +214,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}-management
   annotations:
-    originImageName: netbirdio/management:0.71.4
+    originImageName: netbirdio/management:0.74.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -235,7 +235,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-management
-          image: netbirdio/management:0.71.4
+          image: netbirdio/management:0.74.2
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -292,7 +292,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}-signal
   annotations:
-    originImageName: netbirdio/signal:0.71.4
+    originImageName: netbirdio/signal:0.74.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -313,7 +313,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-signal
-          image: netbirdio/signal:0.71.4
+          image: netbirdio/signal:0.74.2
           imagePullPolicy: IfNotPresent
           args:
             - --log-file
@@ -353,7 +353,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-relay
   annotations:
-    originImageName: netbirdio/relay:0.71.4
+    originImageName: netbirdio/relay:0.74.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -373,7 +373,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-relay
-          image: netbirdio/relay:0.71.4
+          image: netbirdio/relay:0.74.2
           imagePullPolicy: IfNotPresent
           env:
             - name: NB_LOG_LEVEL

--- a/template/node-red/index.yaml
+++ b/template/node-red/index.yaml
@@ -33,7 +33,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: nodered/node-red:4.1.10
+    originImageName: nodered/node-red:5.0.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -58,7 +58,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: ${{ defaults.app_name }}
-        image: nodered/node-red:4.1.10
+        image: nodered/node-red:5.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/template/openobserve/index.yaml
+++ b/template/openobserve/index.yaml
@@ -65,7 +65,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: public.ecr.aws/zinclabs/openobserve:v0.90.3
+    originImageName: public.ecr.aws/zinclabs/openobserve:v0.91.1
     docker-to-sealos.resource-override-source: Live Sealos cold-start validation on v0.90.3 observed 197Mi after first cold start and 178Mi after a probe-enabled restart; 256Mi is below safe headroom, so 512Mi is the minimum stable Sealos memory ladder value.
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
@@ -94,7 +94,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: ${{ defaults.app_name }}
-          image: public.ecr.aws/zinclabs/openobserve:v0.90.3
+          image: public.ecr.aws/zinclabs/openobserve:v0.91.1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/template/paperclip/index.yaml
+++ b/template/paperclip/index.yaml
@@ -254,7 +254,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: fix-paperclip-volume-permissions
-          image: public.ecr.aws/docker/library/busybox:1.36.1
+          image: public.ecr.aws/docker/library/busybox:1.38.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/template/prestashop/index.yaml
+++ b/template/prestashop/index.yaml
@@ -138,7 +138,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: mysql-init
-          image: mysql:8.0.30
+          image: mysql:9.7.1
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -213,7 +213,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: prestashop/prestashop:9.1.3-apache
+    originImageName: prestashop/prestashop:9.1.4-apache
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -234,7 +234,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: prestashop/prestashop:9.1.3-apache
+          image: prestashop/prestashop:9.1.4-apache
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/template/pterodactyl/index.yaml
+++ b/template/pterodactyl/index.yaml
@@ -180,7 +180,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: mysql-init
-          image: public.ecr.aws/docker/library/mysql:8.0.30
+          image: public.ecr.aws/docker/library/mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -365,7 +365,7 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-redis
-          image: public.ecr.aws/docker/library/redis:7.2.7-alpine
+          image: public.ecr.aws/docker/library/redis:8.8.0-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST
@@ -396,7 +396,7 @@ spec:
               memory: 25Mi
       containers:
         - name: pterodactyl-bootstrap
-          image: ghcr.io/pterodactyl/panel:v1.12.4
+          image: ghcr.io/pterodactyl/panel:v1.14.1
           imagePullPolicy: IfNotPresent
           env:
             - name: APP_ENV
@@ -542,7 +542,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/pterodactyl/panel:v1.12.4
+    originImageName: ghcr.io/pterodactyl/panel:v1.14.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.resource-override-source: https://github.com/pterodactyl/panel/blob/v1.12.4/Dockerfile
@@ -565,7 +565,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-mysql
-          image: public.ecr.aws/docker/library/mysql:8.0.30
+          image: public.ecr.aws/docker/library/mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -603,7 +603,7 @@ spec:
               cpu: 20m
               memory: 25Mi
         - name: wait-for-redis
-          image: public.ecr.aws/docker/library/redis:7.2.7-alpine
+          image: public.ecr.aws/docker/library/redis:8.8.0-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST
@@ -633,7 +633,7 @@ spec:
               cpu: 20m
               memory: 25Mi
         - name: wait-for-bootstrap-database
-          image: public.ecr.aws/docker/library/mysql:8.0.30
+          image: public.ecr.aws/docker/library/mysql:9.7.1
           imagePullPolicy: IfNotPresent
           env:
             - name: MYSQL_HOST
@@ -674,7 +674,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/pterodactyl/panel:v1.12.4
+          image: ghcr.io/pterodactyl/panel:v1.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/template/stalwart/index.yaml
+++ b/template/stalwart/index.yaml
@@ -231,7 +231,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: stalwartlabs/stalwart:v0.16.7
+    originImageName: stalwartlabs/stalwart:v0.16.12
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.official-kubernetes-source: https://stalw.art/docs/cluster/orchestration/kubernetes/
@@ -299,7 +299,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}
-          image: stalwartlabs/stalwart:v0.16.7
+          image: stalwartlabs/stalwart:v0.16.12
           imagePullPolicy: IfNotPresent
           args:
             - --config

--- a/template/trendradar/index.yaml
+++ b/template/trendradar/index.yaml
@@ -130,7 +130,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: wantcat/trendradar:6.9.1
+    originImageName: wantcat/trendradar:6.10.0
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -151,7 +151,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: wantcat/trendradar:6.9.1
+          image: wantcat/trendradar:6.10.0
           imagePullPolicy: IfNotPresent
           env:
             - name: TZ

--- a/template/typebot/index.yaml
+++ b/template/typebot/index.yaml
@@ -428,7 +428,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-builder
   annotations:
-    originImageName: baptistearno/typebot-builder:3.17.1
+    originImageName: baptistearno/typebot-builder:3.17.2
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
     docker-to-sealos.resource-override-source: https://github.com/baptisteArno/typebot.io/blob/v3.17.1/docker-compose.yml runs a Next.js builder service backed by PostgreSQL and Redis.
@@ -450,7 +450,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-redis
-          image: public.ecr.aws/docker/library/redis:7.2.7-alpine
+          image: public.ecr.aws/docker/library/redis:8.8.0-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST
@@ -481,7 +481,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}-builder
-          image: baptistearno/typebot-builder:3.17.1
+          image: baptistearno/typebot-builder:3.17.2
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -653,7 +653,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-viewer
   annotations:
-    originImageName: baptistearno/typebot-viewer:3.17.1
+    originImageName: baptistearno/typebot-viewer:3.17.2
     docker-to-sealos.resource-override-source: https://github.com/baptisteArno/typebot.io/blob/v3.17.1/docker-compose.yml runs the Viewer as a separate Next.js public runtime service.
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
@@ -675,7 +675,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         - name: wait-for-redis
-          image: public.ecr.aws/docker/library/redis:7.2.7-alpine
+          image: public.ecr.aws/docker/library/redis:8.8.0-alpine
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST
@@ -706,7 +706,7 @@ spec:
               memory: 25Mi
       containers:
         - name: ${{ defaults.app_name }}-viewer
-          image: baptistearno/typebot-viewer:3.17.1
+          image: baptistearno/typebot-viewer:3.17.2
           imagePullPolicy: IfNotPresent
           env:
             - name: PG_HOST
@@ -821,7 +821,7 @@ kind: Deployment
 metadata:
   name: ${{ defaults.app_name }}-mailpit
   annotations:
-    originImageName: axllent/mailpit:v1.30.1
+    originImageName: axllent/mailpit:v1.30.3
     docker-to-sealos.resource-override-source: https://mailpit.axllent.org/docs/install/docker/
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
@@ -843,7 +843,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}-mailpit
-          image: axllent/mailpit:v1.30.1
+          image: axllent/mailpit:v1.30.3
           imagePullPolicy: IfNotPresent
           ports:
             - name: smtp


### PR DESCRIPTION
## Summary

- Refresh Sealos template image versions for 26 templates from the generated update queue.
- Keep the batch limited to 45 candidates that passed focused docker-to-sealos artifact validation.
- Record 228 blocked candidates where docker-to-sealos validation reported existing template rule failures beyond this image refresh scope.

## Updated templates

- `appwrite` (3 candidates)
- `cobalt` (1 candidate)
- `derper` (2 candidates)
- `dolibarr` (1 candidate)
- `evolution-api` (2 candidates)
- `ghost` (2 candidates)
- `grafana` (1 candidate)
- `jellyfin` (1 candidate)
- `langflow` (1 candidate)
- `listmonk` (2 candidates)
- `litellm` (1 candidate)
- `logto` (1 candidate)
- `loki` (1 candidate)
- `matomo` (2 candidates)
- `mautic` (3 candidates)
- `meilisearch` (1 candidate)
- `minecraft` (2 candidates)
- `netbird` (4 candidates)
- `node-red` (1 candidate)
- `openobserve` (1 candidate)
- `paperclip` (1 candidate)
- `prestashop` (2 candidates)
- `pterodactyl` (3 candidates)
- `stalwart` (1 candidate)
- `trendradar` (1 candidate)
- `typebot` (4 candidates)

## Reports

- Update report: `.sealos/update-reports/template-version-updates.md`
- Machine-readable candidates: `.sealos/update-reports/template-version-updates.json`
- Queue and final statuses: `.sealos/update-reports/template-update-queue.json`
- Status summary: `.sealos/update-reports/template-update-status.md`
- Blocked template list: `.sealos/update-reports/blocked-template-list.md`
- Artifact validation evidence: `.sealos/update-reports/docker-to-sealos-artifact-validation.json`

## Blocked candidates

- 121 queued templates / 228 candidates were blocked after per-artifact docker-to-sealos validation.
- Common blocker categories include existing metadata, ingress, resource ladder, image pull secret, database Job, and legacy template structure violations.
- Full per-template evidence and sample validator findings are recorded in `.sealos/update-reports/docker-to-sealos-artifact-validation.json` and `.sealos/update-reports/template-update-status.json`.

## Validation

- `git diff --check upstream/kb-0.9...HEAD` passed.
- `python3 -c 'import yaml'` failed on the default interpreter, so validation used `/opt/homebrew/Caskroom/miniforge/base/bin/python3`.
- Repository-local `scripts/check_consistency.py` and `scripts/quality_gate.py` are absent in this checkout.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/path_converter.py --self-test` passed.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_check_consistency.py` passed: 101 tests.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_compose_to_template.py` passed: 33 tests.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/test_check_must_coverage.py` passed: 4 tests.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/check_must_coverage.py --skill SKILL.md --mapping references/must-rules-map.yaml --rules-file references/rules-registry.yaml` passed.
- `/opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/check_consistency.py --skill SKILL.md --references references --rules-file references/rules-registry.yaml --artifacts "$ABS_ARTIFACTS"` passed for 26 changed artifacts: 40 rules.
- `DOCKER_TO_SEALOS_ARTIFACTS="$ABS_ARTIFACTS" /opt/homebrew/Caskroom/miniforge/base/bin/python3 scripts/quality_gate.py` passed.

## Branch

- Head: `yangchuansheng:codex/template-version-refresh-20260708`
- Base: `labring-actions/templates:kb-0.9`
