### PR TITLE
fix(dify): add worker startup probe

### DIFF
--- a/template/dify/index.yaml
+++ b/template/dify/index.yaml
@@ -893,6 +893,15 @@ spec:
         volumeMounts:
         - name: vn-appvn-apivn-storage
           mountPath: /app/api/storage
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - celery -A celery_healthcheck.celery inspect ping >/dev/null 2>&1
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 10
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
## Summary

Add a startup probe for the Dify worker container before its existing liveness probe.

## Why

The worker health check can need more time during startup. A startup probe prevents the liveness probe from restarting the worker before Celery is ready to respond.

## Changes

- Add `startupProbe` before the worker `livenessProbe` in `template/dify/index.yaml`.
- Reuse the existing Celery ping command from the liveness/readiness probes.
- Keep the change limited to the Dify worker probe configuration.

## Verification

- Ran `git diff --check upstream/kb-0.9..HEAD`.
- Ran `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML OK"' /Users/mafirsc/Documents/sealos/templates/template/dify/index.yaml`.
- Confirmed the PR branch is ahead of `labring-actions/templates:kb-0.9` by 1 commit and behind by 0.

## Rollback

If this causes unexpected worker startup behavior, revert this PR to remove the startup probe.
