### PR TITLE
fix(plane): remove duplicate Chinese readme config

### DIFF
--- a/template/plane/index.yaml
+++ b/template/plane/index.yaml
@@ -29,9 +29,6 @@ spec:
       type: string
       value: plane-${{ random(8) }}
 
-  i18n:
-    zh:
-      readme: 'https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/plane/README_zh.md'
 ---
 apiVersion: objectstorage.sealos.io/v1
 kind: ObjectStorageBucket


### PR DESCRIPTION
Remove the duplicate `spec.i18n.zh.readme` block from the Plane template. The original localized entry, including its description and README URL, is retained.\n\nValidation: `ruby -ryaml -e 'documents = YAML.load_stream(File.read("template/plane/index.yaml")); puts "parsed #{documents.length} YAML documents"'`