### PR TITLE
fix(dify): add CODE_EXECUTION_ENDPOINT to worker containers and extend API startup probe

### DIFF
--- a/template/dify/index.yaml
+++ b/template/dify/index.yaml
@@ -717,7 +717,7 @@ spec:
             - curl
             - -fsS
             - http://127.0.0.1:5001/health
-          failureThreshold: 30
+          failureThreshold: 90
           periodSeconds: 10
           timeoutSeconds: 5
         livenessProbe:
@@ -878,6 +878,8 @@ spec:
           value: ${{ defaults.sandbox_api_key }}
         - name: SANDBOX_API_KEY
           value: ${{ defaults.sandbox_api_key }}
+        - name: CODE_EXECUTION_ENDPOINT
+          value: http://${{ defaults.app_name }}-sandbox.${{ SEALOS_NAMESPACE }}.svc.cluster.local:8194
         resources:
           requests:
             cpu: 50m
@@ -1060,6 +1062,8 @@ spec:
           value: ${{ defaults.sandbox_api_key }}
         - name: SANDBOX_API_KEY
           value: ${{ defaults.sandbox_api_key }}
+        - name: CODE_EXECUTION_ENDPOINT
+          value: http://${{ defaults.app_name }}-sandbox.${{ SEALOS_NAMESPACE }}.svc.cluster.local:8194
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary

Three changes to `template/dify/index.yaml` to stabilize the Dify deployment on Sealos:

1. **API container startupProbe**: `failureThreshold: 30 → 90` (only the `dify-xxx-api` container, extending the startup budget from 5 to 15 minutes; the `failureThreshold: 30` in weaviate/web/sandbox containers is untouched).
2. **`dify-xxx-worker`**: add `CODE_EXECUTION_ENDPOINT` env var with the same value as the API container, fixing the worker's failure to resolve the sandbox domain when executing code nodes asynchronously.
3. **`dify-xxx-worker-beat`**: add the same env var for consistency, avoiding the same issue for future background tasks.

## Verification

- Branch created from latest `upstream/kb-0.9` (`2aa2a8f`), verified `status: ahead, ahead_by: 1, behind_by: 0`
- Diff matches the official source file `template/dify/index.yaml` on branch `kb-0.9`
- Ran:

```bash
git diff --check upstream/kb-0.9..HEAD
```

- YAML validated after modification

## Rollback

Merge with **Create a merge commit**. If something goes wrong after merge, use GitHub's **Revert** action on this PR.
