### PR TITLE
fix(fastgpt): use numeric service target ports

### DIFF
--- a/template/fastgpt-milvus/index.yaml
+++ b/template/fastgpt-milvus/index.yaml
@@ -363,7 +363,7 @@ spec:
   ports:
     - name: http
       port: 3000
-      targetPort: http
+      targetPort: 3000
       protocol: TCP
 
 ---
@@ -666,7 +666,7 @@ spec:
   ports:
     - name: http
       port: 3000
-      targetPort: http
+      targetPort: 3000
       protocol: TCP
 
 ---


### PR DESCRIPTION
## Summary

Fix the FastGPT and code-sandbox Service target ports in `template/fastgpt-milvus/index.yaml`.

Both Services target the named port `http`, while their corresponding containers expose only port `3000` without that name. Use numeric target ports so Kubernetes can publish usable Service endpoints.

## Verification

- Synced local `kb-0.9` with `upstream/kb-0.9` at `2057a98`
- Changed only two `targetPort` values in `template/fastgpt-milvus/index.yaml`
- Ran `git diff --check`
- Verified the same main Service fix restored the existing FastGPT public endpoint to HTTP 200

## Scope

- No other template fields were changed
- No cluster resources were changed by this PR
