### PR TITLE
feat(eaglercraft): serve the admin console on its own -admin host

### DIFF
--- a/template/eaglercraft-server/README.md
+++ b/template/eaglercraft-server/README.md
@@ -50,7 +50,7 @@ The main container has a `200m` CPU limit and `1024Mi` memory limit; the init co
 
 1. Open the [EaglerCraft Server template](https://sealos.io/products/app-store/eaglercraft-server) and click **Deploy Now**.
 2. Choose `minecraft_version` (`1.12` by default) and set `rcon_password` to a strong, non-empty, single-line password. Save this value for administrator login.
-3. Full game startup typically takes **2-3 minutes**, depending on world generation and plugin loading. Open the application link in the Canvas: it goes to the admin host (`https://<app_host>-admin.<domain>`), which becomes available as soon as the management HTTP service starts. Players use the game host (`https://<app_host>.<domain>`).
+3. Full game startup typically takes **2-3 minutes**, depending on world generation and plugin loading. Open the application link in the Canvas: it goes to the admin host (`https://<app_host>-admin.<domain>`), which becomes available as soon as the management HTTP service starts. Players use the game host (`https://<app_host>.<domain>`); Brain lists only the admin address, so copy the game address from the console's **Overview**.
 4. Enter the deployment RCON password and click **Confirm**. Administrator login is available while the game initializes. World data and game controls become available when the StatefulSet is Ready. Use the header's **Language** selector to choose English or 简体中文.
 5. Once the StatefulSet is Ready, use **Open and join game** on **Overview**, or copy the WebSocket address into the browser client's Multiplayer server list. Complete the player registration or login described below.
 

--- a/template/eaglercraft-server/README.md
+++ b/template/eaglercraft-server/README.md
@@ -8,7 +8,7 @@ EaglerCraft Server bundles a browser game client, secure WebSocket gateway, Pape
 
 Players open the browser client and join a Paper world through a secure WebSocket connection. Choose `1.12` for Paper 1.12.2 or `1.8` for Paper 1.8.8 before the first deployment. Use a separate instance and volume for each Minecraft version.
 
-One StatefulSet runs the game gateway, Paper, and administration bridge. Sealos provisions a 1 GiB persistent volume, a public HTTPS address, and routing for gameplay and the admin panel. World files, server configuration, player accounts, and version-specific plugin repositories survive Pod replacement.
+One StatefulSet runs the game gateway, Paper, and administration bridge. Sealos provisions a 1 GiB persistent volume and two public HTTPS addresses: one for gameplay and one for the admin panel. World files, server configuration, player accounts, and version-specific plugin repositories survive Pod replacement.
 
 ## Common Use Cases
 
@@ -33,7 +33,7 @@ The image includes both browser clients, Paper runtimes, the WebSocket gateway, 
 
 - **StatefulSet**: One replica using `ghcr.io/yangchuansheng/eaglerx1.8server:2.2.4`, pinned to its published SHA-256 digest.
 - **Game route**: HTTPS `/` and secure WebSocket connections reach port `5200`.
-- **Admin route**: `/admin`, `/api`, `/admin.css`, `/admin.js`, `/admin-i18n.js`, and `/dynmap` reach port `5201` on the same host. The Service publishes Pod endpoints during game initialization so the console and browser client open as soon as their HTTP services start.
+- **Admin route**: the `<app_host>-admin` host reaches port `5201`. The admin console, its `/api` endpoints, and the `/dynmap` proxy all live on this host, so players who receive the game address never see the admin console. The Service publishes Pod endpoints during game initialization so the console and browser client open as soon as their HTTP services start.
 - **Internal services**: Paper `25565` and RCON `25575` stay inside the Pod.
 - **Persistent volume**: `/eaglerx-data` contains the full runtime, worlds, and configuration. `PERSISTENT_DATA_ROOT=/eaglerx-data/runtime/server-data` holds the version-specific plugin repositories.
 - **Runtime initialization**: An init container seeds fresh volumes and refreshes image-owned scripts and browser assets on existing volumes, preserving Paper configuration, worlds, and plugin data.
@@ -50,7 +50,7 @@ The main container has a `200m` CPU limit and `1024Mi` memory limit; the init co
 
 1. Open the [EaglerCraft Server template](https://sealos.io/products/app-store/eaglercraft-server) and click **Deploy Now**.
 2. Choose `minecraft_version` (`1.12` by default) and set `rcon_password` to a strong, non-empty, single-line password. Save this value for administrator login.
-3. Full game startup typically takes **2-3 minutes**, depending on world generation and plugin loading. Open the application link in the Canvas: it goes directly to `/admin`, which becomes available as soon as the management HTTP service starts.
+3. Full game startup typically takes **2-3 minutes**, depending on world generation and plugin loading. Open the application link in the Canvas: it goes to the admin host (`https://<app_host>-admin.<domain>`), which becomes available as soon as the management HTTP service starts. Players use the game host (`https://<app_host>.<domain>`).
 4. Enter the deployment RCON password and click **Confirm**. Administrator login is available while the game initializes. World data and game controls become available when the StatefulSet is Ready. Use the header's **Language** selector to choose English or 简体中文.
 5. Once the StatefulSet is Ready, use **Open and join game** on **Overview**, or copy the WebSocket address into the browser client's Multiplayer server list. Complete the player registration or login described below.
 
@@ -96,7 +96,7 @@ For Minecraft 1.8, initialization disables Dynmap's player health and armor disp
 
 ## Troubleshooting
 
-- **The console opens while game controls are still loading**: Check the StatefulSet's Ready status in the Canvas. The browser client `/` and console `/admin` open early; entering the world and using game controls requires Paper and RCON. The `[start]` log lines describe entrypoint configuration. Paper's initialization progress is in `/eaglerx-data/runtime/server/logs/latest.log` inside the container.
+- **The console opens while game controls are still loading**: Check the StatefulSet's Ready status in the Canvas. The browser client (game host) and console (`-admin` host) open early; entering the world and using game controls requires Paper and RCON. The `[start]` log lines describe entrypoint configuration. Paper's initialization progress is in `/eaglerx-data/runtime/server/logs/latest.log` inside the container.
 - **Admin login fails**: Enter the saved `rcon_password`. Five failed attempts from the same source trigger a 10-minute lockout; clients sharing a reverse proxy may share that window.
 - **The player is disconnected shortly after joining**: Complete `/register` on the first visit or `/login` on later visits within 30 seconds, using the same player name.
 - **A plugin upload returns HTTP 413**: Keep the JAR within the template's 32 MiB ingress limit.

--- a/template/eaglercraft-server/README_zh.md
+++ b/template/eaglercraft-server/README_zh.md
@@ -50,7 +50,7 @@ EaglerCraft Server 集成浏览器游戏客户端、安全 WebSocket 网关、Pa
 
 1. 打开 [EaglerCraft Server 模板页面](https://sealos.io/products/app-store/eaglercraft-server)，点击 **Deploy Now**。
 2. 选择 `minecraft_version`，默认值为 `1.12`；将 `rcon_password` 设置为强度足够的非空单行密码，并保存好这个管理员登录密码。
-3. 游戏完整启动通常需要 **2-3 分钟**，具体取决于世界生成和插件加载。在 Canvas 点击应用链接会打开管理域名（`https://<app_host>-admin.<domain>`），管理 HTTP 服务启动后即可访问该页面。玩家使用游戏域名（`https://<app_host>.<domain>`）。
+3. 游戏完整启动通常需要 **2-3 分钟**，具体取决于世界生成和插件加载。在 Canvas 点击应用链接会打开管理域名（`https://<app_host>-admin.<domain>`），管理 HTTP 服务启动后即可访问该页面。玩家使用游戏域名（`https://<app_host>.<domain>`）；Brain 只列出管理地址，游戏地址请在控制台的 **Overview** 中复制。
 4. 输入部署时的 RCON 密码，点击 **Confirm**。游戏初始化期间即可完成管理员登录；StatefulSet 进入 Ready 状态后，世界数据和游戏控制功能可用。可通过页眉的 **Language** 选择 English 或简体中文。
 5. 等待 StatefulSet 进入 Ready 状态后，在 **Overview** 中点击 **Open and join game**，或将 WebSocket 地址复制到浏览器客户端的 Multiplayer 服务器列表。进入世界后，按照下文完成玩家注册或登录。
 

--- a/template/eaglercraft-server/README_zh.md
+++ b/template/eaglercraft-server/README_zh.md
@@ -8,7 +8,7 @@ EaglerCraft Server 集成浏览器游戏客户端、安全 WebSocket 网关、Pa
 
 玩家打开浏览器客户端后，通过安全 WebSocket 连接加入 Paper 世界。首次部署前选择游戏版本：`1.12` 对应 Paper 1.12.2，`1.8` 对应 Paper 1.8.8。每个 Minecraft 版本应使用独立的实例和持久卷。
 
-一个 StatefulSet 运行游戏网关、Paper 和管理桥接服务。Sealos 自动配置 1 GiB 持久卷、公网 HTTPS 地址，以及游戏和管理面板的访问路由。Pod 替换后，世界文件、服务端配置、玩家账号和按版本隔离的插件仓库会继续保留。
+一个 StatefulSet 运行游戏网关、Paper 和管理桥接服务。Sealos 自动配置 1 GiB 持久卷和两个公网 HTTPS 地址：一个给游戏，一个给管理面板。Pod 替换后，世界文件、服务端配置、玩家账号和按版本隔离的插件仓库会继续保留。
 
 ## 常见使用场景
 
@@ -33,7 +33,7 @@ EaglerCraft Server 集成浏览器游戏客户端、安全 WebSocket 网关、Pa
 
 - **StatefulSet**：单副本运行 `ghcr.io/yangchuansheng/eaglerx1.8server:2.2.4`，并固定到已发布的 SHA-256 摘要。
 - **游戏路由**：HTTPS 根路径 `/` 和安全 WebSocket 连接访问端口 `5200`。
-- **管理路由**：同一域名下的 `/admin`、`/api`、`/admin.css`、`/admin.js`、`/admin-i18n.js` 和 `/dynmap` 访问端口 `5201`。Service 在游戏初始化期间就发布 Pod 端点，管理页和浏览器客户端各自的 HTTP 服务启动后即可访问。
+- **管理路由**：`<app_host>-admin` 域名访问端口 `5201`。管理面板、`/api` 接口和 `/dynmap` 代理都在这个域名下，拿到游戏地址的玩家看不到管理面板。Service 在游戏初始化期间就发布 Pod 端点，管理页和浏览器客户端各自的 HTTP 服务启动后即可访问。
 - **内部服务**：Paper 端口 `25565` 和 RCON 端口 `25575` 保持在 Pod 内部。
 - **持久卷**：`/eaglerx-data` 保存完整运行目录、世界和配置。`PERSISTENT_DATA_ROOT=/eaglerx-data/runtime/server-data` 保存按版本隔离的插件仓库。
 - **运行目录初始化**：初始化容器会为新持久卷写入完整运行目录，并刷新已有持久卷中由镜像提供的脚本和浏览器资源，同时保留 Paper 配置、世界及插件数据。
@@ -50,7 +50,7 @@ EaglerCraft Server 集成浏览器游戏客户端、安全 WebSocket 网关、Pa
 
 1. 打开 [EaglerCraft Server 模板页面](https://sealos.io/products/app-store/eaglercraft-server)，点击 **Deploy Now**。
 2. 选择 `minecraft_version`，默认值为 `1.12`；将 `rcon_password` 设置为强度足够的非空单行密码，并保存好这个管理员登录密码。
-3. 游戏完整启动通常需要 **2-3 分钟**，具体取决于世界生成和插件加载。在 Canvas 点击应用链接会直接打开 `/admin`，管理 HTTP 服务启动后即可访问该页面。
+3. 游戏完整启动通常需要 **2-3 分钟**，具体取决于世界生成和插件加载。在 Canvas 点击应用链接会打开管理域名（`https://<app_host>-admin.<domain>`），管理 HTTP 服务启动后即可访问该页面。玩家使用游戏域名（`https://<app_host>.<domain>`）。
 4. 输入部署时的 RCON 密码，点击 **Confirm**。游戏初始化期间即可完成管理员登录；StatefulSet 进入 Ready 状态后，世界数据和游戏控制功能可用。可通过页眉的 **Language** 选择 English 或简体中文。
 5. 等待 StatefulSet 进入 Ready 状态后，在 **Overview** 中点击 **Open and join game**，或将 WebSocket 地址复制到浏览器客户端的 Multiplayer 服务器列表。进入世界后，按照下文完成玩家注册或登录。
 
@@ -96,7 +96,7 @@ Minecraft 1.8 的初始化流程会关闭 Dynmap 的玩家生命值和护甲显�
 
 ## 故障排查
 
-- **管理页面已打开，游戏控制仍在加载**：在 Canvas 查看 StatefulSet 的 Ready 状态。浏览器客户端 `/` 和管理页 `/admin` 提前开放，进入世界及游戏控制需要等待 Paper 和 RCON。`[start]` 日志描述入口脚本的配置过程，Paper 的实际初始化进度保存在容器内的 `/eaglerx-data/runtime/server/logs/latest.log`。
+- **管理页面已打开，游戏控制仍在加载**：在 Canvas 查看 StatefulSet 的 Ready 状态。浏览器客户端（游戏域名）和管理页（`-admin` 域名）提前开放，进入世界及游戏控制需要等待 Paper 和 RCON。`[start]` 日志描述入口脚本的配置过程，Paper 的实际初始化进度保存在容器内的 `/eaglerx-data/runtime/server/logs/latest.log`。
 - **管理员登录失败**：使用已保存的 `rcon_password`。同一来源连续输错 5 次会锁定 10 分钟；通过同一反向代理访问的客户端可能共享这一窗口。
 - **玩家加入后很快断开**：首次访问时在 30 秒内执行 `/register`，之后访问时执行 `/login`，并保持玩家名一致。
 - **插件上传返回 HTTP 413**：将 JAR 文件大小控制在模板的 32 MiB 入口限制内。

--- a/template/eaglercraft-server/index.yaml
+++ b/template/eaglercraft-server/index.yaml
@@ -214,6 +214,9 @@ metadata:
   labels:
     app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
+  annotations:
+    # Brain: the Open control opens the admin console, not the game gateway.
+    brain.io/default-open-port: "5201"
 spec:
   type: ClusterIP
   # Serve the admin console and browser client while Paper initializes.
@@ -240,6 +243,9 @@ metadata:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
   annotations:
+    # Brain: players receive this address from the admin console, so Brain
+    # does not list it as a Public Address of the deployment.
+    brain.io/public-address: unlisted
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'

--- a/template/eaglercraft-server/index.yaml
+++ b/template/eaglercraft-server/index.yaml
@@ -271,7 +271,7 @@ metadata:
   labels:
     app: ${{ defaults.app_name }}
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
-    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}
+    cloud.sealos.io/app-deploy-manager-domain: ${{ defaults.app_host }}-admin
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
@@ -291,46 +291,11 @@ metadata:
       }
 spec:
   rules:
-    - host: ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+    - host: ${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
       http:
         paths:
           - pathType: Prefix
-            path: /api
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 5201
-          - pathType: Prefix
-            path: /admin.css
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 5201
-          - pathType: Prefix
-            path: /admin.js
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 5201
-          - pathType: Exact
-            path: /admin-i18n.js
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 5201
-          - pathType: Prefix
-            path: /admin
-            backend:
-              service:
-                name: ${{ defaults.app_name }}
-                port:
-                  number: 5201
-          - pathType: Prefix
-            path: /dynmap
+            path: /
             backend:
               service:
                 name: ${{ defaults.app_name }}
@@ -338,7 +303,7 @@ spec:
                   number: 5201
   tls:
     - hosts:
-        - ${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}
+        - ${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
       secretName: ${{ SEALOS_CERT_SECRET_NAME }}
 
 ---
@@ -350,7 +315,7 @@ metadata:
     cloud.sealos.io/app-deploy-manager: ${{ defaults.app_name }}
 spec:
   data:
-    url: https://${{ defaults.app_host }}.${{ SEALOS_CLOUD_DOMAIN }}/admin
+    url: https://${{ defaults.app_host }}-admin.${{ SEALOS_CLOUD_DOMAIN }}
   displayType: normal
   icon: https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/eaglercraft-server/logo.svg
   name: EaglerCraft Server


### PR DESCRIPTION
## What

The EaglerCraft admin console (port 5201) was reachable as six path rules (`/admin`, `/api`, `/admin.js`, `/admin.css`, `/admin-i18n.js`, `/dynmap`) under the **game** host. This PR gives it a dedicated `<app_host>-admin` host, the same layout logto, minio and frp already use for their consoles.

- Second Ingress: one rule `/` → 5201 on the `-admin` host, with its own `cloud.sealos.io/app-deploy-manager-domain` label.
- Sealos `App` link now opens the admin host root.
- Game host keeps only the WebSocket client at `/`.
- `README.md` / `README_zh.md` describe the two-address layout.

## Why

- **Cleaner boundary.** Players who receive the game address can no longer stumble onto the admin login page by appending `/admin`.
- **Simpler routing.** Six path rules collapse into one.
- **Two entries show up as two addresses** in Sealos-side UIs that list one row per host, instead of the console being invisible behind the game domain.

## Why no image change is needed

- `admin.js` builds its API base from `location.origin`, so `/api` and `/dynmap` follow whatever host serves `admin.html`.
- The game client (`index.html` on 5200) makes no requests to `/api` or `/dynmap`.
- `PUBLIC_GAME_URL` is unchanged and still points at the game host, so the console's **Open and join game** link stays correct.

The image's own `CONTEXT.md` already treats 游戏入口 and 管理面 as separate entries; this only makes the template match that.

## Brain

Brain shows the deployment with a single entry: the admin console.

- `brain.io/default-open-port: "5201"` on the Service presets Brain's Default Open Port, so the **Open** control opens the admin console rather than the game gateway. (Brain's automatic rule already picks 5201 because the game host is WS-only; the annotation makes the intent explicit.)
- `brain.io/public-address: unlisted` on the game Ingress declares that the game host is not a Public Address Brain lists for this deployment: players receive it from the admin console's **Overview**. The annotation name is provisional; Brain support is pending, and until it lands Brain lists both hosts.

## Verification

- Rendered the template with placeholder substitution: 6 documents, game Ingress `/ → 5200` on `<app_host>`, admin Ingress `/ → 5201` on `<app_host>-admin`, App url `https://<app_host>-admin.<domain>`.
- No live cluster deploy was run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2yBSyr98vDyfNmPyxdg2J

