### PR TITLE
fix(moneyprinterturbo): update image to v1.3.6

### DIFF
--- a/template/moneyprinterturbo/index.yaml
+++ b/template/moneyprinterturbo/index.yaml
@@ -34,7 +34,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200
+    originImageName: ghcr.io/harry0703/moneyprinterturbo:v1.3.6
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -57,7 +57,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200
+          image: ghcr.io/harry0703/moneyprinterturbo:v1.3.6
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
## Summary

Update MoneyPrinterTurbo from the outdated `ghcr.io/yangchuansheng/moneyprinterturbo:20240510083200` image to `ghcr.io/harry0703/moneyprinterturbo:v1.3.6`.

This updates both the `originImageName` annotation and the StatefulSet container image.

## Verification

- Compared `upstream/kb-0.9` with the PR branch
- PR branch is ahead by 1 commit and behind by 0 commits
- Changed files: `template/moneyprinterturbo/index.yaml`
- Ran `git diff --check upstream/kb-0.9..HEAD`
- Parsed the YAML successfully and verified the v1.3.6 image value

## Rollback

Merge with **Create a merge commit**. If something goes wrong after merge, use GitHub's **Revert** action on this PR.
