### PR TITLE
fix(casdoor): persist SQLite database on PVC

### DIFF
--- a/template/casdoor/index.yaml
+++ b/template/casdoor/index.yaml
@@ -362,7 +362,7 @@ spec:
             - name: driverName
               value: sqlite
             - name: dataSourceName
-              value: /tmp/casdoor.db
+              value: /home/casdoor.db
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
## Summary

Update the Casdoor SQLite database path from `/tmp/casdoor.db` to `/home/casdoor.db` so it uses the existing persistent volume mounted at `/home`.

## Verification

- Synced local `kb-0.9` with `upstream/kb-0.9`
- Compared the PR branch with upstream `kb-0.9`: ahead 1, behind 0, 1 file changed
- Ran:

```bash
git diff --check upstream/kb-0.9..HEAD
```

## Rollback

Merge with **Create a merge commit**. If something goes wrong after merge, use GitHub's **Revert** action on this PR.
