### PR TITLE
fix(libredb-studio): update image to 0.14.1

### DIFF
--- a/.sealos/topology-evidence/libredb-studio.yaml
+++ b/.sealos/topology-evidence/libredb-studio.yaml
@@ -4,7 +4,7 @@ metadata:
   name: libredb-studio-topology
 spec:
   appName: libredb-studio
-  source: https://github.com/libredb/libredb-studio/blob/0.9.66/docker-compose.example.yml
+  source: https://github.com/libredb/libredb-studio/blob/0.14.1/docker-compose.example.yml
   resources:
     - kind: Cluster
       name: ${{ defaults.app_name }}-pg

--- a/template/libredb-studio/README.md
+++ b/template/libredb-studio/README.md
@@ -1,6 +1,6 @@
 # Deploy and Host LibreDB Studio on Sealos
 
-LibreDB Studio is an open-source database IDE for querying and managing PostgreSQL, MySQL, SQLite, MongoDB, and other supported data sources from a browser. This template deploys LibreDB Studio 0.9.66 with HTTPS access, persistent server-side storage, health probes, and deployment-defined administrator credentials on Sealos Cloud.
+LibreDB Studio is an open-source database IDE for querying and managing PostgreSQL, MySQL, SQLite, MongoDB, and other supported data sources from a browser. This template deploys LibreDB Studio 0.14.1 with HTTPS access, persistent server-side storage, health probes, and deployment-defined administrator credentials on Sealos Cloud.
 
 ![LibreDB Studio Screenshot](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/libredb-studio/website-screenshot.webp)
 
@@ -21,7 +21,7 @@ The PostgreSQL option stores LibreDB Studio settings such as saved connections a
 
 The template includes the runtime components required for a working deployment:
 
-- **LibreDB Studio**: `ghcr.io/libredb/libredb-studio:0.9.66`
+- **LibreDB Studio**: `ghcr.io/libredb/libredb-studio:0.14.1`
 - **Default SQLite storage**: `/app/data/libredb-storage.db` on a 1 GiB application PVC
 - **Optional PostgreSQL storage**: KubeBlocks-managed `postgresql-16.4.0` with a 1 GiB data PVC
 - **HTTPS entrypoint**: Sealos Service, Ingress, and App resources on port `3000`

--- a/template/libredb-studio/README_zh.md
+++ b/template/libredb-studio/README_zh.md
@@ -1,6 +1,6 @@
 # 在 Sealos 上部署和托管 LibreDB Studio
 
-LibreDB Studio 是一款开源数据库 IDE，可直接在浏览器中查询和管理 PostgreSQL、MySQL、SQLite、MongoDB 等数据源。此模板会在 Sealos Cloud 上部署 LibreDB Studio 0.9.66，并配置 HTTPS 入口、持久化服务端存储、健康检查和部署时创建的管理员账号。
+LibreDB Studio 是一款开源数据库 IDE，可直接在浏览器中查询和管理 PostgreSQL、MySQL、SQLite、MongoDB 等数据源。此模板会在 Sealos Cloud 上部署 LibreDB Studio 0.14.1，并配置 HTTPS 入口、持久化服务端存储、健康检查和部署时创建的管理员账号。
 
 ![LibreDB Studio 截图](https://raw.githubusercontent.com/labring-actions/templates/kb-0.9/template/libredb-studio/website-screenshot.webp)
 
@@ -21,7 +21,7 @@ PostgreSQL 选项保存 LibreDB Studio 的连接配置、收藏查询等应用�
 
 模板包含可用部署所需的运行组件：
 
-- **LibreDB Studio**：`ghcr.io/libredb/libredb-studio:0.9.66`
+- **LibreDB Studio**：`ghcr.io/libredb/libredb-studio:0.14.1`
 - **默认 SQLite 存储**：`/app/data/libredb-storage.db`，使用 1 GiB 应用 PVC
 - **可选 PostgreSQL 存储**：KubeBlocks 托管的 `postgresql-16.4.0`，使用 1 GiB 数据 PVC
 - **HTTPS 入口**：通过 Sealos Service、Ingress 和 App 资源暴露 `3000` 端口

--- a/template/libredb-studio/index.yaml
+++ b/template/libredb-studio/index.yaml
@@ -220,7 +220,7 @@ kind: StatefulSet
 metadata:
   name: ${{ defaults.app_name }}
   annotations:
-    originImageName: ghcr.io/libredb/libredb-studio:0.9.66
+    originImageName: ghcr.io/libredb/libredb-studio:0.14.1
     deploy.cloud.sealos.io/minReplicas: '1'
     deploy.cloud.sealos.io/maxReplicas: '1'
   labels:
@@ -298,7 +298,7 @@ spec:
       ${{ endif() }}
       containers:
         - name: ${{ defaults.app_name }}
-          image: ghcr.io/libredb/libredb-studio:0.9.66
+          image: ghcr.io/libredb/libredb-studio:0.14.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The template still deploys 0.9.66. Current release is 0.14.1.

The version appears in six places and all six move together:

- `template/libredb-studio/index.yaml`: the StatefulSet `originImageName` annotation and the container `image`
- `template/libredb-studio/README.md`: the intro sentence and the image line
- `template/libredb-studio/README_zh.md`: the same two lines
- `.sealos/topology-evidence/libredb-studio.yaml`: the `source` link, now pointing at the 0.14.1 tag

The 0.14.1 tag is published on ghcr.io for linux/amd64 and linux/arm64, and the 0.14.1 git tag carries the `docker-compose.example.yml` the topology evidence refers to.

Nothing else in the template changes. `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `JWT_SECRET`, `STORAGE_PROVIDER` and `STORAGE_SQLITE_PATH` are all still read by 0.14.1, and the storage path stays `/app/data/libredb-storage.db` on the same PVC, so an existing deployment keeps its data.

`index.yaml` parses to the same ten documents before and after the change.