### PR TITLE
fix(eaglercraft-server): drop the invalid WS backend-protocol annotation

### DIFF
--- a/template/eaglercraft-server/index.yaml
+++ b/template/eaglercraft-server/index.yaml
@@ -247,7 +247,6 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: 32m
     nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
     nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
-    nginx.ingress.kubernetes.io/backend-protocol: WS
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   rules:


### PR DESCRIPTION
Follow-up to #758.

## What

Removes `nginx.ingress.kubernetes.io/backend-protocol: WS` from the game Ingress. ingress-nginx does not accept `WS` as a value and the WebSocket upgrade on port 5200 works without it. The annotation only marked port 5200 as WebSocket-only for the platform, which hid the browser client page behind a copy-only `wss://` address. Port 5200 serves the client over HTTP and upgrades the same path, so it is an HTTP port.

The explicit `/admin.css`, `/admin.js`, `/admin-i18n.js` paths on the console Ingress are unchanged. That path set was validated live in #717 and #748.

## Verification

- `python scripts/test_eaglercraft_runtime_refresh.py` → PASS
- `index.yaml` parses; the game Ingress carries no `backend-protocol` annotation; the console path list is unchanged.
- Not verified on a cluster: WebSocket traffic through ingress-nginx without the annotation. The value was never valid for ingress-nginx, so no behaviour change is expected, but it has not been exercised live in this PR.

## Related

- labring/brain#346 (draft) reads `spec.entries` from #758.
- yangchuansheng/eaglerXserver#16 pre-fills the client's server list; the image bump to that release will be validated live and will switch `share` back to the plain root URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5m7FUKCppYpMxKwHxrPgV
